### PR TITLE
VTK file import fix

### DIFF
--- a/src/medSql/medAbstractDatabaseImporter.cpp
+++ b/src/medSql/medAbstractDatabaseImporter.cpp
@@ -192,6 +192,8 @@ void medAbstractDatabaseImporter::importFile ( void )
     QString currentSeriesUid = "-1";
     QString currentSeriesId = "";
 
+    bool atLeastOneImportSucceeded = false;
+
     foreach ( QString file, fileList )
     {
         if ( d->isCancelled ) // check if user cancelled the process
@@ -385,6 +387,10 @@ void medAbstractDatabaseImporter::importFile ( void )
                 emit showError (tr ( "Could not save data file: " ) + filesPaths[0], 5000 );
                 continue;
             }
+            else
+            {
+                atLeastOneImportSucceeded = true;
+            }
         }
 
         // and finally we populate the database
@@ -404,6 +410,12 @@ void medAbstractDatabaseImporter::importFile ( void )
         itPat++;
         itSer++;
     } // end of the final loop
+
+    if ( ! atLeastOneImportSucceeded) {
+        emit progress ( this,100 );
+        emit failure(this);
+        return;
+    }
 
 
     // if a partial import was attempted we tell the user what to do
@@ -729,6 +741,7 @@ dtkSmartPointer<dtkAbstractDataWriter> medAbstractDatabaseImporter::getSuitableW
     // first try with the last
     for (int i=0; i<writers.size(); i++) {
         dataWriter = dtkAbstractDataFactory::instance()->writerSmartPointer(writers[i]);
+        dataWriter->setData(dtkData);
         if (d->lastSuccessfulWriterDescription==dataWriter->identifier()) {
             if (dataWriter->handled().contains(dtkData->identifier()) && dataWriter->canWrite(filename)) {
 
@@ -743,6 +756,7 @@ dtkSmartPointer<dtkAbstractDataWriter> medAbstractDatabaseImporter::getSuitableW
     for ( int i=0; i<writers.size(); i++ )
     {
         dataWriter = dtkAbstractDataFactory::instance()->writerSmartPointer ( writers[i] );
+        dataWriter->setData(dtkData);
 
         if (dataWriter->handled().contains(dtkData->identifier()) &&
              dataWriter->canWrite( filename ) ) {


### PR DESCRIPTION
In the canWrite method of mesh writers we expected data() to be set and it wasn't, thus failing to recognise that the writer could write VTK file in the DB, and thus failing to import.

There's also a quick fix regarding the handling of import errors, as before we would claim success on a failure...
