### PR TITLE
Add option to disable medCompositDataSets by default

### DIFF
--- a/src-plugins/CMakeLists.txt
+++ b/src-plugins/CMakeLists.txt
@@ -81,9 +81,10 @@ option(BUILD_ALL_PLUGINS "Build all Medinria plugins (overrides individual selec
 
 option(MEDINRIA-PLUGINS_BUILD_EXAMPLES "Enable this if you want to build the examples" OFF)
 
+option(MEDINRIA-PLUGINS_BUILD_COMPOSITEDATASET "Enable this if you want to build compositeDataSet plugin" OFF)
+
 ## ADD here any new plugin you want to include in the build, except for registration plugins, see below.
 set(PLUGIN_LIST
-  ${EXAMPLE_PLUGINS}
   v3dData                        ON
   v3dView                        ON
   itkDataImage                   ON
@@ -98,7 +99,6 @@ set(PLUGIN_LIST
   itkDataTensorImageWriter       ON
   itkDataTensorImageReader       ON
   medSegmentation                ON
-  medCompositeDataSets           ON
   itkFilters                     ON
   qtdcmDataSource                ON
   )
@@ -110,6 +110,13 @@ if (MEDINRIA-PLUGINS_BUILD_EXAMPLES)
     ITKProcessExample              ON
     )
 endif()
+
+if(MEDINRIA-PLUGINS_BUILD_COMPOSITEDATASET)
+  set (PLUGIN_LIST
+    ${PLUGIN_LIST}
+    medCompositeDataSets           ON
+    )
+endif()    
 
 #MACRO_ADD_PLUGIN_LIST ("${PLUGIN_LIST}")
 


### PR DESCRIPTION
I guess we don't have time to fix that.
