### PR TITLE
link medGui-medSQL removal

### DIFF
--- a/src/medGui/toolboxes/medFiberBundlingToolBox.cpp
+++ b/src/medGui/toolboxes/medFiberBundlingToolBox.cpp
@@ -28,8 +28,6 @@
 #include <medMetaDataKeys.h>
 #include <medImageFileLoader.h>
 
-#include <medDatabaseNonPersistentController.h>
-
 class medFiberBundlingToolBoxPrivate
 {
 public:


### PR DESCRIPTION
# include <medDatabaseNonPersistentController.h> removed from src/medGui/toolboxes/medFiberBundlingToolBox.cpp
