### PR TITLE
Mesh scalar range editor

### DIFF
--- a/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
+++ b/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
@@ -645,8 +645,23 @@ void vtkDataMeshInteractor::updateRange()
     if (!lut)
         return;
     
-    if (d->minRange->value()>d->maxRange->value())
-        return;
+    medDoubleParameter *sender = dynamic_cast<medDoubleParameter *>(this->sender());
+    if(sender)
+    {
+        if( sender == d->minRange && d->minRange->value() >= d->maxRange->value() )
+        {
+            d->maxRange->blockSignals(true);
+            d->maxRange->setValue(d->minRange->value());
+            d->maxRange->blockSignals(false);
+        }
+        else if( sender == d->maxRange && d->maxRange->value() <= d->minRange->value() )
+        {
+            d->minRange->blockSignals(true);
+            d->minRange->setValue(d->maxRange->value());
+            d->minRange->blockSignals(false);
+        }
+    }
+    
     lut->SetRange(d->minRange->value(),d->maxRange->value());
     mapper2d->SetLookupTable(lut);
     mapper3d->SetLookupTable(lut);

--- a/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
+++ b/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
@@ -388,23 +388,19 @@ void vtkDataMeshInteractor::setAttribute(const QString & attributeName)
         mapper2d->SelectColorArray(qPrintable(attributeName));
         mapper3d->SelectColorArray(qPrintable(attributeName));
 
-        this->setLut(d->lut.first);
-
-        mapper2d->SetScalarVisibility(1);
-        mapper3d->SetScalarVisibility(1);
         d->range_button->show();
         double * range = d->metaDataSet->GetCurrentScalarRange();
-        double step = (range[1]-range[0])/100.0;
-        d->minRange->setSingleStep(step);
-        d->maxRange->setSingleStep(step);
-        /*dtkSignalBlocker dtkBlocker1 (d->minRange);
-        dtkSignalBlocker dtkBlocker2 (d->maxRange);*/
-        /*dtkBlocker1.blockSignals(true);
-        dtkBlocker2.blockSignals(true);*/
         d->minRange->setRange(range[0],range[1]);
         d->maxRange->setRange(range[0],range[1]);
         d->minRange->setValue(range[0]);
         d->maxRange->setValue(range[1]);
+        d->view2d->SetColorRange(range);
+        d->view3d->SetColorRange(range);
+        
+        this->setLut(d->lut.first);
+
+        mapper2d->SetScalarVisibility(1);
+        mapper3d->SetScalarVisibility(1);
     }
     else
     {
@@ -437,7 +433,7 @@ void vtkDataMeshInteractor::setLut(const QString & lutName)
         lut = vtkLookupTableManager::GetLookupTable(lutName.toStdString());
 
     if ( ! d->attribute)
-     return;
+        return;
 
     d->lut = LutPair(lut, lutName);
     this->setLut(lut);
@@ -493,7 +489,6 @@ void vtkDataMeshInteractor::setLut(vtkLookupTable * lut)
             values[3] = 1.0;
             lut->SetTableValue(i, values);
         }
-
         double * range = d->metaDataSet->GetCurrentScalarRange();
         lut->SetRange(range);
     }
@@ -501,14 +496,16 @@ void vtkDataMeshInteractor::setLut(vtkLookupTable * lut)
     vtkMapper * mapper2d = d->actor2d->GetMapper();
     vtkMapper * mapper3d = d->actor3d->GetMapper();
 
+    d->view2d->SetLookupTable(lut);
     mapper2d->SetLookupTable(lut);
     mapper2d->UseLookupTableScalarRangeOn();
     mapper2d->InterpolateScalarsBeforeMappingOn();
+
+    d->view3d->SetLookupTable(lut,d->view->layer(this->inputData()));
     mapper3d->SetLookupTable(lut);
     mapper3d->UseLookupTableScalarRangeOn();
     mapper3d->InterpolateScalarsBeforeMappingOn();
-    d->view2d->GetScalarBar()->SetLabelFormat("%10.3f");  // todo : take into account the range?
-    d->view3d->GetScalarBar()->SetLabelFormat("%10.3f");
+    
     updateRange();
 }
 
@@ -640,7 +637,6 @@ void vtkDataMeshInteractor::updateRange()
     if (!d->metaDataSet)
         return;
     
-    vtkMapper * mapper2d = d->actor2d->GetMapper();
     vtkMapper * mapper3d = d->actor3d->GetMapper();
 
     vtkLookupTable * lut = vtkLookupTable::SafeDownCast(mapper3d->GetLookupTable());
@@ -649,12 +645,8 @@ void vtkDataMeshInteractor::updateRange()
         return;
     
     lut->SetRange(d->minRange->value(),d->maxRange->value());
-    mapper2d->SetLookupTable(lut);
-    mapper3d->SetLookupTable(lut);
-    d->view3d->GetScalarBar()->SetLookupTable(lut);
-    d->view2d->GetScalarBar()->SetLookupTable(lut);
 
-    d->view->viewWidget()->update();
+    d->view->render();
 }
 
 void vtkDataMeshInteractor::showRangeWidgets(bool checked)

--- a/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
+++ b/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
@@ -500,7 +500,7 @@ void vtkDataMeshInteractor::setLut(vtkLookupTable * lut)
     mapper2d->SetLookupTable(lut);
     mapper2d->UseLookupTableScalarRangeOn();
     mapper2d->InterpolateScalarsBeforeMappingOn();
-
+    
     d->view3d->SetLookupTable(lut,d->view->layer(this->inputData()));
     mapper3d->SetLookupTable(lut);
     mapper3d->UseLookupTableScalarRangeOn();
@@ -637,6 +637,7 @@ void vtkDataMeshInteractor::updateRange()
     if (!d->metaDataSet)
         return;
     
+    vtkMapper * mapper2d = d->actor2d->GetMapper();
     vtkMapper * mapper3d = d->actor3d->GetMapper();
 
     vtkLookupTable * lut = vtkLookupTable::SafeDownCast(mapper3d->GetLookupTable());
@@ -645,6 +646,10 @@ void vtkDataMeshInteractor::updateRange()
         return;
     
     lut->SetRange(d->minRange->value(),d->maxRange->value());
+    mapper2d->SetLookupTable(lut);
+    mapper3d->SetLookupTable(lut);
+    d->view3d->GetScalarBar()->SetLookupTable(lut);
+    d->view2d->GetScalarBar()->SetLookupTable(lut);
 
     d->view->render();
 }

--- a/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
+++ b/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
@@ -560,8 +560,8 @@ QWidget* vtkDataMeshInteractor::buildToolBoxWidget()
     layout->addRow(d->range_button);
     d->minRange->getSlider()->setOrientation(Qt::Horizontal);
     d->maxRange->getSlider()->setOrientation(Qt::Horizontal);
-    QHBoxLayout *minRangeLayout = new QHBoxLayout(toolbox);
-    QHBoxLayout *maxRangeLayout = new QHBoxLayout(toolbox);
+    QHBoxLayout *minRangeLayout = new QHBoxLayout();
+    QHBoxLayout *maxRangeLayout = new QHBoxLayout();
     minRangeLayout->addWidget(d->minRange->getSlider());
     minRangeLayout->addWidget(d->minRange->getSpinBox());
     maxRangeLayout->addWidget(d->maxRange->getSlider());
@@ -645,6 +645,8 @@ void vtkDataMeshInteractor::updateRange()
     if (!lut)
         return;
     
+    if (d->minRange->value()>d->maxRange->value())
+        return;
     lut->SetRange(d->minRange->value(),d->maxRange->value());
     mapper2d->SetLookupTable(lut);
     mapper3d->SetLookupTable(lut);

--- a/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
+++ b/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
@@ -51,6 +51,7 @@
 #include <medAbstractImageView.h>
 #include <medIntParameter.h>
 #include <medVtkViewBackend.h>
+#include <vtkScalarBarActor.h>
 
 #include <vector>
 
@@ -82,7 +83,10 @@ public:
     medBoolParameter *edgeVisibleParam;
     medStringListParameter *colorParam;
     medStringListParameter *renderingParam;
+    medDoubleParameter *minRange,*maxRange;
 
+    QPushButton * range_button;
+    
     QList <medAbstractParameter*> parameters;
 
     medIntParameter *slicingParameter;
@@ -107,6 +111,12 @@ vtkDataMeshInteractor::vtkDataMeshInteractor(medAbstractView *parent):
     d->colorParam = NULL;
     d->renderingParam = NULL;
     d->slicingParameter = NULL;
+    d->minRange = 0;
+    d->maxRange = 0;
+
+    d->range_button = new QPushButton("Modify Range");
+    d->range_button->setCheckable(true);
+    connect(d->range_button,SIGNAL(toggled(bool)),this,SLOT(showRangeWidgets(bool)));
 }
 
 
@@ -246,6 +256,12 @@ void vtkDataMeshInteractor::setupParameters()
 
     d->parameters << this->visibilityParameter();
 
+    d->minRange = new medDoubleParameter("Min",this);
+    d->maxRange = new medDoubleParameter("Max",this);
+
+    connect(d->minRange,SIGNAL(valueChanged(double)),this,SLOT(updateRange()));
+    connect(d->maxRange,SIGNAL(valueChanged(double)),this,SLOT(updateRange()));
+
     this->updateWidgets();
 }
 
@@ -349,7 +365,7 @@ void vtkDataMeshInteractor::setAttribute(const QString & attributeName)
 
     if (attributes)
     {
-
+        
         if(d->colorParam)
             d->colorParam->hide();
         if(d->LUTParam)
@@ -364,6 +380,7 @@ void vtkDataMeshInteractor::setAttribute(const QString & attributeName)
 
             d->attribute = attributes->GetArray(qPrintable(attributeName));
             attributes->SetActiveScalars(qPrintable(attributeName));
+            d->metaDataSet->SetCurrentActiveArray(attributes->GetArray(qPrintable(attributeName)));
 
             d->LUTParam->show();
         }
@@ -375,9 +392,24 @@ void vtkDataMeshInteractor::setAttribute(const QString & attributeName)
 
         mapper2d->SetScalarVisibility(1);
         mapper3d->SetScalarVisibility(1);
+        d->range_button->show();
+        double * range = d->metaDataSet->GetCurrentScalarRange();
+        double step = (range[1]-range[0])/100.0;
+        d->minRange->setSingleStep(step);
+        d->maxRange->setSingleStep(step);
+        /*dtkSignalBlocker dtkBlocker1 (d->minRange);
+        dtkSignalBlocker dtkBlocker2 (d->maxRange);*/
+        /*dtkBlocker1.blockSignals(true);
+        dtkBlocker2.blockSignals(true);*/
+        d->minRange->setRange(range[0],range[1]);
+        d->maxRange->setRange(range[0],range[1]);
+        d->minRange->setValue(range[0]);
+        d->maxRange->setValue(range[1]);
     }
     else
     {
+        d->range_button->setChecked(false);
+        d->range_button->hide();
         if(d->LUTParam)
             d->LUTParam->hide();
         if(d->colorParam)
@@ -471,8 +503,13 @@ void vtkDataMeshInteractor::setLut(vtkLookupTable * lut)
 
     mapper2d->SetLookupTable(lut);
     mapper2d->UseLookupTableScalarRangeOn();
+    mapper2d->InterpolateScalarsBeforeMappingOn();
     mapper3d->SetLookupTable(lut);
     mapper3d->UseLookupTableScalarRangeOn();
+    mapper3d->InterpolateScalarsBeforeMappingOn();
+    d->view2d->GetScalarBar()->SetLabelFormat("%10.3f");  // todo : take into account the range?
+    d->view3d->GetScalarBar()->SetLabelFormat("%10.3f");
+    updateRange();
 }
 
 
@@ -523,7 +560,18 @@ QWidget* vtkDataMeshInteractor::buildToolBoxWidget()
     layout->addRow(d->edgeVisibleParam->getLabel(), d->edgeVisibleParam->getCheckBox());
     layout->addRow(d->colorParam->getLabel(), d->colorParam->getComboBox());
     layout->addRow(d->renderingParam->getLabel(), d->renderingParam->getComboBox());
-
+    layout->addRow(d->range_button);
+    d->minRange->getSlider()->setOrientation(Qt::Horizontal);
+    d->maxRange->getSlider()->setOrientation(Qt::Horizontal);
+    QHBoxLayout *minRangeLayout = new QHBoxLayout(toolbox);
+    QHBoxLayout *maxRangeLayout = new QHBoxLayout(toolbox);
+    minRangeLayout->addWidget(d->minRange->getSlider());
+    minRangeLayout->addWidget(d->minRange->getSpinBox());
+    maxRangeLayout->addWidget(d->maxRange->getSlider());
+    maxRangeLayout->addWidget(d->maxRange->getSpinBox());
+    layout->addRow(d->minRange->getLabel(),minRangeLayout);
+    layout->addRow(d->maxRange->getLabel(),maxRangeLayout);
+    showRangeWidgets(false);
     return toolbox;
 }
 
@@ -585,4 +633,40 @@ void vtkDataMeshInteractor::updateSlicingParam()
     d->slicingParameter->blockSignals(false);
 
     d->slicingParameter->setValue(d->view2d->GetSlice());
+}
+
+void vtkDataMeshInteractor::updateRange()
+{
+    if (!d->metaDataSet)
+        return;
+    
+    vtkMapper * mapper2d = d->actor2d->GetMapper();
+    vtkMapper * mapper3d = d->actor3d->GetMapper();
+
+    vtkLookupTable * lut = vtkLookupTable::SafeDownCast(mapper3d->GetLookupTable());
+    
+    if (!lut)
+        return;
+    
+    lut->SetRange(d->minRange->value(),d->maxRange->value());
+    mapper2d->SetLookupTable(lut);
+    mapper3d->SetLookupTable(lut);
+    d->view3d->GetScalarBar()->SetLookupTable(lut);
+    d->view2d->GetScalarBar()->SetLookupTable(lut);
+
+    d->view->viewWidget()->update();
+}
+
+void vtkDataMeshInteractor::showRangeWidgets(bool checked)
+{
+    if (checked)
+    {
+        d->maxRange->show();
+        d->minRange->show();
+    }
+    else
+    {
+        d->maxRange->hide();
+        d->minRange->hide();
+    }
 }

--- a/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.h
+++ b/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.h
@@ -71,8 +71,7 @@ public slots:
 
 
     virtual void updateWidgets();
-
-
+    
 protected:
     void updatePipeline ();
     void setLut(vtkLookupTable * lut);
@@ -84,6 +83,8 @@ private:
 
 private slots:
     void updateSlicingParam();
+    void updateRange();
+    void showRangeWidgets(bool);
 
 private:
     vtkDataMeshInteractorPrivate * d;

--- a/src/medVtkInria/vtkImageView/vtkImageView.cxx
+++ b/src/medVtkInria/vtkImageView/vtkImageView.cxx
@@ -865,10 +865,17 @@ void vtkImageView::SetScalarBarLabelFormat(double* intensityRange)
 {
     double diff = fabs(fabs(intensityRange[1])-fabs(intensityRange[0]));
 
-    if (diff>1 || diff == 0)
+    if (diff>1)
     {
         this->ScalarBar->SetLabelFormat ("%.f");
         return;
+    }
+
+    if (diff == 0)
+    {
+        if (intensityRange[1]==0)
+            return;
+        diff = fabs(intensityRange[1]);
     }
 
     int precision = -floor(log10(diff))+1; //+1 for the third value displayed (mean) not to be rounded


### PR DESCRIPTION
This code adds a button into the vtkDataMeshInteractor and 2 medDoubleParameters to modify the range of a mesh.
Thanks to this  "mapper3d->InterpolateScalarsBeforeMappingOn();", it also improves the quality of the mesh visualization, I think it is now like paraview (visually).
Some changes have been made to SetScalarBarLabelFormat in vtkImageView.cxx

You can test on this data : 
https://transfert.inria.fr/fichiers/abc107dd6efc2eb5b45fcc50b93f3225/2-Map_mesh_attributes.vtk
