### PR TITLE
Crash when empty study

### DIFF
--- a/src/medCore/data/medAbstractData.cpp
+++ b/src/medCore/data/medAbstractData.cpp
@@ -138,7 +138,6 @@ void medAbstractData::invokeModified()
 
 QImage& medAbstractData::thumbnail()
 {
-    this->retain();
     if(d->thumbnail == QImage())
     {
         if (QThread::currentThread() != QApplication::instance()->thread())
@@ -146,7 +145,6 @@ QImage& medAbstractData::thumbnail()
         else
             this->generateThumbnail();
     }
-    this->release();
 
     return d->thumbnail;
 }

--- a/src/medCore/database/medAbstractDatabaseImporter.cpp
+++ b/src/medCore/database/medAbstractDatabaseImporter.cpp
@@ -30,7 +30,7 @@ class medAbstractDatabaseImporterPrivate
 {
 public:
     QString file;
-    medAbstractData *data;
+    dtkSmartPointer<medAbstractData> data;
     static QMutex mutex;
     bool isCancelled;
     bool indexWithoutImporting;
@@ -431,7 +431,7 @@ void medAbstractDatabaseImporter::importData()
         
 
     QString size ="";
-    if ( medAbstractImageData *imagedata = dynamic_cast<medAbstractImageData*> ( d->data) )
+    if ( medAbstractImageData *imagedata = dynamic_cast<medAbstractImageData*> ( d->data.data()) )
         size = QString::number ( imagedata->zDimension() );
     d->data->addMetaData ( medMetaDataKeys::Size.key(), size );
 

--- a/src/medCore/gui/database/medDatabasePreview.cpp
+++ b/src/medCore/gui/database/medDatabasePreview.cpp
@@ -189,6 +189,9 @@ medDatabasePreviewDynamicScene::~medDatabasePreviewDynamicScene()
 
 void medDatabasePreviewDynamicScene::previewMouseMoveEvent(QMouseEvent *event, int width)
 {
+    if(d->seriesDescriptionDataIndexPairList.empty())
+        return;
+
     int seriesIndex = event->x() / (width / (double)d->seriesDescriptionDataIndexPairList.size());
     seriesIndex = qBound(0, seriesIndex, d->seriesDescriptionDataIndexPairList.size()-1);
     this->setImage(d->seriesDescriptionDataIndexPairList.at(seriesIndex).first);

--- a/src/medCore/gui/database/medDatabaseView.cpp
+++ b/src/medCore/gui/database/medDatabaseView.cpp
@@ -441,6 +441,8 @@ void medDatabaseView::onCreatePatientRequested(void)
         birthdate = editDialog.value(medMetaDataKeys::BirthDate.label()).toString();
         gender = editDialog.value(medMetaDataKeys::Gender.label()).toString();
 
+        // TODO: Hack to be able to create patient using medAbstractData
+        // Need to be rethought
         medAbstractData* medData = new medAbstractData();
 
         QString generatedPatientID = QUuid::createUuid().toString().replace ( "{","" ).replace ( "}","" );
@@ -495,6 +497,8 @@ void medDatabaseView::onCreateStudyRequested(void)
         {
             QString studyName = editDialog.value(medMetaDataKeys::StudyDescription.label()).toString();
 
+            // TODO: Hack to be able to create study using medAbstractData
+            // Need to be rethought
             medAbstractData* medData = new medAbstractData();
 
             medData->addMetaData ( medMetaDataKeys::PatientName.key(), QStringList() << patientName );


### PR DESCRIPTION
This PR should correct a crash that happened when you were hovering the thumbnail area after creating a new study