### PR TITLE
Fix registration for unsigned short images

### DIFF
--- a/src/medRegistration/itkProcessRegistration.cpp
+++ b/src/medRegistration/itkProcessRegistration.cpp
@@ -304,6 +304,10 @@ bool itkProcessRegistration::setInputData(medAbstractData *data, int channel)
     {
         castFilterAdapterPtr.reset(new CastFilterTemplateAdapter<short>);
     }
+    else if (id == "itkDataImageUShort3")
+    {
+        castFilterAdapterPtr.reset(new CastFilterTemplateAdapter<unsigned short>);
+    }
     else if(id == "itkDataImageInt3")
     {
         castFilterAdapterPtr.reset(new CastFilterTemplateAdapter<int>);


### PR DESCRIPTION
Reenabling registration for unsigned short images (like I1.nhdr) that was not possible in medInria2.2.2