### PR TITLE
Reintroduce a grey border to the workspace thumbnails

### DIFF
--- a/app/medInria/medInria.qss
+++ b/app/medInria/medInria.qss
@@ -991,6 +991,7 @@ medHomepagePushButton
 {
     background-color: $HOME_PAGE_BUTTON_BACKGROUND;
     font-size: $WIDGET_FONTSIZE;
+    border: 2px solid $WIDGET_BACKGROUND;
 }
 
 medHomepagePushButton:hover


### PR DESCRIPTION
As the title says. It is so that the thumbnails don't shift when selected. It was there before the big QSS modification, so this just fixes a slight regression.
