### PR TITLE
Fix bug introduced by upgrading to VTK 5.10

### DIFF
--- a/src-plugins/libs/vtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src-plugins/libs/vtkInria/vtkImageView/vtkImageView3D.cxx
@@ -843,47 +843,22 @@ void vtkImageView3D::UpdateVolumeFunctions(int layer)
   vtkPiecewiseFunction     * opacity =
   this->VolumeProperty->GetScalarOpacity(layer);
 
-
-  double colorValue[6]   = { 0.0, 0.0, 0.0, 0.0, 0.5, 0.0 };
-  double opacityValue[4] = { 0.0, 0.0,           0.5, 0.0 };
-
   const double * range = lookuptable->GetRange();
   double width = range[1] - range[0];
 
   int numColors = lookuptable->GetNumberOfTableValues();
   double factor = 1.0 / static_cast< double >( numColors - 1 );
-  if ( color->GetSize() == numColors && opacity->GetSize() == numColors )
+  color->RemoveAllPoints();
+  opacity->RemoveAllPoints();
+
+  // this->OpacityFunction->AddPoint (0.0,  0.0);
+  for ( int i = 0; i < numColors; ++i )
   {
-    for( int i = 0; i < numColors; ++i )
-    {
-      double x = range[0] + factor * static_cast< double >( i ) * width;
+    double x = range[0] + factor * static_cast< double >( i ) * width;
 
-      double * val = lookuptable->GetTableValue( i );
-      colorValue[0] = x;
-      colorValue[1] = val[0];
-      colorValue[2] = val[1];
-      colorValue[3] = val[2];
-      color->SetNodeValue( i, colorValue );
-
-      opacityValue[0] = x;
-      opacityValue[1] = val[3];
-      opacity->SetNodeValue( i, opacityValue);
-    }
-  }
-  else
-  {
-    color->RemoveAllPoints();
-    opacity->RemoveAllPoints();
-
-    // this->OpacityFunction->AddPoint (0.0,  0.0);
-    for ( int i = 0; i < numColors; ++i )
-    {
-      double x = range[0] + factor * static_cast< double >( i ) * width;
-
-      double * val = lookuptable->GetTableValue( i );
-      color->AddRGBPoint( x, val[0], val[1], val[2]);
-      opacity->AddPoint( x, val[3] );
-    }
+    double * val = lookuptable->GetTableValue( i );
+    color->AddRGBPoint( x, val[0], val[1], val[2]);
+    opacity->AddPoint( x, val[3] );
   }
 }
 


### PR DESCRIPTION
So, after a long chase, I finally got it. After a git bisect from VTK 5.8 to VTK 5.10.1, I found that the bug was due to commit 9b4061 in VTK, which made sure to re-sort the nodes of the color transfer function when their value were updated. That wasn't taken into account by an optimisation in the vtkImageView3D, which tries to only modifies node values instead of flushing and recreating the whole color transfer function when the number of color nodes, except that by modifying node values, their sort order might change, so more or less randomising the lookup table and making a mess of the display.

Unless I'm mistaken, this should only be run when the lookup table is changed, so performance is not critical, so I just removed the optimisation altogether, and now we regenerate the whole color transfer function everytime. A quick usage test did not seem to show any worsening of the window/level speed.
