### PR TITLE
Direct file view

### DIFF
--- a/app/medInria/main.cpp
+++ b/app/medInria/main.cpp
@@ -148,7 +148,7 @@ int main(int argc,char* argv[]) {
 
     medMainWindow mainwindow;
     if (DirectView)
-        mainwindow.setStartup(2,FileToView);
+        mainwindow.setStartup(medMainWindow::WorkSpace,FileToView);
 
     forceShow(mainwindow);
 

--- a/app/medInria/medMainWindow.cpp
+++ b/app/medInria/medMainWindow.cpp
@@ -174,7 +174,7 @@ medMainWindow::medMainWindow ( QWidget *parent ) : QMainWindow ( parent ), d ( n
     connect(d->browserArea,SIGNAL(load(const QString&)),this,SLOT(load(const QString&)));
     connect(d->browserArea,SIGNAL(open(const medDataIndex&)),this,SLOT(open(const medDataIndex&)));
 
-    //  Viewer area.
+    //  Workspace area.
 
     d->workspaceArea = new medWorkspaceArea ( this );
     d->workspaceArea->setObjectName ( "Viewer" );
@@ -362,7 +362,7 @@ void medMainWindow::readSettings ( void )
 
     //  If nothing is configured then Browser is the default area
 
-    const int areaIndex = mnger->value("startup","default_starting_area",0).toInt();
+    const AreaType areaIndex = static_cast<AreaType>(mnger->value("startup","default_starting_area",0).toInt());
 
     switchToArea(areaIndex);
 
@@ -388,12 +388,12 @@ void medMainWindow::writeSettings() {
     }
 }
 
-void medMainWindow::setStartup(const int areaIndex,const QString& filename) {
+void medMainWindow::setStartup(const AreaType areaIndex,const QString& filename) {
     switchToArea(areaIndex);
     open(filename);
 }
 
-void medMainWindow::switchToArea(const int areaIndex) {
+void medMainWindow::switchToArea(const AreaType areaIndex) {
     switch (areaIndex) {
         case 0:
             this->switchToHomepageArea();
@@ -499,7 +499,7 @@ void medMainWindow::resizeEvent ( QResizeEvent* event )
 }
 
 
-void medMainWindow::setWallScreen ( bool full )
+void medMainWindow::setWallScreen (const bool full )
 {
     if ( full )
     {
@@ -512,7 +512,7 @@ void medMainWindow::setWallScreen ( bool full )
     }
 }
 
-void medMainWindow::setFullScreen ( bool full )
+void medMainWindow::setFullScreen (const bool full )
 {
     if ( full )
         this->showFullScreen();

--- a/app/medInria/medMainWindow.h
+++ b/app/medInria/medMainWindow.h
@@ -31,27 +31,32 @@ class medMainWindow : public QMainWindow
     Q_OBJECT
 
 public:
+
+     typedef enum { HomePage, Browser, WorkSpace } AreaType;
+
      medMainWindow(QWidget *parent = 0);
     ~medMainWindow(void);
 
     void readSettings(void);
     void writeSettings();
 
-    void setStartup(const int areaIndex,const QString& filename);
+    void setStartup(const AreaType areaIndex,const QString& filename);
     void updateQuickAccessMenu(void);
     void resizeEvent( QResizeEvent * event );
 
 public slots:
-    void setWallScreen(bool full);
-    void setFullScreen(bool full);
+    void setWallScreen(const bool full);
+    void setFullScreen(const bool full);
 
     /**
      * @brief Switches from the Fullscreen mode to the normal mode.
      *
      */
     void switchFullScreen(void);
+    void switchToArea(const AreaType areaIndex);
 
-    void switchToArea(const int areaIndex);
+private slots:
+
     void switchToBrowserArea(void);
     void switchToWorkspaceArea(void);
     void switchToHomepageArea(void);


### PR DESCRIPTION
Here is a cherry-pick of the direct view of a file (no SingleApplication in this pull request yet, I have to trace that back). Basically, this allows to use:

medInria --view file to directly view a file (quitting is still a burden as you have to confirm 2 times). Since I cannot prevent in doing that, I also improved some code organisation, made some parameters const, made some slots private, and introduced some enums to reference the Areas. I'm not totally happy with the method "medMainWindow::setStartup" since its name is very general but yes has a file parameter which is currently only valid the Visualisation Area. I'm hapily getting some comments here (but will probably ask to do this merge first and to provide a subsequent patch ;-) ).
