### PR TITLE
Adding opacity to VectorField

### DIFF
--- a/src/medCore/gui/medTabbedViewContainers.cpp
+++ b/src/medCore/gui/medTabbedViewContainers.cpp
@@ -131,7 +131,10 @@ void medTabbedViewContainers::resetTabState()
 
 medViewContainer* medTabbedViewContainers::addContainerInTab()
 {
-    return this->addContainerInTab(QString("%0 %1").arg(d->owningWorkspace->name()).arg(count()));
+    if (this->count())
+        return this->addContainerInTab(QString("%0 %1").arg(d->owningWorkspace->name()).arg(count()));
+    else
+        return this->addContainerInTab(QString("%0").arg(d->owningWorkspace->name()));
 }
 
 medViewContainer* medTabbedViewContainers::addContainerInTab(const QString &name)


### PR DESCRIPTION
Added an opacity slider to vectorfields.

Also a slight change in behaviour - when we close the last tab, and the application automatically creates a new tab, it will no longer appear as "Tabname 0" (i.e. Segmentation 0), but will instead display the tabname only (like it is when we open the workspace for the first time)
New tabs are unaffected.

As ever, please give pointers if I'm doing things in a strange way!
