### PR TITLE
Allows to change the db with an already existing db

### DIFF
--- a/src/medCore/database/medDatabaseController.cpp
+++ b/src/medCore/database/medDatabaseController.cpp
@@ -544,21 +544,26 @@ bool medDatabaseController::moveDatabase( QString newLocation)
 
     QString oldLocation = medStorage::dataLocation();
 
-    // now copy all the images and thumbnails
-    QStringList sourceList;
-    medStorage::recurseAddDir(QDir(oldLocation), sourceList);
+    // if there's no existing db in the new location
+    if(QDir(newLocation).entryInfoList(QStringList("db")).isEmpty()) 
+    {
+        // now copy all the images and thumbnails
+        QStringList sourceList;
+        medStorage::recurseAddDir(QDir(oldLocation), sourceList);
 
-    // create destination filelist
-    QStringList destList;
-    if (!medStorage::createDestination(sourceList,destList,oldLocation, newLocation))
-    {
-        res = false;
-    }
-    else
-    {
-        // now copy
-        if (!medStorage::copyFiles(sourceList, destList))
+        // create destination filelist
+        QStringList destList;
+
+        if (!medStorage::createDestination(sourceList,destList,oldLocation, newLocation))
+        {
             res = false;
+        }
+        else
+        {
+            // now copy
+            if (!medStorage::copyFiles(sourceList, destList))
+                res = false;
+        }
     }
 
     if (res)
@@ -587,13 +592,6 @@ bool medDatabaseController::moveDatabase( QString newLocation)
             qDebug() << "Restarting connection...";
             this->createConnection();
         }
-
-        // now delete the old archive
-        if(medStorage::removeDir(oldLocation))
-            qDebug() << "deleting old database: success";
-        else
-            qDebug() << "deleting old database: failure";
-
     }
 
     if (res)

--- a/src/medCore/gui/settingsWidgets/medDatabaseSettingsWidget.cpp
+++ b/src/medCore/gui/settingsWidgets/medDatabaseSettingsWidget.cpp
@@ -47,6 +47,7 @@ medDatabaseSettingsWidget::medDatabaseSettingsWidget(QWidget *parent) :
 
     QFormLayout* formLayout = new QFormLayout(this);
     formLayout->addRow(tr("Database location:"), databaseLocation);
+    formLayout->addRow(new QLabel("* The changes will only be effective after a restart of the software."));
 }
 
 void medDatabaseSettingsWidget::selectDbDirectory()
@@ -58,9 +59,10 @@ void medDatabaseSettingsWidget::selectDbDirectory()
      if (dialog.exec())
      {
          QString path = dialog.selectedFiles().first();
-         if (!QDir(path).entryInfoList(QDir::NoDotAndDotDot | QDir::Dirs | QDir::Files).isEmpty())
+         if (!QDir(path).entryInfoList(QDir::NoDotAndDotDot | QDir::Dirs | QDir::Files).isEmpty() && QDir(path).entryInfoList(QStringList("db")).isEmpty())
          {
-             QMessageBox::information( this, tr("Directory not empty"), tr("The archive directory needs to be empty! \nPlease choose another one."));
+             QMessageBox::information( this, tr("Database location not valid"), 
+                 tr("The directory selected is not valid:\nEither it doesn't point to an existing medInria database directory \nOR your new directory is not empty. \nPlease choose another one."));
          }
          else
          {


### PR DESCRIPTION
While switching between medInria, MUSIC and MUSIC Viewer on Windows (I don't think I had this behavior on Mac), I had my db location changed every time (db directory = ../organisationName/applicationName). Since my MUSIC Viewer db was new and empty, I wanted to select an already existing db (e.g medInria). But it is impossible because, from the source code, a valid db directory is an empty one. 
In this PR, I try to fix that by first checking whether the selected directory contains a db file.
I also removed the "previous db deletion" because you may want to switch between db without deleting it.
Finally, I added a label warning that the changes will be effective after restart of medInria.