### PR TITLE
VTK thumbnails for Mac crash when doing several thumbnails

### DIFF
--- a/src-plugins/vtkDataMesh/vtkDataMesh.cpp
+++ b/src-plugins/vtkDataMesh/vtkDataMesh.cpp
@@ -120,38 +120,36 @@ QList<QImage> & vtkDataMesh::thumbnails()
 
   if (!mesh || !mesh->GetNumberOfPoints())
       return d->thumbnails;
+    
+  unsigned int w=128, h=128;
+  QImage img(w, h, QImage::Format_RGB32);
+    img.fill(0);
 
-  vtkDataSetSurfaceFilter* geometryextractor = vtkDataSetSurfaceFilter::New();
-  vtkPolyDataMapper* mapper = vtkPolyDataMapper::New();
-  vtkActor* actor = vtkActor::New();
-  vtkProperty* prop = vtkProperty::New();
-  vtkRenderer* renderer = vtkRenderer::New();
-  vtkRenderWindow* window = vtkRenderWindow::New();
+#ifndef Q_WS_MAC
+  vtkSmartPointer <vtkDataSetSurfaceFilter> geometryextractor = vtkDataSetSurfaceFilter::New();
+  vtkSmartPointer <vtkPolyDataMapper> mapper = vtkPolyDataMapper::New();
+  vtkSmartPointer <vtkActor> actor = vtkActor::New();
+  vtkSmartPointer <vtkProperty> prop = vtkProperty::New();
+  vtkSmartPointer <vtkRenderer> renderer = vtkRenderer::New();
+  vtkSmartPointer <vtkRenderWindow> window = vtkRenderWindow::New();
   geometryextractor->SetInput (mesh);
   mapper->SetInput (geometryextractor->GetOutput());
   actor->SetMapper (mapper);
   actor->SetProperty (prop);
   renderer->AddViewProp(actor);
-  window->SetSize (128,128);
-  window->OffScreenRenderingOn();
+  window->SetSize (w,h);
+  window->SetOffScreenRendering(1);
   window->AddRenderer (renderer);
 
   renderer->ResetCamera();
   window->Render();
-  unsigned int w=128, h=128;
 
-  QImage img(w, h, QImage::Format_RGB32);
-
-  vtkUnsignedCharArray* pixels = vtkUnsignedCharArray::New();
+  vtkSmartPointer <vtkUnsignedCharArray> pixels = vtkUnsignedCharArray::New();
   pixels->SetArray(img.bits(), w*h*4, 1);
   window->GetRGBACharPixelData(0, 0, w-1, h-1, 1, pixels);
-  pixels->Delete();
-
-  mapper->Delete();
-  geometryextractor->Delete();
-  actor->Delete();
-  renderer->Delete();
+    
   window->Delete();
+#endif
 
   d->thumbnails.push_back (img);
 


### PR DESCRIPTION
Well, I did not find a way to correct this properly given that it is VTK related (on UNIX based systems off screen rendering still creates a window) and system related (it would seem vtk, at least 5.8, is not thread safe for mac systems when creating several render windows).

So this patch basically reverts to no thumbnails for vtk files on macs (as was the case before for 2.0.1).

If merged, this should be applied to 2.1.1 as well.
