### PR TITLE
Real-time update of the cursor information v2

### DIFF
--- a/src-plugins/libs/vtkInria/vtkImageView/vtkImageView.cxx
+++ b/src-plugins/libs/vtkInria/vtkImageView/vtkImageView.cxx
@@ -534,6 +534,16 @@ void vtkImageView::SetCurrentPoint (double pos[3])
   this->CurrentPoint[1] = inside_pos[1];
   this->CurrentPoint[2] = inside_pos[2];
   this->InvokeEvent (vtkImageView::CurrentPointChangedEvent, NULL);
+}
+
+void vtkImageView::UpdateCursorPosition (double pos[3])
+{
+  double inside_pos[3];
+  this->GetWithinBoundsPosition (pos, inside_pos);
+
+  this->CursorPosition[0] = inside_pos[0];
+  this->CursorPosition[1] = inside_pos[1];
+  this->CursorPosition[2] = inside_pos[2];
   this->Modified();
 }
 

--- a/src-plugins/libs/vtkInria/vtkImageView/vtkImageView.h
+++ b/src-plugins/libs/vtkInria/vtkImageView/vtkImageView.h
@@ -322,11 +322,19 @@ class VTK_IMAGEVIEW_EXPORT vtkImageView : public vtkObject
   virtual void SetCurrentPoint (double pos[3]);
 
   /**
-     Get the current position in world coordinate.
+     Get the current position in world coordinate of
+     the lastly clicked point.
+  */
+  vtkGetVector3Macro (CurrentPoint, double);
+
+  /**
+     Get/Update the current position of the cursor
+     in world coordinate.
      This framework is only used in vtkViewImage2D to
      update corner annotations and cursor position.
   */
-  vtkGetVector3Macro (CurrentPoint, double);
+  vtkGetVector3Macro (CursorPosition, double);
+  virtual void UpdateCursorPosition (double pos[3]);
 
   /**
      Reset the 3D position to center of the image
@@ -783,6 +791,7 @@ protected:
      update corner annotations and cursor position.
   */
   double CurrentPoint[3];
+  double CursorPosition[3];
 
   int CurrentLayer;
   int IsInteractorInstalled;

--- a/src-plugins/libs/vtkInria/vtkImageView/vtkImageView2D.cxx
+++ b/src-plugins/libs/vtkInria/vtkImageView/vtkImageView2D.cxx
@@ -1377,6 +1377,9 @@ void vtkImageView2D::InstallPipeline()
     if ( !this->InteractorStyle->HasObserver (vtkImageView2DCommand::RequestedPositionEvent, this->Command) )
       this->InteractorStyle->AddObserver (vtkImageView2DCommand::RequestedPositionEvent, this->Command, 10);
 
+    if ( !this->InteractorStyle->HasObserver (vtkImageView2DCommand::RequestedCursorInformationEvent, this->Command) )
+      this->InteractorStyle->AddObserver (vtkImageView2DCommand::RequestedCursorInformationEvent, this->Command, 10);
+
     if ( !this->InteractorStyle->HasObserver (vtkImageView2DCommand::ResetViewerEvent, this->Command) )
       this->InteractorStyle->AddObserver (vtkImageView2DCommand::ResetViewerEvent, this->Command, 10);
 

--- a/src-plugins/libs/vtkInria/vtkImageView/vtkImageView2DCommand.cxx
+++ b/src-plugins/libs/vtkInria/vtkImageView/vtkImageView2DCommand.cxx
@@ -228,6 +228,16 @@ vtkImageView2DCommand::Execute(vtkObject*    caller,
     return;
   }
 
+  // Cursor Position requested
+  if (event == vtkImageView2DCommand::RequestedCursorInformationEvent)
+  {
+    double position[3];
+    this->Viewer->GetWorldCoordinatesFromDisplayPosition (isi->GetRequestedPosition (), position);
+    this->Viewer->vtkImageView::UpdateCursorPosition(position);
+    this->Viewer->Render();
+    return;
+  }
+
   // default move : align cursor and update annotation accordingly
   if( event == vtkImageView2DCommand::DefaultMoveEvent)
   {

--- a/src-plugins/libs/vtkInria/vtkImageView/vtkImageView2DCommand.h
+++ b/src-plugins/libs/vtkInria/vtkImageView/vtkImageView2DCommand.h
@@ -54,7 +54,8 @@ class VTK_IMAGEVIEW_EXPORT vtkImageView2DCommand : public vtkCommand
     CameraMoveEvent,
     CameraZoomEvent,
     CameraPanEvent,
-    DefaultMoveEvent
+    DefaultMoveEvent,
+    RequestedCursorInformationEvent
   };
   //ETX
 

--- a/src-plugins/libs/vtkInria/vtkImageView/vtkImageViewCornerAnnotation.cxx
+++ b/src-plugins/libs/vtkInria/vtkImageView/vtkImageViewCornerAnnotation.cxx
@@ -77,7 +77,7 @@ void vtkImageViewCornerAnnotation::TextReplace(vtkImageActor *ia,
   if (this->ImageView)
   {
     
-    this->ImageView->GetCurrentPoint (pos);
+    this->ImageView->GetCursorPosition (pos);
     this->ImageView->GetImageCoordinatesFromWorldCoordinates (pos, coord);
     value = this->ImageView->GetValueAtPosition(pos);
     zoom  = this->ImageView->GetZoom()*100.0;

--- a/src-plugins/libs/vtkInria/vtkImageView/vtkInteractorStyleImageView2D.cxx
+++ b/src-plugins/libs/vtkInria/vtkImageView/vtkInteractorStyleImageView2D.cxx
@@ -54,6 +54,9 @@ vtkInteractorStyleImageView2D::~vtkInteractorStyleImageView2D()
 //----------------------------------------------------------------------------
 void vtkInteractorStyleImageView2D::OnMouseMove() 
 {
+  int x = this->Interactor->GetEventPosition()[0];
+  int y = this->Interactor->GetEventPosition()[1];
+  this->FindPokedRenderer(x, y);
   switch (this->State) 
   {
 	case VTKIS_SLICE_MOVE:
@@ -83,7 +86,9 @@ void vtkInteractorStyleImageView2D::OnMouseMove()
 	this->InvokeEvent(vtkImageView2DCommand::CameraMoveEvent, this);
 	break;
       case VTKIS_NONE:
-          this->DefaultMoveAction();
+	this->RequestedPosition[0] = x;
+	this->RequestedPosition[1] = y;
+	this->InvokeEvent (vtkImageView2DCommand::RequestedCursorInformationEvent, this);
           break;
       default:
 	this->Superclass::OnMouseMove();


### PR DESCRIPTION
Issue : https://med.inria.fr/redmine/issues/1741

Goal :  automatically update cursor information (X, Y, pixel value) while moving the mouse.

After a mouseEvent, a new vtkImageView2DCommand is invoked, that indirectly launches vtkImageView::UpdateCursorPosition.

The mistake of the first version was to use an existing Command (RequestedPositionEvent) that was already used for other purposes.
Hints : last time, bugs appeared with the Custom View (with Sagittal, Axial, ...), by linking the position and moving the mouse.It was modifying the slices of the views.
