### PR TITLE
DCMTK links need fix on mac only if not built static

### DIFF
--- a/src-plugins/cmake/FixDCMTKMacInstall.cmake
+++ b/src-plugins/cmake/FixDCMTKMacInstall.cmake
@@ -14,9 +14,13 @@
 MACRO(FixDCMTKMacInstall)
 
   foreach(lib dcmdata dcmimage dcmimgle dcmjpeg dcmnet dcmpstat dcmqrdb dcmsr dcmtls ijg12 ijg16 ijg8 oflog ofstd)
-    foreach(linkedlib dcmdata dcmimage dcmimgle dcmjpeg dcmnet dcmpstat dcmqrdb dcmsr dcmtls ijg12 ijg16 ijg8 oflog ofstd)
-      execute_process(COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change lib${linkedlib}.dylib ${DCMTK_DIR}/lib/lib${linkedlib}.dylib ${DCMTK_DIR}/lib/lib${lib}.dylib)
-    endforeach()
+    if (EXISTS ${DCMTK_DIR}/lib/lib${lib}.dylib)
+      foreach(linkedlib dcmdata dcmimage dcmimgle dcmjpeg dcmnet dcmpstat dcmqrdb dcmsr dcmtls ijg12 ijg16 ijg8 oflog ofstd)
+        if (EXISTS ${DCMTK_DIR}/lib/lib${linkedlib}.dylib)
+          execute_process(COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change lib${linkedlib}.dylib ${DCMTK_DIR}/lib/lib${linkedlib}.dylib ${DCMTK_DIR}/lib/lib${lib}.dylib)
+        endif()
+      endforeach()
+    endif()
   endforeach()
 
 ENDMACRO(FixDCMTKMacInstall)

--- a/src-plugins/cmake/FixDCMTKMacLink.cmake
+++ b/src-plugins/cmake/FixDCMTKMacLink.cmake
@@ -14,11 +14,13 @@
 MACRO(FixDCMTKMacLink lib_name)
 
   foreach(lib dcmdata dcmimage dcmimgle dcmjpeg dcmnet dcmpstat dcmqrdb dcmsr dcmtls ijg12 ijg16 ijg8 oflog ofstd)
-    add_custom_command(TARGET ${lib_name}
-	POST_BUILD
-	COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change lib${lib}.dylib ${DCMTK_DIR}/lib/lib${lib}.dylib ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lib${lib_name}.dylib
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BIN_DIR}
-    )
+    if(EXISTS "${DCMTK_DIR}/lib/lib${lib}.dylib")
+      add_custom_command(TARGET ${lib_name}
+	    POST_BUILD
+	    COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change lib${lib}.dylib ${DCMTK_DIR}/lib/lib${lib}.dylib ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lib${lib_name}.dylib
+          WORKING_DIRECTORY ${CMAKE_CURRENT_BIN_DIR}
+      )
+    endif()
   endforeach()
 
 ENDMACRO(FixDCMTKMacLink)


### PR DESCRIPTION
Quick fix to avoid warnings in chain on mac when dcmtk is compiled static
