### PR TITLE
Simplify symbol exports  for DLL

### DIFF
--- a/app/medInria/resources/CMakeLists.txt
+++ b/app/medInria/resources/CMakeLists.txt
@@ -4,26 +4,26 @@
 #
 # Copyright (c) INRIA 2013 - 2014. All rights reserved.
 # See LICENSE.txt for details.
-# 
+#
 #  This software is distributed WITHOUT ANY WARRANTY; without even
 #  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 #  PURPOSE.
 #
 ################################################################################
 
-file(GLOB ${PROJECT_NAME}_QRC
+file(GLOB ${TARGET_NAME}_QRC
   *.qrc
   )
-set(${PROJECT_NAME}_QRC 
-  ${${PROJECT_NAME}_QRC} 
+set(${TARGET_NAME}_QRC
+  ${${TARGET_NAME}_QRC}
   PARENT_SCOPE
   )
 
 
-file(GLOB ${PROJECT_NAME}_QSS
+file(GLOB ${TARGET_NAME}_QSS
   *.qss
   )
-set(${PROJECT_NAME}_QSS 
-  ${${PROJECT_NAME}_QSS} 
+set(${TARGET_NAME}_QSS
+  ${${TARGET_NAME}_QSS}
   PARENT_SCOPE
   )

--- a/cmake/module/set_lib_install_rules.cmake
+++ b/cmake/module/set_lib_install_rules.cmake
@@ -29,6 +29,7 @@ macro(set_lib_install_rules
 set_target_properties(${target} PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/
   ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/
+  DEFINE_SYMBOL MEDINRIA_EXPORTS
   )
 
 install(TARGETS ${target}

--- a/cmake/module/set_plugin_install_rules.cmake
+++ b/cmake/module/set_plugin_install_rules.cmake
@@ -25,6 +25,7 @@ macro(set_plugin_install_rules
 set_target_properties(${target} PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins/
   ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins/
+  DEFINE_SYMBOL MEDINRIA_EXPORTS
   )
 
 install(TARGETS ${target}

--- a/src-plugins/medItkAddImageProcess/medItkAddImageProcess.h
+++ b/src-plugins/medItkAddImageProcess/medItkAddImageProcess.h
@@ -17,7 +17,7 @@
 
 class medItkAddImageProcessPrivate;
 
-class medItkAddImageProcess: public medAbstractAddImageProcess
+class MEDINRIA_EXPORT medItkAddImageProcess: public medAbstractAddImageProcess
 {
 public:
     medItkAddImageProcess(QObject* parent = NULL);

--- a/src-plugins/medItkAddImageProcess/medItkAddImageProcessPlugin.h
+++ b/src-plugins/medItkAddImageProcess/medItkAddImageProcessPlugin.h
@@ -15,7 +15,7 @@
 
 #include <medAbstractAddImageProcess.h>
 
-class medItkAddImageProcessPlugin : public medAbstractAddImageProcessPlugin
+class MEDINRIA_EXPORT medItkAddImageProcessPlugin : public medAbstractAddImageProcessPlugin
 {
     Q_OBJECT
     Q_INTERFACES(medAbstractAddImageProcessPlugin)

--- a/src-plugins/medItkDivideImageProcess/medItkDivideImageProcess.h
+++ b/src-plugins/medItkDivideImageProcess/medItkDivideImageProcess.h
@@ -17,7 +17,7 @@
 
 class medItkDivideImageProcessPrivate;
 
-class medItkDivideImageProcess: public medAbstractDivideImageProcess
+class MEDINRIA_EXPORT medItkDivideImageProcess: public medAbstractDivideImageProcess
 {
 public:
     medItkDivideImageProcess(QObject* parent = NULL);

--- a/src-plugins/medItkDivideImageProcess/medItkDivideImageProcessPlugin.h
+++ b/src-plugins/medItkDivideImageProcess/medItkDivideImageProcessPlugin.h
@@ -15,7 +15,7 @@
 
 #include <medAbstractDivideImageProcess.h>
 
-class medItkDivideImageProcessPlugin : public medAbstractDivideImageProcessPlugin
+class MEDINRIA_EXPORT medItkDivideImageProcessPlugin : public medAbstractDivideImageProcessPlugin
 {
     Q_OBJECT
     Q_INTERFACES(medAbstractDivideImageProcessPlugin)

--- a/src-plugins/medItkMultiplyImageProcess/medItkMultiplyImageProcess.h
+++ b/src-plugins/medItkMultiplyImageProcess/medItkMultiplyImageProcess.h
@@ -17,7 +17,7 @@
 
 class medItkMultiplyImageProcessPrivate;
 
-class medItkMultiplyImageProcess: public medAbstractMultiplyImageProcess
+class MEDINRIA_EXPORT medItkMultiplyImageProcess: public medAbstractMultiplyImageProcess
 {
 public:
     medItkMultiplyImageProcess(QObject* parent = NULL);

--- a/src-plugins/medItkMultiplyImageProcess/medItkMultiplyImageProcessPlugin.h
+++ b/src-plugins/medItkMultiplyImageProcess/medItkMultiplyImageProcessPlugin.h
@@ -15,7 +15,7 @@
 
 #include <medAbstractMultiplyImageProcess.h>
 
-class medItkMultiplyImageProcessPlugin : public medAbstractMultiplyImageProcessPlugin
+class MEDINRIA_EXPORT medItkMultiplyImageProcessPlugin : public medAbstractMultiplyImageProcessPlugin
 {
     Q_OBJECT
     Q_INTERFACES(medAbstractMultiplyImageProcessPlugin)

--- a/src/medCore/gui/area/medAbstractArea.h
+++ b/src/medCore/gui/area/medAbstractArea.h
@@ -16,7 +16,9 @@
 #include <QWidget>
 #include <QString>
 
-class medAbstractArea : public QWidget
+#include <medInriaExport.h>
+
+class MEDINRIA_EXPORT medAbstractArea : public QWidget
 {
     Q_OBJECT
 

--- a/src/medCore/gui/area/medAbstractAreaPlugin.h
+++ b/src/medCore/gui/area/medAbstractAreaPlugin.h
@@ -18,7 +18,9 @@
 
 #include <medAbstractArea.h>
 
-class medAbstractAreaPlugin : public QObject
+#include <medInriaExport.h>
+
+class MEDINRIA_EXPORT medAbstractAreaPlugin : public QObject
 {
     Q_OBJECT
 
@@ -40,10 +42,10 @@ public:
 
 Q_DECLARE_INTERFACE(medAbstractAreaPlugin, DTK_DECLARE_PLUGIN_INTERFACE(medAbstractArea))
 
-class medAbstractAreaPluginFactory : public dtkCorePluginFactory<medAbstractArea>
+class MEDINRIA_EXPORT medAbstractAreaPluginFactory : public dtkCorePluginFactory<medAbstractArea>
 {
 };
 
-class medAbstractAreaPluginManager : public dtkCorePluginManager<medAbstractAreaPlugin>
+class MEDINRIA_EXPORT medAbstractAreaPluginManager : public dtkCorePluginManager<medAbstractAreaPlugin>
 {
 };

--- a/src/medCore/gui/medGuiLayer.h
+++ b/src/medCore/gui/medGuiLayer.h
@@ -15,18 +15,19 @@
 
 #include <medAbstractAreaPlugin.h>
 
+#include <medInriaExport.h>
+
 namespace medGuiLayer
 {
     namespace pluginManager
     {
-        void initialize(const QString& path = QString());
+        MEDINRIA_EXPORT void initialize(const QString& path = QString());
     }
 
     namespace area
     {
-        medAbstractAreaPluginManager& pluginManager(void);
-        medAbstractAreaPluginFactory& pluginFactory(void);
-        void initialize(const QString& path);
-
+        MEDINRIA_EXPORT medAbstractAreaPluginManager& pluginManager(void);
+        MEDINRIA_EXPORT medAbstractAreaPluginFactory& pluginFactory(void);
+        MEDINRIA_EXPORT void initialize(const QString& path);
     }
 }

--- a/src/medCore/process/arithmetic_operation/medAbstractAddImageProcess.h
+++ b/src/medCore/process/arithmetic_operation/medAbstractAddImageProcess.h
@@ -17,9 +17,9 @@
 
 #include <dtkCore>
 
-#include <medCoreExport.h>
+#include <medInriaExport.h>
 
-class medAbstractAddImageProcess: public medAbstractArithmeticOperationProcess
+class MEDINRIA_EXPORT  medAbstractAddImageProcess: public medAbstractArithmeticOperationProcess
 {
     Q_OBJECT
 public:
@@ -27,6 +27,6 @@ public:
 };
 
 DTK_DECLARE_OBJECT        (medAbstractAddImageProcess*)
-DTK_DECLARE_PLUGIN        (medAbstractAddImageProcess, MEDCORE_EXPORT)
-DTK_DECLARE_PLUGIN_FACTORY(medAbstractAddImageProcess, MEDCORE_EXPORT)
-DTK_DECLARE_PLUGIN_MANAGER(medAbstractAddImageProcess, MEDCORE_EXPORT)
+DTK_DECLARE_PLUGIN        (medAbstractAddImageProcess, MEDINRIA_EXPORT)
+DTK_DECLARE_PLUGIN_FACTORY(medAbstractAddImageProcess, MEDINRIA_EXPORT)
+DTK_DECLARE_PLUGIN_MANAGER(medAbstractAddImageProcess, MEDINRIA_EXPORT)

--- a/src/medCore/process/arithmetic_operation/medAbstractArithmeticOperationProcess.h
+++ b/src/medCore/process/arithmetic_operation/medAbstractArithmeticOperationProcess.h
@@ -15,11 +15,13 @@
 
 #include <medAbstractProcess.h>
 
+#include <medInriaExport.h>
+
 class medAbstractImageData;
 class medViewContainerSplitter;
 
 class medAbstractArithmeticOperationProcessPrivate;
-class medAbstractArithmeticOperationProcess : public medAbstractProcess
+class MEDINRIA_EXPORT  medAbstractArithmeticOperationProcess : public medAbstractProcess
 {
     Q_OBJECT
 

--- a/src/medCore/process/arithmetic_operation/medAbstractDivideImageProcess.h
+++ b/src/medCore/process/arithmetic_operation/medAbstractDivideImageProcess.h
@@ -17,9 +17,9 @@
 
 #include <dtkCore>
 
-#include <medCoreExport.h>
+#include <medInriaExport.h>
 
-class medAbstractDivideImageProcess: public medAbstractArithmeticOperationProcess
+class MEDINRIA_EXPORT medAbstractDivideImageProcess: public medAbstractArithmeticOperationProcess
 {
     Q_OBJECT
 public:
@@ -27,6 +27,6 @@ public:
 };
 
 DTK_DECLARE_OBJECT        (medAbstractDivideImageProcess*)
-DTK_DECLARE_PLUGIN        (medAbstractDivideImageProcess, MEDCORE_EXPORT)
-DTK_DECLARE_PLUGIN_FACTORY(medAbstractDivideImageProcess, MEDCORE_EXPORT)
-DTK_DECLARE_PLUGIN_MANAGER(medAbstractDivideImageProcess, MEDCORE_EXPORT)
+DTK_DECLARE_PLUGIN        (medAbstractDivideImageProcess, MEDINRIA_EXPORT)
+DTK_DECLARE_PLUGIN_FACTORY(medAbstractDivideImageProcess, MEDINRIA_EXPORT)
+DTK_DECLARE_PLUGIN_MANAGER(medAbstractDivideImageProcess, MEDINRIA_EXPORT)

--- a/src/medCore/process/arithmetic_operation/medAbstractMultiplyImageProcess.h
+++ b/src/medCore/process/arithmetic_operation/medAbstractMultiplyImageProcess.h
@@ -17,9 +17,9 @@
 
 #include <dtkCore>
 
-#include <medCoreExport.h>
+#include <medInriaExport.h>
 
-class medAbstractMultiplyImageProcess: public medAbstractArithmeticOperationProcess
+class MEDINRIA_EXPORT medAbstractMultiplyImageProcess: public medAbstractArithmeticOperationProcess
 {
     Q_OBJECT
 public:
@@ -27,6 +27,6 @@ public:
 };
 
 DTK_DECLARE_OBJECT        (medAbstractMultiplyImageProcess*)
-DTK_DECLARE_PLUGIN        (medAbstractMultiplyImageProcess, MEDCORE_EXPORT)
-DTK_DECLARE_PLUGIN_FACTORY(medAbstractMultiplyImageProcess, MEDCORE_EXPORT)
-DTK_DECLARE_PLUGIN_MANAGER(medAbstractMultiplyImageProcess, MEDCORE_EXPORT)
+DTK_DECLARE_PLUGIN        (medAbstractMultiplyImageProcess, MEDINRIA_EXPORT)
+DTK_DECLARE_PLUGIN_FACTORY(medAbstractMultiplyImageProcess, MEDINRIA_EXPORT)
+DTK_DECLARE_PLUGIN_MANAGER(medAbstractMultiplyImageProcess, MEDINRIA_EXPORT)

--- a/src/medCore/process/arithmetic_operation/medAbstractSubtractImageProcess.h
+++ b/src/medCore/process/arithmetic_operation/medAbstractSubtractImageProcess.h
@@ -17,7 +17,7 @@
 
 #include <dtkCore>
 
-#include <medCoreExport.h>
+#include <medInriaExport.h>
 
 class medAbstractSubtractImageProcess: public medAbstractArithmeticOperationProcess
 {
@@ -27,6 +27,6 @@ public:
 };
 
 DTK_DECLARE_OBJECT        (medAbstractSubtractImageProcess*)
-DTK_DECLARE_PLUGIN        (medAbstractSubtractImageProcess, MEDCORE_EXPORT)
-DTK_DECLARE_PLUGIN_FACTORY(medAbstractSubtractImageProcess, MEDCORE_EXPORT)
-DTK_DECLARE_PLUGIN_MANAGER(medAbstractSubtractImageProcess, MEDCORE_EXPORT)
+DTK_DECLARE_PLUGIN        (medAbstractSubtractImageProcess, MEDINRIA_EXPORT)
+DTK_DECLARE_PLUGIN_FACTORY(medAbstractSubtractImageProcess, MEDINRIA_EXPORT)
+DTK_DECLARE_PLUGIN_MANAGER(medAbstractSubtractImageProcess, MEDINRIA_EXPORT)

--- a/src/medCore/process/medAbstractProcess.h
+++ b/src/medCore/process/medAbstractProcess.h
@@ -17,10 +17,12 @@
 #include <QRunnable>
 #include <QPushButton>
 
+#include <medInriaExport.h>
+
 class medAbstractParameter;
 class medViewContainerSplitter;
 
-struct medProcessDetails
+struct MEDINRIA_EXPORT medProcessDetails
 {
     QString name;
     QString version;
@@ -28,7 +30,7 @@ struct medProcessDetails
 };
 
 class medAbstractProcessPrivate;
-class medAbstractProcess: public QObject, public QRunnable
+class MEDINRIA_EXPORT medAbstractProcess: public QObject, public QRunnable
 {
     Q_OBJECT
 public:

--- a/src/medCore/process/medProcessLayer.h
+++ b/src/medCore/process/medProcessLayer.h
@@ -19,44 +19,45 @@
 #include <medAbstractMultiplyImageProcess.h>
 #include <medAbstractDivideImageProcess.h>
 
+#include <medInriaExport.h>
+
 namespace medProcessLayer
 {
-    medProcessDetails readDetailsFromJson(QString const& filePath);
+    MEDINRIA_EXPORT medProcessDetails readDetailsFromJson(QString const& filePath);
 
     namespace pluginManager
     {
-        void initialize(const QString& path = QString(), bool verbose = true);
+        MEDINRIA_EXPORT void initialize(const QString& path = QString(), bool verbose = true);
     }
 
     namespace arithmeticalOperation
     {
         namespace addImage
         {
-            medAbstractAddImageProcessPluginManager& pluginManager(void);
-            medAbstractAddImageProcessPluginFactory& pluginFactory(void);
-            void initialize(const QString& path, bool verbose = true);
+            MEDINRIA_EXPORT medAbstractAddImageProcessPluginManager& pluginManager(void);
+            MEDINRIA_EXPORT medAbstractAddImageProcessPluginFactory& pluginFactory(void);
+            MEDINRIA_EXPORT void initialize(const QString& path, bool verbose = true);
 
         }
         namespace subtractImage
         {
-            medAbstractSubtractImageProcessPluginManager& pluginManager(void);
-            medAbstractSubtractImageProcessPluginFactory& pluginFactory(void);
-            void initialize(const QString& path, bool verbose = true);
+            MEDINRIA_EXPORT medAbstractSubtractImageProcessPluginManager& pluginManager(void);
+            MEDINRIA_EXPORT medAbstractSubtractImageProcessPluginFactory& pluginFactory(void);
+            MEDINRIA_EXPORT void initialize(const QString& path, bool verbose = true);
 
         }
         namespace multiplyImage
         {
-            medAbstractMultiplyImageProcessPluginManager& pluginManager(void);
-            medAbstractMultiplyImageProcessPluginFactory& pluginFactory(void);
-            void initialize(const QString& path, bool verbose = true);
+            MEDINRIA_EXPORT medAbstractMultiplyImageProcessPluginManager& pluginManager(void);
+            MEDINRIA_EXPORT medAbstractMultiplyImageProcessPluginFactory& pluginFactory(void);
+            MEDINRIA_EXPORT void initialize(const QString& path, bool verbose = true);
 
         }
         namespace divideImage
         {
-            medAbstractDivideImageProcessPluginManager& pluginManager(void);
-            medAbstractDivideImageProcessPluginFactory& pluginFactory(void);
-            void initialize(const QString& path, bool verbose = true);
-
+            MEDINRIA_EXPORT medAbstractDivideImageProcessPluginManager& pluginManager(void);
+            MEDINRIA_EXPORT medAbstractDivideImageProcessPluginFactory& pluginFactory(void);
+            MEDINRIA_EXPORT void initialize(const QString& path, bool verbose = true);
         }
     }
 }


### PR DESCRIPTION
 Use the DEFINE_SYMBOL target property to simplify exports MACROS

This allow to have the same MACRO indicating if the header is being include from inside the lib or from a client application, thus we can have only one ###Export.h file to defined the EXPORTS macro for all the target in medInria instead of having one for each lib / plugin.