### PR TITLE
Adding keyboard shortcuts to orientation buttons

### DIFF
--- a/src/medGui/toolboxes/medViewPropertiesToolBox.cpp
+++ b/src/medGui/toolboxes/medViewPropertiesToolBox.cpp
@@ -217,31 +217,37 @@ medToolBox(parent), d(new medViewPropertiesToolBoxPrivate)
     d->mouseGroup->addButton ( d->measuringPushButton );
     d->mouseGroup->setExclusive (true);
 
+#if defined(Q_WS_MAC)
+#  define CTRL_KEY "Cmd"
+#else
+#   define CTRL_KEY "Ctrl"
+#endif
+
     // Orientation buttons //
     d->axialButton = new QPushButton(this);
     d->axialButton->setIcon(QIcon(":/icons/AxialIcon.png"));
-    d->axialButton->setToolTip(tr("Axial view (CTRL + 1)"));
+    d->axialButton->setToolTip(tr("Axial view (" CTRL_KEY " + 1)"));
     d->axialButton->setCheckable(true);
     d->axialButton->setMinimumHeight(45);
     d->axialButton->setIconSize(QSize(40,40));
     d->axialButton->setShortcut(Qt::CTRL + Qt::Key_1);
     d->coronalButton = new QPushButton(this);
     d->coronalButton->setIcon(QIcon(":/icons/CoronalIcon.png"));
-    d->coronalButton->setToolTip(tr("Coronal view (CTRL + 2)"));
+    d->coronalButton->setToolTip(tr("Coronal view (" CTRL_KEY " + 2)"));
     d->coronalButton->setCheckable(true);
     d->coronalButton->setMinimumHeight(45);
     d->coronalButton->setIconSize(QSize(40,40));
     d->coronalButton->setShortcut(Qt::CTRL + Qt::Key_2);
     d->sagittalButton = new QPushButton(this);
     d->sagittalButton->setIcon(QIcon(":/icons/SagittalIcon.png"));
-    d->sagittalButton->setToolTip(tr("Sagittal view (CTRL + 3)"));
+    d->sagittalButton->setToolTip(tr("Sagittal view (" CTRL_KEY " + 3)"));
     d->sagittalButton->setCheckable(true);
     d->sagittalButton->setMinimumHeight(45);
     d->sagittalButton->setIconSize(QSize(45,45));
     d->sagittalButton->setShortcut(Qt::CTRL + Qt::Key_3);
     d->view3DButton = new QPushButton(this);
     d->view3DButton->setIcon(QIcon(":/icons/3DIcon.png"));
-    d->view3DButton->setToolTip(tr("3D view (CTRL + 4)"));
+    d->view3DButton->setToolTip(tr("3D view (" CTRL_KEY " + 4)"));
     d->view3DButton->setCheckable(true);
     d->view3DButton->setMinimumHeight(45);
     d->view3DButton->setIconSize(QSize(40,40));


### PR DESCRIPTION
Following [this forum post](http://med.inria.fr/forum/5-visualization-workspace/238-re-v20-to-v21view-orientation-controls-moved-from), this adds keyboard shortcuts to the orientation buttons.
