### PR TITLE
Quick fix for the ITK process example toolbox

### DIFF
--- a/src-plugins/ITKProcessExample/ITKProcessExampleToolBox.cpp
+++ b/src-plugins/ITKProcessExample/ITKProcessExampleToolBox.cpp
@@ -114,13 +114,6 @@ dtkAbstractData* ITKProcessExampleToolBox::processOutput()
     return d->process->output();
 }
 
-dtkPlugin* ITKProcessExampleToolBox::plugin()
-{
-    medPluginManager* pm = medPluginManager::instance();
-    dtkPlugin* plugin = pm->plugin ( "ITKProcessExamplePlugin" );
-    return plugin;
-}
-
 void ITKProcessExampleToolBox::run()
 {
     if(!this->parentToolBox())

--- a/src-plugins/ITKProcessExample/ITKProcessExampleToolBox.h
+++ b/src-plugins/ITKProcessExample/ITKProcessExampleToolBox.h
@@ -26,9 +26,6 @@ public:
      ITKProcessExampleToolBox(QWidget *parentToolBox = 0);
     ~ITKProcessExampleToolBox();
 
-    dtkPlugin*          plugin();
-
-public:
     static bool registered();
     dtkAbstractData* processOutput();
     dtkPlugin* plugin();


### PR DESCRIPTION
Probably a merging error. Anyway now it compiles for me.
