### PR TITLE
Itk data improvements

### DIFF
--- a/app/medInria/medApplication.cpp
+++ b/app/medInria/medApplication.cpp
@@ -170,7 +170,7 @@ void medApplication::initialize()
     viewerWSpaceFactory->registerWorkspace<medSegmentationWorkspace>();
 
     //Register settingsWidgets
-    medSettingsWidgetFactory * settingsWidgetFactory = medSettingsWidgetFactory::instance();
+    medSettingsWidgetFactory* settingsWidgetFactory = medSettingsWidgetFactory::instance();
     settingsWidgetFactory->registerSettingsWidget<medStartupSettingsWidget>();
     settingsWidgetFactory->registerSettingsWidget<medDatabaseSettingsWidget>();
 

--- a/src-plugins/itkDataImage/datas/itkDataImage.h
+++ b/src-plugins/itkDataImage/datas/itkDataImage.h
@@ -15,207 +15,44 @@
 
 #include <itkVector.h>
 #include <itkImage.h>
-#include <itkMinimumMaximumImageCalculator.h>
-#include <itkScalarImageToHistogramGenerator.h>
 #include <itkRGBPixel.h>
 #include <itkRGBAPixel.h>
-#include <itkScalarToRGBColormapImageFilter.h>
-#include <itkRegionOfInterestImageFilter.h>
-#include <itkExtractImageFilter.h>
-#include <itkShrinkImageFilter.h>
-#include <itkResampleImageFilter.h>
-#include <itkRecursiveGaussianImageFilter.h>
 
 #include <medAbstractDataFactory.h>
 #include <medAbstractTypedImageData.h>
 #include <itkDataImagePluginExport.h>
-
-
-template <typename T>
-struct ImageTypeIndex {
-    static const unsigned Index = 0;
-};
-
-template <typename T,unsigned N>
-struct ImageTypeIndex<itk::Vector<T,N> > {
-    static const unsigned Index = 1;
-};
-
-template <typename T>
-struct ImageTypeIndex<itk::RGBPixel<T> > {
-    static const unsigned Index = 1;
-};
-
-template <typename T>
-struct ImageTypeIndex<itk::RGBAPixel<T> > {
-    static const unsigned Index = 1;
-};
-
-template <unsigned DIM,typename T,unsigned N>
-class itkDataImagePrivate {
-public:
-    typedef T ScalarType;
-    typedef typename itk::Image<ScalarType,DIM> ImageType;
-    typedef typename itk::Statistics::ScalarImageToHistogramGenerator<ImageType> HistogramGeneratorType;
-    typedef typename HistogramGeneratorType::HistogramType HistogramType;
-
-    itkDataImagePrivate()
-    {
-        image = 0;
-        histogram = 0;
-        range_computed = false;
-        range_min = 0;
-        range_max = 0;
-        histogram_min = 0;
-        histogram_max = 0;
-    }
-
-    void reset() { range_computed = false; }
-
-    int minRangeValue() {
-        computeRange();
-        if (!range_computed)
-            qDebug() << "Cannot compute range";
-        return range_min;
-    }
-
-    int maxRangeValue() {
-        computeRange();
-        return range_max;
-    }
-
-    int scalarValueCount(int value) {
-        computeValueCounts();
-        if((ScalarType)value>=range_min && (ScalarType)value<=range_max)
-            return histogram->GetFrequency(value,0);
-        return -1;
-    }
-
-    int scalarValueMinCount() {
-        computeValueCounts();
-        return histogram_min;
-    }
-
-    int scalarValueMaxCount() {
-        computeValueCounts();
-        return histogram_max;
-    }
-
-    typename ImageType::Pointer image;
-    bool range_computed;
-    ScalarType range_min;
-    ScalarType range_max;
-    typename HistogramType::Pointer histogram;
-    int histogram_min;
-    int histogram_max;
-    QList<QImage> thumbnails;
-
-private:
-
-    void computeRange();
-    void computeValueCounts();
-};
-
-template <unsigned DIM,typename T,unsigned N>
-void itkDataImagePrivate<DIM,T,N>::computeRange() {
-    if (range_computed)
-        return;
-
-    if (image->GetLargestPossibleRegion().GetNumberOfPixels()==0)
-        return;
-
-    typedef itk::MinimumMaximumImageCalculator<ImageType> MinMaxCalculatorType;
-
-    typename MinMaxCalculatorType::Pointer calculator = MinMaxCalculatorType::New();
-    calculator->SetImage (image);
-    calculator->SetRegion(image->GetLargestPossibleRegion());
-    try {
-        calculator->Compute();
-    } catch (itk::ExceptionObject &e) {
-        std::cerr << e;
-        return;
-    }
-    range_min = calculator->GetMinimum();
-    range_max = calculator->GetMaximum();
-    range_computed = true;
-}
-
-template <unsigned DIM,typename T,unsigned N>
-void itkDataImagePrivate<DIM,T,N>::computeValueCounts() {
-    if (histogram.IsNull()) {
-        computeRange();
-
-        typename HistogramGeneratorType::Pointer histogramGenerator = HistogramGeneratorType::New();
-        histogramGenerator->SetInput(image);
-        histogramGenerator->SetNumberOfBins(range_max-range_min+1);
-        histogramGenerator->SetMarginalScale(1.0);
-        histogramGenerator->SetHistogramMin(range_min);
-        histogramGenerator->SetHistogramMax(range_max);
-
-        try {
-            std::cerr << "calculating histogram...";
-            histogramGenerator->Compute();
-            std::cerr << "done" << std::endl;
-        } catch (itk::ExceptionObject &e) {
-            std::cerr << e;
-            return;
-        }
-
-        typedef typename HistogramGeneratorType::HistogramType HistogramType;
-        typedef typename HistogramType::AbsoluteFrequencyType FrequencyType;
-
-        histogram = const_cast<HistogramType*>(histogramGenerator->GetOutput());
-
-        FrequencyType min = itk::NumericTraits< FrequencyType >::max();
-        FrequencyType max = itk::NumericTraits< FrequencyType >::min();
-
-        typedef typename HistogramType::Iterator Iterator;
-        for (Iterator it=histogram->Begin(),end=histogram->End();it!=end;++it) {
-            FrequencyType c = it.GetFrequency();
-            if (min>c) min = c;
-            if (max<c) max = c;
-        }
-        histogram_min = static_cast<int>(min);
-        histogram_max = static_cast<int>(max);
-    }
-}
+#include <itkDataPrivateTypes.h>
 
 template <unsigned DIM,typename T>
-class itkDataImagePrivate<DIM,T,1> {
-public:
-    typedef T ScalarType;
-    typedef typename itk::Image<ScalarType,DIM> ImageType;
+struct ImagePrivateType: public itkDataScalarImagePrivateType<DIM,T> { };
 
-    itkDataImagePrivate() { image = 0; }
+template <unsigned DIM,typename T,unsigned N>
+struct ImagePrivateType<DIM,itk::Vector<T,N> >: public itkDataVectorImagePrivateType<DIM,itk::Vector<T,N> > { };
 
-    void reset() const { }
+template <unsigned DIM,typename T>
+struct ImagePrivateType<DIM,itk::RGBPixel<T> >: public itkDataVectorImagePrivateType<DIM,itk::RGBPixel<T> > { };
 
-    int minRangeValue() const { return -1; }
-    int maxRangeValue() const { return -1; }
-
-    int scalarValueCount(int) const { return -1; }
-    int scalarValueMinCount() const { return -1; }
-    int scalarValueMaxCount() const { return -1; }
-
-    typename ImageType::Pointer image;
-    QList<QImage> thumbnails;
-};
+template <unsigned DIM,typename T>
+struct ImagePrivateType<DIM,itk::RGBAPixel<T> >: public itkDataVectorImagePrivateType<DIM,itk::RGBAPixel<T> > { };
 
 template <unsigned DIM,typename T,const char* ID>
 class ITKDATAIMAGEPLUGIN_EXPORT itkDataImage: public medAbstractTypedImageData<DIM,T> {
 
-    typedef itkDataImagePrivate<DIM,T,ImageTypeIndex<T>::Index> PrivateMember;
+    typedef ImagePrivateType<DIM,T> PrivateMember;
 
     // Special macro because this class is templated, so moc can't run on it
     // so we don;t have a staticMetaObject attribute, hence we need to define our
     // own staticIdentifier() method, as done below.
     MED_DATA_INTERFACE_NO_MOC("Itk Data Image", "Itk Data Image")
+
 public:
+
+    typedef T PixelType;
+    enum { Dimension=DIM };
 
     itkDataImage(): medAbstractTypedImageData<DIM,T>(),d(new PrivateMember) { }
 
-    ~itkDataImage()
-    {
+    ~itkDataImage() {
         delete d;
         d = 0;
     }
@@ -255,7 +92,6 @@ public:
 
     // derived from medAbstractImageData
 
-
     medAbstractImageData::MatrixType orientationMatrix()
     {
        medAbstractImageData::MatrixType orientationMatrix;
@@ -263,8 +99,7 @@ public:
        if (!d->image)
            return orientationMatrix;
 
-       for (unsigned int i = 0;i < DIM;++i)
-       {
+       for (unsigned int i = 0;i < DIM;++i) {
            std::vector <double> orientationVector(DIM,0);
            for(unsigned int j = 0;j < DIM;++j)
                orientationVector[j] = d->image->GetDirection()(i,j);
@@ -274,8 +109,6 @@ public:
 
        return orientationMatrix;
     }
-
-
 
     int xDimension() {
         if (d->image.IsNull())

--- a/src-plugins/itkDataImage/datas/itkDataPrivateTypes.h
+++ b/src-plugins/itkDataImage/datas/itkDataPrivateTypes.h
@@ -1,0 +1,167 @@
+//=========================================================================
+//
+// medInria
+//
+// Copyright (c) INRIA 2013 - 2014. All rights reserved.
+// See LICENSE.txt for details.
+// 
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.
+//
+//=========================================================================
+
+#pragma once
+
+#include <itkMinimumMaximumImageCalculator.h>
+#include <itkScalarImageToHistogramGenerator.h>
+
+template <unsigned DIM,typename T>
+struct itkDataImagePrivateTypeBase {
+    typedef typename itk::Image<T,DIM> ImageType;
+
+    itkDataImagePrivateTypeBase(): image(0) { }
+
+    typename ImageType::Pointer image;
+    QList<QImage>               thumbnails;
+};
+
+template <unsigned DIM,typename T>
+class itkDataVectorImagePrivateType: public itkDataImagePrivateTypeBase<DIM,T> {
+public:
+
+    itkDataVectorImagePrivateType() { }
+
+    void reset() const { }
+
+    int minRangeValue() const { return -1; }
+    int maxRangeValue() const { return -1; }
+
+    int scalarValueCount(int) const { return -1; }
+    int scalarValueMinCount() const { return -1; }
+    int scalarValueMaxCount() const { return -1; }
+};
+
+template <unsigned DIM,typename T>
+class itkDataScalarImagePrivateType: public itkDataImagePrivateTypeBase<DIM,T> {
+
+    typedef itkDataImagePrivateTypeBase<DIM,T> base;
+
+public:
+
+    typedef T                                                                    PixelType;
+    typedef typename base::ImageType                                             ImageType;
+    typedef typename itk::Statistics::ScalarImageToHistogramGenerator<ImageType> HistogramGeneratorType;
+    typedef typename HistogramGeneratorType::HistogramType                       HistogramType;
+
+    itkDataScalarImagePrivateType(): histogram(0),range_min(0),range_max(0),histogram_min(0),histogram_max(0) {
+        reset();
+    }
+
+    void reset() { range_computed = false; }
+
+    int minRangeValue() {
+        computeRange();
+        if (!range_computed)
+            qDebug() << "Cannot compute range";
+        return range_min;
+    }
+
+    int maxRangeValue() {
+        computeRange();
+        return range_max;
+    }
+
+    int scalarValueCount(int value) {
+        computeValueCounts();
+        if((PixelType)value>=range_min && (PixelType)value<=range_max)
+            return histogram->GetFrequency(value,0);
+        return -1;
+    }
+
+    int scalarValueMinCount() {
+        computeValueCounts();
+        return histogram_min;
+    }
+
+    int scalarValueMaxCount() {
+        computeValueCounts();
+        return histogram_max;
+    }
+
+private:
+
+    typename HistogramType::Pointer histogram;
+    bool                            range_computed;
+    PixelType                       range_min;
+    PixelType                       range_max;
+    int                             histogram_min;
+    int                             histogram_max;
+
+    void computeRange();
+    void computeValueCounts();
+};
+
+template <unsigned DIM,typename T>
+void itkDataScalarImagePrivateType<DIM,T>::computeRange() {
+    if (range_computed)
+        return;
+
+    if (base::image->GetLargestPossibleRegion().GetNumberOfPixels()==0)
+        return;
+
+    typedef itk::MinimumMaximumImageCalculator<ImageType> MinMaxCalculatorType;
+
+    typename MinMaxCalculatorType::Pointer calculator = MinMaxCalculatorType::New();
+    calculator->SetImage(base::image);
+    calculator->SetRegion(base::image->GetLargestPossibleRegion());
+    try {
+        calculator->Compute();
+    } catch (itk::ExceptionObject &e) {
+        std::cerr << e;
+        return;
+    }
+    range_min = calculator->GetMinimum();
+    range_max = calculator->GetMaximum();
+    range_computed = true;
+}
+
+template <unsigned DIM,typename T>
+void itkDataScalarImagePrivateType<DIM,T>::computeValueCounts() {
+    if (histogram.IsNull()) {
+        computeRange();
+
+        typename HistogramGeneratorType::Pointer histogramGenerator = HistogramGeneratorType::New();
+        histogramGenerator->SetInput(base::image);
+        histogramGenerator->SetNumberOfBins(range_max-range_min+1);
+        histogramGenerator->SetMarginalScale(1.0);
+        histogramGenerator->SetHistogramMin(range_min);
+        histogramGenerator->SetHistogramMax(range_max);
+
+        try {
+            std::cerr << "calculating histogram...";
+            histogramGenerator->Compute();
+            std::cerr << "done" << std::endl;
+        } catch (itk::ExceptionObject &e) {
+            std::cerr << e;
+            return;
+        }
+
+        typedef typename HistogramGeneratorType::HistogramType HistogramType;
+        typedef typename HistogramType::AbsoluteFrequencyType FrequencyType;
+
+        histogram = const_cast<HistogramType*>(histogramGenerator->GetOutput());
+
+        FrequencyType min = itk::NumericTraits< FrequencyType >::max();
+        FrequencyType max = itk::NumericTraits< FrequencyType >::min();
+
+        typedef typename HistogramType::Iterator Iterator;
+        for (Iterator it=histogram->Begin(),end=histogram->End();it!=end;++it) {
+            FrequencyType c = it.GetFrequency();
+            if (min>c) min = c;
+            if (max<c) max = c;
+        }
+        histogram_min = static_cast<int>(min);
+        histogram_max = static_cast<int>(max);
+    }
+}

--- a/src/medCore/data/medAbstractTypedImageData.h
+++ b/src/medCore/data/medAbstractTypedImageData.h
@@ -26,8 +26,7 @@ public:
     virtual int                                Dimension() const { return DIM;       }
     virtual const medAbstractImageData::PixId& PixelType() const { return typeid(T); }
 
-    virtual const QString PixelMeaning() const
-    {
+    virtual const QString PixelMeaning() const {
         if (hasMetaData(medAbstractImageData::PixelMeaningMetaData))
             return metadata(medAbstractImageData::PixelMeaningMetaData);
         return "";


### PR DESCRIPTION
This is a cleanup of itkDataImage. Several things where done:
- Put the private types in their own header file.
- Suppressed number of includes that were no longer used.
- Simplify the mecanism that uses two different private types for scalar and vectorial type. No longer use a ugly specialization. I believe the stuff is now simpler.

Future work: Split further itkDataPrivateTypes.h ???