### PR TITLE
Send a failure signal when failing to read the image

### DIFF
--- a/src/medSql/medAbstractDatabaseImporter.cpp
+++ b/src/medSql/medAbstractDatabaseImporter.cpp
@@ -359,7 +359,8 @@ void medAbstractDatabaseImporter::importFile ( void )
         {
             qWarning() << "Could not repopulate data!";
             emit showError (tr ( "Could not read data: " ) + filesPaths[0], 5000 );
-            continue;
+            emit failure(this);
+            return;
         }
 
         // check for partial import attempts

--- a/src/medSql/medDatabaseControllerImpl.cpp
+++ b/src/medSql/medDatabaseControllerImpl.cpp
@@ -409,6 +409,8 @@ void medDatabaseControllerImpl::import(const QString& file,bool indexWithoutCopy
     
     connect(importer, SIGNAL(success(QObject *)), message, SLOT(success()));
     connect(importer, SIGNAL(failure(QObject *)), message, SLOT(failure()));
+    connect(importer,SIGNAL(showError(const QString&,unsigned int)),
+            medMessageController::instance(),SLOT(showError(const QString&,unsigned int)));
 
     medJobManager::instance()->registerJobItem(importer);
     QThreadPool::globalInstance()->start(importer);
@@ -429,6 +431,8 @@ void medDatabaseControllerImpl::import( dtkAbstractData *data, QString importUui
     connect(importer, SIGNAL(success(QObject *)), message, SLOT(success()));
     connect(importer, SIGNAL(failure(QObject *)), message, SLOT(failure()));
 
+    connect(importer,SIGNAL(showError(const QString&,unsigned int)),
+            medMessageController::instance(),SLOT(showError(const QString&,unsigned int)));
 
     medJobManager::instance()->registerJobItem(importer);
     QThreadPool::globalInstance()->start(importer);

--- a/src/medSql/medDatabaseNonPersistentControllerImpl.cpp
+++ b/src/medSql/medDatabaseNonPersistentControllerImpl.cpp
@@ -104,6 +104,8 @@ void medDatabaseNonPersistentControllerImpl::import(const QString& file,QString 
             message, SLOT(success()));
     connect(reader, SIGNAL(failure(QObject *)),
              message, SLOT(failure()));
+    connect(reader,SIGNAL(showError(const QString&,unsigned int)),
+            medMessageController::instance(),SLOT(showError(const QString&,unsigned int)));
 
     medJobManager::instance()->registerJobItem(reader);
     QThreadPool::globalInstance()->start(reader);


### PR DESCRIPTION
Issue: https://med.inria.fr/redmine/issues/1751

To correct the fact that we were sending a "Operation succeeded" message while it was a fail.
