### PR TITLE
Valgrind errors cleaning

### DIFF
--- a/cmake/valgrind.supp
+++ b/cmake/valgrind.supp
@@ -1,0 +1,155 @@
+{
+   vfprintf[Memcheck:Cond]
+   Memcheck:Cond
+   fun:vfprintf
+   fun:vsprintf
+   fun:sprintf
+}
+
+{
+   __mpn_extract_double[Memcheck:Cond]
+   Memcheck:Cond
+   fun:__mpn_extract_double
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsprintf
+   fun:sprintf
+}
+
+{
+   Memcheck:Cond
+   fun:__mpn_mul_1
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsprintf
+   fun:sprintf
+}
+
+{
+   __mpn_mul[Memcheck:Cond]
+   Memcheck:Cond
+   fun:__mpn_mul
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsprintf
+   fun:sprintf
+}
+
+{
+   __printf_fp[Memcheck:Cond]
+   Memcheck:Cond
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsprintf
+   fun:sprintf
+}
+
+{
+   __mpn_rshift[Memcheck:Cond]
+   Memcheck:Cond
+   fun:__mpn_rshift
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsprintf
+   fun:sprintf
+}
+
+{
+   __mpn_lshift[Memcheck:Cond]
+   Memcheck:Cond
+   fun:__mpn_lshift
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsprintf
+   fun:sprintf
+}
+
+{
+   strstr[Memcheck:Cond]
+   Memcheck:Cond
+   fun:strstr
+}
+
+{
+   strlen[Memcheck:Cond]
+   Memcheck:Cond
+   fun:strlen
+}
+
+{
+   strcpy[Memcheck:Cond]
+   Memcheck:Cond
+   fun:strcpy
+}
+
+{
+   index[Memcheck:Cond]
+   Memcheck:Cond
+   fun:index
+}
+
+{
+   strncpy[Memcheck:Cond]
+   Memcheck:Cond
+   fun:strncpy
+}
+
+{
+   strcmp[Memcheck:Cond]
+   Memcheck:Cond
+   fun:strcmp
+}
+
+{
+   __printf_fp[Memcheck:Value8]
+   Memcheck:Value8
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsprintf
+   fun:sprintf
+}
+
+{
+   __mpn_mul[Memcheck:Value8]
+   Memcheck:Value8
+   fun:__mpn_mul
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsprintf
+   fun:sprintf
+}
+
+{
+   __mpn_rshift[Memcheck:Value8]
+   Memcheck:Value8
+   fun:__mpn_rshift
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsprintf
+   fun:sprintf
+}
+
+{
+   __mpn_lshift[Memcheck:Value8]
+   Memcheck:Value8
+   fun:__mpn_lshift
+   fun:__printf_fp
+   fun:vfprintf
+   fun:vsprintf
+   fun:sprintf
+}
+
+{
+   _itoa_word[Memcheck:Cond]
+   Memcheck:Cond
+   fun:_itoa_word
+   fun:vfprintf
+   fun:vsprintf
+   fun:sprintf
+}
+
+{
+   malloc[Memcheck:Leak]
+   Memcheck:Leak
+   fun:malloc
+}

--- a/src-plugins/libs/vtkInria/vtkVisuManagement/vtkSphericalHarmonicSource.cxx
+++ b/src-plugins/libs/vtkInria/vtkVisuManagement/vtkSphericalHarmonicSource.cxx
@@ -102,14 +102,17 @@ vtkSphericalHarmonicSource::vtkSphericalHarmonicSource(const int tess) {
     Center[2] = 0.0;
     RotationMatrix = 0;
 
+    Deform = true;
+    Normalize = false;
+
     SetNumberOfInputPorts(0);
 
-    DeformOn();
-    NormalizeOff();
-
     // By Default we flip the z-axis, the internal x,y,z have z flipped with respect to visu
-    SetFlipVector(false,false,true);
-    MaxThesisFuncOff();
+    FlipVector[0] = false;
+    FlipVector[1] = false;
+    FlipVector[2] = true;
+
+    MaxThesisFunc = false;
 
     TesselationType = Icosahedron;
     TesselationBasis = SHMatrix;


### PR DESCRIPTION
I started a branch to try to clean Valgrind errors.
Most of the errors are not related to our code but some are, and it's kind of difficult to find them when you get hundreds od errors. I corrected some of them and created a valgrind suppression file to start filtering the ohers.

For those using QtCreator, you can try this suppression file by editing valgrind properties: Tools > Options > Analyser > Suppression file. Hopefully, you should get less errors. (For now I just tried to open an image in medInria)

I've spent some time to try to correct one error that seem related to our code, but couldn't find the solution.If someone wants to try...You should get dozens of errors like: "Conditional jump or move depends on uninitialised value(s) in vtkImageView::GetValueAtPosition(double*, int, int) in src-plugins/libs/vtkInria/vtkImageView/vtkImageView.cxx:1110". I tried to intiialize the variables with memset, or to change the methods used, but withou success. Does someone have an idea of what's wrong there? 
