### PR TITLE
Change format of scalar bar text to scientific

### DIFF
--- a/src/medVtkInria/vtkImageView/vtkImageView.cxx
+++ b/src/medVtkInria/vtkImageView/vtkImageView.cxx
@@ -151,7 +151,7 @@ vtkImageView::vtkImageView()
   this->CornerAnnotation->PickableOff();
   this->CornerAnnotation->SetText (3, "<patient>\n<study>\n<series>");
 
-  this->ScalarBar->SetLabelFormat ("%.0f");
+  this->ScalarBar->SetLabelFormat ("%.3E");
   this->ScalarBar->SetNumberOfLabels (3);
   this->ScalarBar->GetPositionCoordinate()->SetCoordinateSystemToNormalizedViewport();
   this->ScalarBar->SetLabelTextProperty (this->TextProperty);
@@ -164,8 +164,6 @@ vtkImageView::vtkImageView()
   this->ScalarBar->SetPosition (0.9,0.3);
   this->ScalarBar->PickableOff();
   this->ScalarBar->VisibilityOn();
-
-
 
   for(int i=0; i<3; i++)
     this->CurrentPoint[i] = 0.0; //VTK_DOUBLE_MIN;
@@ -847,34 +845,6 @@ void vtkImageView::SetTransferFunctionRangeFromWindowSettings(int layer)
                   targetRange[1]);
       touched = true;
   }
-
-  if ( touched )
-  {
-    //todo: Call Modified on the right object
-//    this->GetWindowLevel(layer)->Modified();
-
-    //probably should change the lookuptable of this scalar bar?
-    //no, done in setLookupTable.
-
-    this->SetScalarBarLabelFormat(targetRange);
-    this->ScalarBar->Modified();
-  }
-}
-
-void vtkImageView::SetScalarBarLabelFormat(double* intensityRange)
-{
-    double diff = fabs(fabs(intensityRange[1])-fabs(intensityRange[0]));
-
-    if (diff>1 || diff == 0)
-    {
-        this->ScalarBar->SetLabelFormat ("%.f");
-        return;
-    }
-
-    int precision = -floor(log10(diff))+1; //+1 for the third value displayed (mean) not to be rounded
-    char format[10];
-    snprintf(format, 10, "%%.%df", precision);
-    this->ScalarBar->SetLabelFormat (format);
 }
 
 //----------------------------------------------------------------------------

--- a/src/medVtkInria/vtkImageView/vtkImageView.h
+++ b/src/medVtkInria/vtkImageView/vtkImageView.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -733,10 +733,6 @@ class MEDVTKINRIA_EXPORT vtkImageView : public vtkObject
      the closest position that lies within the image boundaries.
    */
   virtual void GetWithinBoundsPosition (double* pos1, double* dos2);
-  /**
-      Set the precision of the scalarBar values
-    */
-   void SetScalarBarLabelFormat(double* range);
 
   private:
     //! Template function which implements SetInput for all types.


### PR DESCRIPTION
This is the most elegant way IMO to always have a good display of any value (either very small or very big).
It also fix the Nan bug on windows (CRASH) (DrawNanValue is coming with Vtk 6 to correctly display Nan values on the scalar bar.