### PR TITLE
Remove RGB(A) image support in writer that don't actually support it

### DIFF
--- a/src-plugins/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
+++ b/src-plugins/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
@@ -99,7 +99,7 @@ QStringList medVtkViewItkDataImageInteractor::dataHandled()
                                   << "itkDataImageDouble3"
                                   << "itkDataImageRGB3"
                                   << "itkDataImageRGBA3"
-                                  << "itkDataImageVector3";
+                                  << "itkDataImageVectorUChar3";
     return  d;
 }
 
@@ -166,7 +166,7 @@ void medVtkViewItkDataImageInteractor::setInputData(medAbstractData *data)
           SetViewInput<itk::Image<double,3> >("itkDataImageDouble3", data, d->view->layer(data)) ||
           SetViewInput<itk::Image<itk::RGBPixel<unsigned char>,3> >("itkDataImageRGB3", data, d->view->layer(data)) ||
           SetViewInput<itk::Image<itk::RGBAPixel<unsigned char>,3> >("itkDataImageRGBA3", data, d->view->layer(data)) ||
-          SetViewInput<itk::Image<itk::Vector<unsigned char,3>,3> >("itkDataImageVector3", data, d->view->layer(data))))
+          SetViewInput<itk::Image<itk::Vector<unsigned char,3>,3> >("itkDataImageVectorUChar3", data, d->view->layer(data))))
     {
         qDebug() << "Unable to add data: " << data->identifier() << " to view " << this->identifier();
         return;

--- a/src-plugins/itkDataImage/writers/itkGiplDataImageWriter.cpp
+++ b/src-plugins/itkDataImage/writers/itkGiplDataImageWriter.cpp
@@ -32,8 +32,7 @@ static QStringList s_handled() {
                           << "itkDataImageLong3" << "itkDataImageLong4"
                           << "itkDataImageULong3" << "itkDataImageULong4"
                           << "itkDataImageFloat3" << "itkDataImageFloat4"
-                          << "itkDataImageDouble3" << "itkDataImageDouble4"
-                          << "itkDataImageRGB3" << "itkDataImageRGBA3";
+                          << "itkDataImageDouble3" << "itkDataImageDouble4";
 }
 
 itkGiplDataImageWriter::itkGiplDataImageWriter(): itkDataImageWriterBase() {

--- a/src-plugins/itkDataImage/writers/itkMetaDataImageWriter.cpp
+++ b/src-plugins/itkDataImage/writers/itkMetaDataImageWriter.cpp
@@ -34,8 +34,7 @@ QStringList s_handled() {
                           << "itkDataImageFloat3" << "itkDataImageFloat4"
                           << "itkDataImageDouble3" << "itkDataImageDouble4"
                           << "itkDataImageVectorUChar3" << "itkDataImageVectorFloat3"
-                          << "itkDataImageVectorDouble3"
-                          << "itkDataImageRGB3" << "itkDataImageRGBA3";
+                          << "itkDataImageVectorDouble3";
 }
 
 itkMetaDataImageWriter::itkMetaDataImageWriter(): itkDataImageWriterBase() {

--- a/src-plugins/itkDataImage/writers/itkNiftiDataImageWriter.cpp
+++ b/src-plugins/itkDataImage/writers/itkNiftiDataImageWriter.cpp
@@ -32,8 +32,7 @@ static QStringList s_handled() {
                           << "itkDataImageLong3" << "itkDataImageLong4"
                           << "itkDataImageULong3" << "itkDataImageULong4"
                           << "itkDataImageFloat3" << "itkDataImageFloat4"
-                          << "itkDataImageDouble3" << "itkDataImageDouble4"
-                          << "itkDataImageRGB3" << "itkDataImageRGBA3";
+                          << "itkDataImageDouble3" << "itkDataImageDouble4";
 }
 
 itkNiftiDataImageWriter::itkNiftiDataImageWriter(): itkDataImageWriterBase() {


### PR DESCRIPTION
This fixes 2 problems : the viewer can actually display uchar vector 3 as RGB but there was a typo in the identifier, so they weren't properly recognised. Secondly, the Meta Image, Gipl and Nifti writers were claiming to handle RGB/RGBA when they actually degrade them to uchar vector 3, so I disabled support for writing RGB/RGBA files with these. Which means now RGB/RGA images are saved as Nrrd, which is the only writer we have that actually saves them properly as RGB/RGBA.

This triggers another, more general question of how to handle vector images... a vector uchar 3 is now currently being interpreted as a RGB image, but it could just as well be a vector field image with uchar vector coordinates. What do we think is the best way to deal with ambiguities such as these ? There should probably be some way on load/import of ambiguous type to be able to tag them with some extra semantic sense.