### PR TITLE
4D sagittal view orientation

### DIFF
--- a/src-plugins/v3dView/v3dView.cpp
+++ b/src-plugins/v3dView/v3dView.cpp
@@ -1053,15 +1053,12 @@ void v3dView::setData ( dtkAbstractData *data, int layer )
                 {
                 case vtkImageView2D::VIEW_ORIENTATION_SAGITTAL:
 				    this->setProperty("Orientation","Sagittal");
-                    d->orientation = "Sagittal";
                     break;
                 case vtkImageView2D::VIEW_ORIENTATION_CORONAL:
 				    this->setProperty("Orientation","Coronal");
-                    d->orientation = "Coronal";
                     break;
                 case vtkImageView2D::VIEW_ORIENTATION_AXIAL:
 				    this->setProperty("Orientation","Axial");
-                    d->orientation = "Axial";
                     break;
                 }
             }


### PR DESCRIPTION
https://med.inria.fr/redmine/issues/1573

Bug description : 
A new bug related to diffusion imaging of the spine where images are acquired sagittal first. In that case, when you drop the image it shows the sagittal view (normal up till there), but the view properties toolbox has the axial button clicked. So if you want to see the axial view, you have to go to another plane, then come back to axial.

Solution : 
The states of the orientation buttons depend on the output of : d->view2d->GetViewOrientation() in v3dView. 
In the case of spine images the viewOrientation is not known by view2d at that time in the v3dView::setData function. Therefore, we decided to move the code few lines after, when we are sure the viewOrientation is correctly computed.
