### PR TITLE
Tooltips for navigator items

### DIFF
--- a/src/medGui/database/medDatabaseNavigatorItem.cpp
+++ b/src/medGui/database/medDatabaseNavigatorItem.cpp
@@ -61,7 +61,7 @@ medDatabaseNavigatorItem::medDatabaseNavigatorItem(const medDataIndex & index,  
 
     d->persistent = dbc->isPersistent();
     d->text = dbc->metaData(index,medMetaDataKeys::SeriesDescription);
-
+    this->setToolTip("<span style=\"background: #fff8dc;\">" + d->text + "</span>");
 
     bool shouldSkipLoading = false;
     if ( thumbpath.isEmpty() ) {


### PR DESCRIPTION
Adds tooltips for patient navigator items, so that names of items can always be distinguished, even for long names. 

Those tooltips have the same problem as the one mentioned in bug 818 in redmine since they lay in the same class. But I think they are readable enough
