### PR TITLE
Fixed bug in layer order when data had attached data

### DIFF
--- a/src-plugins/v3dView/v3dView.cpp
+++ b/src-plugins/v3dView/v3dView.cpp
@@ -903,7 +903,6 @@ bool v3dView::SetViewInput(const char* type,dtkAbstractData* data,const int laye
         d->view2d->SetITKInput(image,layer);
         d->view3d->SetITKInput(image,layer);
     }
-    dtkAbstractView::setData(data);
     return true;
 }
 
@@ -912,7 +911,6 @@ bool v3dView::SetView(const char* type,dtkAbstractData* data)
     if (data->identifier()!=type)
         return false;
 
-    dtkAbstractView::setData(data);
     return true;
 }
 
@@ -926,7 +924,6 @@ bool v3dView::SetViewInputWithConversion(const char* type,const char* newtype,dt
         d->view2d->SetITKInput(image,layer);
         d->view3d->SetITKInput(image,layer);
     }
-    dtkAbstractView::setData(data);
     return true;
 }
 
@@ -1000,7 +997,6 @@ void v3dView::setData ( dtkAbstractData *data, int layer )
             }
         }
         
-        dtkAbstractView::setData(data);
         if (!isDataTypeHandled)
             return;
     }
@@ -1047,6 +1043,8 @@ void v3dView::setData ( dtkAbstractData *data, int layer )
 
     //this->addDataInList ( data, layer );
     this->addDataInList ( data);
+    dtkAbstractView::setData(data);
+
     setCurrentLayer(layer);
     emit dataAdded ( data );
     emit dataAdded ( data, layer );


### PR DESCRIPTION
When a data with attached data (typically what happens if you start a segmentation with the paint tool then close the view) was opened in a new view, the layer order would be messed up.
This was due to the attachedData being added by the v3dViewAnnotationInteractor half-way through the original image being added. Something to keep in mind while designing the view refactor : should interactors be allowed to add data to the view (I think yes), and if yes, make sure it doesn't mess up the layer order.
