### PR TITLE
Take into account the return value of read and readinformation

### DIFF
--- a/src/medSql/medAbstractDatabaseImporter.cpp
+++ b/src/medSql/medAbstractDatabaseImporter.cpp
@@ -799,12 +799,14 @@ dtkSmartPointer<dtkAbstractData> medAbstractDatabaseImporter::tryReadImages ( co
 
     if ( dataReader )
     {
+        bool readSuccessful = false;
         if ( readOnlyImageInformation )
-            dataReader->readInformation ( filesPaths );
+            readSuccessful = dataReader->readInformation ( filesPaths );
         else
-            dataReader->read ( filesPaths );
+            readSuccessful = dataReader->read ( filesPaths );
 
-        dtkData = dataReader->data();
+        if (readSuccessful)
+            dtkData = dataReader->data();
     }
     else
     {


### PR DESCRIPTION
Fixes a crash reported on the mailing list, we were ignoring the return value of read/readInformation, and thus manipulating a invalid image when generating thumbnails etc.
