### PR TITLE
Better value for MaximumNumberOfPeels and OcclusionRatio of 3d renderer

### DIFF
--- a/src-plugins/v3dView/v3dView.cpp
+++ b/src-plugins/v3dView/v3dView.cpp
@@ -396,8 +396,8 @@ v3dView::v3dView() : medAbstractView(), d ( new v3dViewPrivate )
 
     // Activate depth-peeling to have a proper opacity rendering
     d->renderer3d->SetUseDepthPeeling(1);
-    d->renderer3d->SetMaximumNumberOfPeels(100);
-    d->renderer3d->SetOcclusionRatio(0.01);
+    d->renderer3d->SetMaximumNumberOfPeels(10);
+    d->renderer3d->SetOcclusionRatio(0.5);
 
     d->view3d = vtkImageView3D::New();
     d->view3d->SetRenderer ( d->renderer3d );


### PR DESCRIPTION
See issue 1694 on redmine.

I trie to find a better compromise between perf and quality. If you want to test your own values :

MaximumNumberOfPeels + OcclusionRatio  close to 1  -> better perf.

MaximumNumberOfPeels high + OcclusionRatio close to 0 -> better rendering.
