### PR TITLE
Fix for broken camera

### DIFF
--- a/src/medVtkInria/vtkWidgetsAddOn/vtkInteractorStyleTrackballCamera2.cxx
+++ b/src/medVtkInria/vtkWidgetsAddOn/vtkInteractorStyleTrackballCamera2.cxx
@@ -107,13 +107,16 @@ void vtkInteractorStyleTrackballCamera2::Azimuth(double angle)
 {
   vtkCamera *camera = this->CurrentRenderer->GetActiveCamera();
 
+  double axis[3];
   double newPosition[3];
   double fp[3]; camera->GetFocalPoint(fp);
   double position[3]; camera->GetPosition(position);
 
+  camera->GetViewUp(axis);
+
   this->Transform->Identity();
   this->Transform->Translate(+fp[0],+fp[1],+fp[2]);
-  this->Transform->RotateWXYZ(angle, UpAxis);
+  this->Transform->RotateWXYZ(angle, axis);
   this->Transform->Translate(-fp[0],-fp[1],-fp[2]);
   this->Transform->TransformPoint(position, newPosition);
 


### PR DESCRIPTION
Previous behaviour :

Open mesh in VR mode
Hold CTRL and leftmouse, and move mouse horizontally, to rotate camera around the Z-axis.
Hold leftmouse and move mouse horizontally - doesn't correctly rotate around the Y-axis anymore.

New behaviour:

As above, except rotation around the Y-axis is no longer broken by rotating around the Z-axis.

The problem came from the fact that z-rotation is handled by vtk directly, while x and y rotation is handeld by our own code, that relies upon certain variables being updated. vtk obviously doesn't update those variables, as it doesn't know about them, so we don't correctly handle the change in camera y-axis after a z-rotation.