### PR TITLE
1729-Window level always done one first image

### DIFF
--- a/src/medGui/toolboxes/medViewPropertiesToolBox.cpp
+++ b/src/medGui/toolboxes/medViewPropertiesToolBox.cpp
@@ -422,8 +422,14 @@ void medViewPropertiesToolBox::update(dtkAbstractView *view)
 
     d->view = medView;
     d->propertiesTree->clear();
+
+
+    double layer1Opacity = 0.5;
+    //retrieve layer1 opacity, if possible
+    if(d->view->layerCount() == 2)
+        layer1Opacity =  d->view->opacity(1);
     //decide whether to show the 2 layers slider
-    raiseSlider(d->view->layerCount() == 2);
+    raiseSlider(d->view->layerCount() == 2, layer1Opacity);
 
     if ( ! d->meshInteractor )
         d->meshInteractor = dynamic_cast<medMeshAbstractViewInteractor*>(d->view->interactor ("v3dViewMeshInteractor"));


### PR DESCRIPTION
I changed the update() method in medViewPropertiesToolBox to select item corresponding to the current layer instead of selecting item 0. 

It seems a bit strange because there was a comment saying that we didn't have the current layer information, although we do have it...
The lines I modified were introduced in commit e90ff200411d0eb7642af9a8ce37d0d4afed43ef ("Selects the new layer as current layer, or 0 when deleting it.").

Guillaume
