### PR TITLE
Closing tabbedViewContainers doesn't make its views emit closed signals

### DIFF
--- a/src/medGui/medTabbedViewContainers.cpp
+++ b/src/medGui/medTabbedViewContainers.cpp
@@ -14,6 +14,7 @@
 #include <QtCore>
 #include <QShortcut>
 
+#include <dtkCore/dtkAbstractView.h>
 #include "medTabbedViewContainers.h"
 
 #include "medViewContainer.h"
@@ -80,6 +81,8 @@ void medTabbedViewContainers::deleteContainerShortcutActivated()
 
 void medTabbedViewContainers::deleteContainerClicked(int index)
 {
+    QString tabName = this->tabText(index);
+
     if (this->count() == 1)
     {
         QString name = this->current()->identifier();
@@ -95,7 +98,8 @@ void medTabbedViewContainers::deleteContainerClicked(int index)
         if (newTab != NULL)
         {
             this->blockSignals(true);
-            QString tabName = this->tabText(index);
+            foreach(dtkAbstractView * view, d->containers[tabName]->views())
+                view->close();
             this->removeTab(index);
             this->insertContainer(index,tabName,newTab);
             this->setCurrentIndex(index);
@@ -106,6 +110,8 @@ void medTabbedViewContainers::deleteContainerClicked(int index)
     }
     else
     {
+        foreach(dtkAbstractView * view, d->containers[tabName]->views())
+                view->close();
         d->containers.remove(this->tabText(index));
         this->removeTab(index);
     }


### PR DESCRIPTION
Everything is in the title.

Problem maybe solved with the refactoring, I don't know.
