### PR TITLE
Bringing back data converters

### DIFF
--- a/app/medPluginGenerator/medPluginGenerator.h
+++ b/app/medPluginGenerator/medPluginGenerator.h
@@ -35,7 +35,7 @@ enum pluginType
     IMAGE_NAVIGATOR,
     EXTRA_NAVIGATOR,
 
-    FILTERING = 17,
+    FILTERING = 18,
     REGISTRATION,
     DIFFUSION,
 

--- a/src/medCore/data/medAbstractData.h
+++ b/src/medCore/data/medAbstractData.h
@@ -38,6 +38,8 @@ public:
 
     QList< medAttachedData * > attachedData() const;
 
+    medAbstractData *convert(const QString &type);
+
     virtual QImage& thumbnail();
 
 public slots:


### PR DESCRIPTION
Converters were allowed by DTK abstract data to define conversions between data types. For some old data types that we still use for demos, I had to bring them back in medAbstractData. It can be something useful for future data types people will handle.

This also solves a bug on mac where the plugin generator was generating a registration plugin when we were asking for a filtering plugin