### PR TITLE
Silence some new gcc warnings.

### DIFF
--- a/src-plugins/itkDataDiffusionGradientList/itkDataDiffusionGradientList.cpp
+++ b/src-plugins/itkDataDiffusionGradientList/itkDataDiffusionGradientList.cpp
@@ -85,14 +85,13 @@ bool itkDataDiffusionGradientList::read (const QString& filename)
     //Read Gradients
     typedef itk::GradientFileReader ReaderType;
     typedef ReaderType::VectorListType VectorListType;
-    typedef ReaderType::VectorType VectorType;
     
     ReaderType::Pointer reader = ReaderType::New();
     reader->SetFileName (filename.toStdString());
     reader->Update();
     VectorListType gradients = reader->GetGradientList();
     
-    for(int i=0; i<(gradients.size()); i++)
+    for(unsigned i=0; i<(gradients.size()); i++)
     {
         GradientType grad (3);
         grad[0] = gradients[i][0];

--- a/src-plugins/itkDataImage/itkDataImage.h
+++ b/src-plugins/itkDataImage/itkDataImage.h
@@ -536,7 +536,6 @@ public:
 
 template <unsigned DIM,typename T>
 QList<QImage>& itkDataImagePrivate<DIM,T,1>::make_thumbnails(const int sz,const bool singlez) {
-    typedef itk::Image<T,2> Image2DType;
     typename ImageType::Pointer im = image;
     typename ImageType::SizeType size = image->GetLargestPossibleRegion().GetSize();
     typename ImageType::SizeType newSize = size;

--- a/src-plugins/itkDataSHImageReader/itkDataSHImageReaderBase.cpp
+++ b/src-plugins/itkDataSHImageReader/itkDataSHImageReaderBase.cpp
@@ -148,7 +148,6 @@ bool itkDataSHImageReaderBase::read (const QString &path)
 
         if (dtkdata->identifier()=="itkDataSHImageDouble3") {
             typedef itk::VectorImage<double, 3> SHImageType;
-            typedef SHImageType::PixelType    SHType;
 
             typedef itk::ImageFileReader<SHImageType> ReaderType;
 
@@ -169,7 +168,6 @@ bool itkDataSHImageReaderBase::read (const QString &path)
         }
         else if (dtkdata->identifier()=="itkDataSHImageFloat3") {
             typedef itk::VectorImage<float, 3> SHImageType;
-            typedef SHImageType::PixelType    SHType;
 
             typedef itk::ImageFileReader<SHImageType> ReaderType;
 

--- a/src-plugins/libs/itkProcessRegistration/itkProcessRegistration.cpp
+++ b/src-plugins/libs/itkProcessRegistration/itkProcessRegistration.cpp
@@ -122,6 +122,7 @@ template <typename PixelType>
        {
            QString pixel_type =  typeid(PixelType).name();
            qDebug()<< "Error: The pixel type " + pixel_type + " is not supported yet."  ;
+           return;
        }
     if ( dimensions == 3 ){
 

--- a/src-plugins/libs/vtkInria/vtkDataManagement/vtkMetaDataSetSequence.cxx
+++ b/src-plugins/libs/vtkInria/vtkDataManagement/vtkMetaDataSetSequence.cxx
@@ -1587,7 +1587,6 @@ void vtkMetaDataSetSequence::ComputeTimesFromDuration()
 vtkMetaDataSetSequence::ShortImageType::PointType vtkMetaDataSetSequence::ExtractPARRECImageOrigin (const char* filename, ShortDirectionType direction)
 {
 
-  typedef ShortDirectionType DirectionType;
   typedef ShortImageType::PointType PointType;
   PointType nullorigin;
   nullorigin[0] = nullorigin[1] = nullorigin[2] = 0.0;

--- a/src-plugins/libs/vtkInria/vtkDataManagement/vtkMetaDataSetSequence.h
+++ b/src-plugins/libs/vtkInria/vtkDataManagement/vtkMetaDataSetSequence.h
@@ -229,11 +229,7 @@ class VTK_DATAMANAGEMENT_EXPORT vtkMetaDataSetSequence: public vtkMetaDataSet
   
     typedef typename itk::Image<type, 4> Image4DType;
     typedef typename itk::Image<type, 3> Image3DType;
-    typedef typename Image4DType::RegionType Region4dType;
-    typedef typename Image4DType::SpacingType Spacing4Dtype;
   
-    typedef typename itk::ImageRegionIterator<Image4DType> Iterator4DType;
-    typedef typename Iterator4DType::IndexType Index4DType;
     typedef typename Image3DType::DirectionType Direction3Dtype;
     typedef typename Image4DType::DirectionType Direction4Dtype;
     
@@ -281,14 +277,7 @@ class VTK_DATAMANAGEMENT_EXPORT vtkMetaDataSetSequence: public vtkMetaDataSet
     
     typedef typename itk::Image<type, 4> Image4DType;
     typedef typename itk::Image<type, 3> Image3DType;
-    typedef typename Image4DType::RegionType Region4dType;
-    typedef typename Image4DType::SpacingType Spacing4Dtype;
   
-    typedef typename itk::ImageRegionIterator<Image4DType> Iterator4DType;
-    typedef typename Iterator4DType::IndexType Index4DType;
-    typedef typename Image3DType::DirectionType Direction3Dtype;
-    typedef typename Image4DType::DirectionType Direction4Dtype;
-
     typename Image4DType::Pointer image = dataset;
 
     typename Image4DType::SizeType size = image->GetLargestPossibleRegion().GetSize();

--- a/src/medGui/database/medDatabaseNavigator.cpp
+++ b/src/medGui/database/medDatabaseNavigator.cpp
@@ -124,7 +124,6 @@ void medDatabaseNavigator::onPatientClicked(const medDataIndex& index)
     }
     d->currentPatient = baseIndex.patientId();
 
-    typedef QSet<medDataIndex> IndexSet;
     typedef QList<int> IntList;
     typedef QList<medDataIndex> IndexList;
 


### PR DESCRIPTION
With gcc-4.8.2 some new warnings are added to -Wall. Notably there is one that shows locally defined types that are not used. This patch set corrects those warnings. One of the changes (in src-plugins/libs/itkProcessRegistration/itkProcessRegistration.cpp) probably corrects a bug in some weird cases as a value might be used without having been initialised.
