### PR TITLE
Some cleanups in the DICOM importer, and fix importing some sequences

### DIFF
--- a/src-plugins/itkDataImage/readers/itkDCMTKDataImageReader.cpp
+++ b/src-plugins/itkDataImage/readers/itkDCMTKDataImageReader.cpp
@@ -274,7 +274,7 @@ bool itkDCMTKDataImageReader::readInformation (const QStringList& paths)
 
     std::vector< std::string > filenames;
     for (int i=0; i<paths.size(); i++)
-        filenames.push_back(paths[i].toAscii().constData());
+        filenames.push_back(paths[i].toLocal8Bit().constData());
 
     d->io->SetFileNames(filenames);
     try {
@@ -485,13 +485,6 @@ bool itkDCMTKDataImageReader::read(const QStringList& paths)
         return false;
 
     this->readInformation(paths);
-
-    /*
-      if (d->io->GetNumberOfDimensions() != 3) {
-      qWarning() << "Only 3D images are supported for now (required: " << d->io->GetNumberOfDimensions() << ")";
-      return false;
-      }
-    */
 
     itk::DCMTKDataImageReaderCommand::Pointer command = itk::DCMTKDataImageReaderCommand::New();
     command->SetDataImageReader(this);

--- a/src/medSql/medAbstractDatabaseImporter.cpp
+++ b/src/medSql/medAbstractDatabaseImporter.cpp
@@ -955,9 +955,15 @@ QString medAbstractDatabaseImporter::generateUniqueVolumeId ( const medAbstractD
     // This information will then be passed to the database.
     QString patientName = medMetaDataKeys::PatientName.getFirstValue(medData);
     QString studyDicomId = medMetaDataKeys::StudyDicomID.getFirstValue(medData);
-    QString seriesDicomId = medMetaDataKeys::SeriesDicomID.getFirstValue(medData);
-    QString orientation = medMetaDataKeys::Orientation.getFirstValue(medData); // orientation sometimes differ by a few digits, thus this is not reliable
-    QString seriesNumber = medMetaDataKeys::SeriesNumber.getFirstValue(medData);
+
+    // We don't use the seriesDicomID, too unreliable : you can have images part
+    // of the same series with different UIDs, and different volumes within the
+    // same study with the same UIDs... instead, use Series Description
+    QString seriesDescription = medMetaDataKeys::SeriesDescription.getFirstValue(medData);
+
+    // orientation sometimes differ by a few digits, thus this is not reliable
+    QString orientation = medMetaDataKeys::Orientation.getFirstValue(medData);
+
     QString sequenceName = medMetaDataKeys::SequenceName.getFirstValue(medData);
     QString sliceThickness = medMetaDataKeys::SliceThickness.getFirstValue(medData);
     QString rows = medMetaDataKeys::Rows.getFirstValue(medData);
@@ -979,7 +985,7 @@ QString medAbstractDatabaseImporter::generateUniqueVolumeId ( const medAbstractD
     // define a unique key string to identify which volume an image belongs to.
     // we use: patientName, studyId, seriesId, orientation, seriesNumber, sequenceName, sliceThickness, rows, columns.
     // All images of the same volume should share similar values of these parameters
-    QString key = patientName+studyDicomId+seriesDicomId+orientation+seriesNumber+sequenceName+sliceThickness+rows+columns;
+    QString key = patientName+studyDicomId+seriesDescription+orientation+sequenceName+sliceThickness+rows+columns;
 
     return key;
 }


### PR DESCRIPTION
Some DICOM sequences had each slice with an independent Series Instance UID, thus confusing the importer which would import each slice as a separate volume. 

So, in medAbstractDatabaseImporter.cpp I changed the "volumeId" computation from using that Series Id and the Series number to using the Series Description.

The rest are just code cleanups.
