### PR TITLE
Precision of scalar bar values

### DIFF
--- a/src-plugins/libs/vtkInria/vtkImageView/vtkImageView.cxx
+++ b/src-plugins/libs/vtkInria/vtkImageView/vtkImageView.cxx
@@ -73,6 +73,9 @@ namespace {
     IMAGE_VIEW_FLOATVECTOR3TYPE  };
 }
 
+#ifdef WIN32
+    #define snprintf _snprintf_s
+#endif
 
 // pIMPL class for vtkImageView
 class vtkImageView::vtkImageViewImplementation {
@@ -856,10 +859,25 @@ void vtkImageView::SetTransferFunctionRangeFromWindowSettings(int layer)
 
     //probably should change the lookuptable of this scalar bar?
     //no, done in setLookupTable.
+    this->SetScalarBarLabelFormat(targetRange);
     this->ScalarBar->Modified();
   }
 }
+void vtkImageView::SetScalarBarLabelFormat(double* intensityRange)
+{
+    double diff = fabs(fabs(intensityRange[1])-fabs(intensityRange[0]));
 
+    if (diff>1 || diff == 0)
+    {
+        this->ScalarBar->SetLabelFormat ("%.f");
+        return;
+    }
+
+    int precision = -floor(log10(diff))+1; //+1 for the third value displayed (mean) not to be rounded
+    char format[10];
+    snprintf(format, 10, "%%.%df", precision);
+    this->ScalarBar->SetLabelFormat (format);
+}
 //----------------------------------------------------------------------------
 void vtkImageView::SetWindowSettingsFromTransferFunction()
 {

--- a/src-plugins/libs/vtkInria/vtkImageView/vtkImageView.h
+++ b/src-plugins/libs/vtkInria/vtkImageView/vtkImageView.h
@@ -442,7 +442,6 @@ class VTK_IMAGEVIEW_EXPORT vtkImageView : public vtkObject
   virtual void SetColorRange( double r[2], int layer );
   virtual void GetColorRange( double r[2], int layer );
 
-
   /**
      Reset the window level
   */
@@ -700,6 +699,11 @@ class VTK_IMAGEVIEW_EXPORT vtkImageView : public vtkObject
      the closest position that lies within the image boundaries.
    */
   virtual void GetWithinBoundsPosition (double* pos1, double* dos2);
+
+  /**
+    Set the precision of the scalarBar values
+   */
+  void SetScalarBarLabelFormat(double* range);
 
   private:
     //! Template function which implements SetInput for all types.


### PR DESCRIPTION
https://med.inria.fr/redmine/issues/1802
We currently round values displayed on the scalarBar, which is not what we want when displaying, for instance, images with 0 < values < 1.
Example of test image on Redmine.
