### PR TITLE
Correct crashing bug in ITK basic filters

### DIFF
--- a/src-plugins/itkFilters/itkFiltersProcessBase.cpp
+++ b/src-plugins/itkFilters/itkFiltersProcessBase.cpp
@@ -69,8 +69,8 @@ void itkFiltersProcessBase::setInput(medAbstractData *data)
     
     QString identifier = data->identifier();
     
-    d->output = medAbstractDataFactory::instance()->create(identifier);
-    d->input = data;
+    d->output = dynamic_cast<medAbstractImageData*> (medAbstractDataFactory::instance()->create(identifier));
+    d->input = dynamic_cast<medAbstractImageData*> (data);
 }
 
 medAbstractData * itkFiltersProcessBase::output ( void )

--- a/src-plugins/itkFilters/itkFiltersProcessBase_p.h
+++ b/src-plugins/itkFilters/itkFiltersProcessBase_p.h
@@ -15,7 +15,7 @@
 
 #include <dtkCore/dtkAbstractProcess.h>
 #include <dtkCore/dtkAbstractProcess_p.h>
-#include <medAbstractData.h>
+#include <medAbstractImageData.h>
 #include <dtkLog/dtkLog.h>
 
 #include <itkFiltersPluginExport.h>
@@ -39,9 +39,8 @@ public:
     itk::CStyleCommand::Pointer callback;
     itkFiltersProcessBase *filter;
     
-    medAbstractData *input;
-    //TODO smartPointer ? - rde
-    medAbstractData *output;
+    dtkSmartPointer <medAbstractImageData> input;
+    dtkSmartPointer <medAbstractImageData> output;
     
     template <class PixelType> void setupFilter() {}
     virtual void setFilterDescription() {}


### PR DESCRIPTION
Just smart pointing again seems to solve the problem
