### PR TITLE
Add tests on NaN values to avoid crash during window-leveling

### DIFF
--- a/src-plugins/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
+++ b/src-plugins/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
@@ -566,6 +566,8 @@ void medVtkViewItkDataImageInteractor::setWindowLevel(QHash<QString,QVariant> va
 
     double w = values["Window"].toDouble();
     double l = values["Level"].toDouble();
+    if(w != w || l != l) // NaN values
+        return;
 
     if (d->view2d->GetColorWindow(d->view->layer(d->imageData)) != w)
     {


### PR DESCRIPTION
The invert intensity image filter is broken and make always images with really high values (1.798^308)

If you change the WL of the resulting image, it try to apply a window or a level with NaN and it crashes. Here is a patch to fix the crashes caused by the NaN.

I'll fix the invert intensity image filter soon.

