### PR TITLE
Add support for VTK vtp file format

### DIFF
--- a/src-plugins/libs/vtkInria/vtkDataManagement/vtkMetaSurfaceMesh.h
+++ b/src-plugins/libs/vtkInria/vtkDataManagement/vtkMetaSurfaceMesh.h
@@ -49,6 +49,7 @@ class VTK_DATAMANAGEMENT_EXPORT vtkMetaSurfaceMesh: public vtkMetaDataSet
   enum
   {
     FILE_IS_VTK = 1,
+    FILE_IS_VTP,
     FILE_IS_MESH,
     FILE_IS_OBJ,
     LAST_FILE_ID
@@ -71,6 +72,7 @@ class VTK_DATAMANAGEMENT_EXPORT vtkMetaSurfaceMesh: public vtkMetaDataSet
      Static methods for I/O
   */
   static bool         IsVtkExtension (const char* ext);
+  static bool         IsVtpExtension (const char* ext);
   static bool         IsMeshExtension (const char* ext);
   static bool         IsOBJExtension (const char* ext);
   static unsigned int CanReadFile (const char* filename);
@@ -90,10 +92,12 @@ class VTK_DATAMANAGEMENT_EXPORT vtkMetaSurfaceMesh: public vtkMetaDataSet
   ~vtkMetaSurfaceMesh();
 
   virtual void ReadVtkFile(const char* filename);
+  virtual void ReadVtpFile(const char* filename);
   virtual void ReadMeshFile(const char* filename);
   virtual void ReadOBJFile(const char* filename);
   virtual void WriteOBJFile(const char* filename);
   virtual void WriteVtkFile (const char* filename);
+  virtual void WriteVtpFile (const char* filename);
 
   /**
      Method called everytime the dataset changes for initialization

--- a/src-plugins/vtkDataMeshWriter/vtkDataMeshWriter.cpp
+++ b/src-plugins/vtkDataMeshWriter/vtkDataMeshWriter.cpp
@@ -42,7 +42,7 @@ QStringList vtkDataMeshWriter::s_handled()
 
 bool vtkDataMeshWriter::canWrite(const QString& path)
 {
-  return path.endsWith (QString (".vtk"));
+  return path.endsWith (QString (".vtk")) || path.endsWith(QString (".vtp"));
 }
 
 bool vtkDataMeshWriter::write(const QString& path)

--- a/utils/osx_packaging/Info_Addon.plist
+++ b/utils/osx_packaging/Info_Addon.plist
@@ -18,9 +18,12 @@
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>vtk</string>
+				<string>vtp</string>
+				<string>fib</string>
+				<string>xml</string>
 			</array>
 			<key>CFBundleTypeName</key>
-			<string>VTK files</string>
+			<string>VTK and special mesh files</string>
 			<key>LSHandlerRank</key>
 			<string>Default</string>
 		</dict>


### PR DESCRIPTION
This adds, following a request in Visages, support for VTK polydata file format. It has the main advantage that these files take a lot less space.

If you want to test, we have a few vtp files here and there in medinria-data. Would be nice to have this included in 2.1.2
