### PR TITLE
Multiple views from command line

### DIFF
--- a/app/medInria/main.cpp
+++ b/app/medInria/main.cpp
@@ -97,7 +97,8 @@ int main(int argc,char* argv[]) {
 
     medSettingsManager* mnger = medSettingsManager::instance();
 
-    QStringList posargs;
+    QList<QStringList> posargs;
+    int k = 0;
     for (int i=1;i<application.argc();++i) {
         const QString arg = application.argv()[i];
         if (arg.startsWith("--")) {
@@ -112,19 +113,32 @@ int main(int argc,char* argv[]) {
             for (QStringList::const_iterator opt=options.constBegin();opt!=options.constEnd();++opt)
                 if (arg.startsWith(*opt))
                     valid_option = true;
+                if(arg.startsWith("--view"))
+                {
+                    posargs.append(QStringList());
+                    k++;
+                }
             if (!valid_option) { qDebug() << "Ignoring unknown option " << arg; }
             continue;
         }
-        posargs.append(arg);
+        if(k==0)
+            continue;
+
+        posargs[k-1].append(arg);
     }
 
     const bool DirectView = dtkApplicationArgumentsContain(&application,"--view") || posargs.size()!=0;
     int runningMedInria = 0;
     if (DirectView) {
         show_splash = false;
-        for (QStringList::const_iterator i=posargs.constBegin();i!=posargs.constEnd();++i) {
-            const QString& message = QString("/open ")+*i;
-            runningMedInria = application.sendMessage(message);
+        for(QList<QStringList>::const_iterator it=posargs.constBegin(); it!=posargs.constEnd(); ++it)
+        {
+            QStringList list = *it;
+            for (QStringList::const_iterator i= list.constBegin();i!=list.constEnd();++i)
+            {
+                const QString& message = QString("/open ")+*i;
+                runningMedInria = application.sendMessage(message);
+            }
         }
     } else {
         runningMedInria = application.sendMessage("");

--- a/app/medInria/medMainWindow.h
+++ b/app/medInria/medMainWindow.h
@@ -39,7 +39,7 @@ public:
     void saveSettings();
     QWidget* currentArea() const;
 
-    void setStartup(const AreaType areaIndex,const QStringList& filenames);
+    void setStartup(const AreaType areaIndex, const QList<QStringList> &filenames);
     void resizeEvent( QResizeEvent * event );
 
 signals:
@@ -80,25 +80,8 @@ private slots:
 
     void availableSpaceOnStatusBar();
 
-    /**
-     * @brief Overload existing showFullScreen().
-     *
-     * Allows the update of the fullScreen button.
-     */
     void showFullScreen();
-
-    /**
-     * @brief Overload existing showNormal().
-     *
-     * Allows the update of the fullScreen button.
-     */
     void showNormal();
-
-    /**
-     * @brief Overload existing showMaximized().
-     *
-     * Allows the update of the fullScreen button.
-     */
     void showMaximized();
 
     void adjustContainersSize();


### PR DESCRIPTION
We were asked if we could  try to solve #218 so I did a quick attempt to correct it.
You should now be able to open different files in different containers using for example:

> medinria --view file1 file2 -- view file3 --view file4

However, it raises some questions/problems...
I only changed the behavior of the open(QString file) method. The open(medDataIndex) method should probably be able to do the same. Moreover, we can open images from various places (medMainWindow, medApplication, medAbstractWorkspace...), We should probably try to limit the number of possibilities and probably find a way to allow the opening in a new container...and be able to handle multiple openings form the browser, as Mike was saying in #220 .

In the next few days I have, I will try to focus on process refactoring, so if someone wants to take this over, please go ahead.
