### PR TITLE
Memory improvements (The return)

### DIFF
--- a/src/medVtkInria/vtkImageView/vtkImageView3D.h
+++ b/src/medVtkInria/vtkImageView/vtkImageView3D.h
@@ -305,6 +305,9 @@ protected:
 
   //! Get layer specific info
   vtkImage3DDisplay * GetImage3DDisplayForLayer(int layer) const;
+  
+  //! Cast layers to layer 0 's type if necessary
+  void castLayers();
 
   // plane actors
   vtkImageActor* ActorX;
@@ -366,6 +369,7 @@ protected:
 
   struct LayerInfo {
       vtkSmartPointer<vtkImage3DDisplay> ImageDisplay;
+      bool NeedCast;
   };
 
   vtkSmartPointer<vtkImageMapToColors>        PlanarWindowLevel;
@@ -373,7 +377,6 @@ protected:
   //(API change)
   typedef std::vector<LayerInfo > LayerInfoVecType;
   LayerInfoVecType LayerInfoVec;
-
 private:
   vtkImageView3D(const vtkImageView3D&);  // Not implemented.
   void operator=(const vtkImageView3D&);    // Not implemented.


### PR DESCRIPTION
Before  : 
- When we add a layer, the image added is casted into the type of the layer 0 for VR visualization. Memory is therefore allocated, even when VR is not activated. This can be troublesome with 600x600x200 images for example (CTscan) and paint segmentation. You can easily reach 1 Go with no effort.
- The vtkImageAppendComponents  is used to append the different layers into a single vtkImageData which is then setted as an input in the VolumeMapper. The VR visualization of this data can be extremely painful when we have more than 1 layer. We noticed that it is quite slow even when the visibility of all layers except the layer 0 is set to off.

Now: 
- We keep in mind which layers need to be casted, and we cast them only when the VR mode is activated.
- We have changed the code so that when the visilibility of a layer is set to off, its data is not given to the vtkImageAppendComponents to be appended. This enables us to improve interactions, and to be able to have normal VR on a single layer if all the other are Off (visibility) .

Remaining issues : 
- After deleting a layer, no memory seems to be deallocated.
- In a simple case, like for example using paint on an image, a new layer is added, if the user wants to go to VR mode to visualize its layer 0, this will lead to memory allocated for its layer 1 which he probably doesnt want to see in VR, and his/her computer getting slow because of multiple layers being ON (visibility). A possible solution would be to set to Off (visibility) all layers excepts the layer 0 when going to VR. The user can still activate them back, if he wants to visualize them. What do you think ?? 
