### PR TITLE
Fix case where one lib is using another one.

### DIFF
--- a/cmake/module/set_lib_install_rules.cmake
+++ b/cmake/module/set_lib_install_rules.cmake
@@ -29,7 +29,6 @@ macro(set_lib_install_rules
 set_target_properties(${target} PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/
   ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/
-  DEFINE_SYMBOL MEDINRIA_EXPORTS
   )
 
 install(TARGETS ${target}

--- a/cmake/module/set_plugin_install_rules.cmake
+++ b/cmake/module/set_plugin_install_rules.cmake
@@ -25,7 +25,7 @@ macro(set_plugin_install_rules
 set_target_properties(${target} PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins/
   ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins/
-  DEFINE_SYMBOL MEDINRIA_EXPORTS
+  DEFINE_SYMBOL MEDPLUGIN_EXPORTS
   )
 
 install(TARGETS ${target}

--- a/src-plugins/process/arithmetic_operation/medItkAddImageProcess/medItkAddImageProcess.h
+++ b/src-plugins/process/arithmetic_operation/medItkAddImageProcess/medItkAddImageProcess.h
@@ -15,9 +15,11 @@
 
 #include <medAbstractAddImageProcess.h>
 
+#include <medPluginExport.h>
+
 class medItkAddImageProcessPrivate;
 
-class MEDINRIA_EXPORT medItkAddImageProcess: public medAbstractAddImageProcess
+class MEDPLUGIN_EXPORT medItkAddImageProcess: public medAbstractAddImageProcess
 {
 public:
     medItkAddImageProcess(QObject* parent = NULL);

--- a/src-plugins/process/arithmetic_operation/medItkAddImageProcess/medItkAddImageProcessPlugin.h
+++ b/src-plugins/process/arithmetic_operation/medItkAddImageProcess/medItkAddImageProcessPlugin.h
@@ -15,7 +15,9 @@
 
 #include <medAbstractAddImageProcess.h>
 
-class MEDINRIA_EXPORT medItkAddImageProcessPlugin : public medAbstractAddImageProcessPlugin
+#include <medPluginExport.h>
+
+class MEDPLUGIN_EXPORT medItkAddImageProcessPlugin : public medAbstractAddImageProcessPlugin
 {
     Q_OBJECT
     Q_INTERFACES(medAbstractAddImageProcessPlugin)

--- a/src-plugins/process/arithmetic_operation/medItkDivideImageProcess/medItkDivideImageProcess.h
+++ b/src-plugins/process/arithmetic_operation/medItkDivideImageProcess/medItkDivideImageProcess.h
@@ -15,9 +15,11 @@
 
 #include <medAbstractDivideImageProcess.h>
 
+#include <medPluginExport.h>
+
 class medItkDivideImageProcessPrivate;
 
-class MEDINRIA_EXPORT medItkDivideImageProcess: public medAbstractDivideImageProcess
+class MEDPLUGIN_EXPORT medItkDivideImageProcess: public medAbstractDivideImageProcess
 {
 public:
     medItkDivideImageProcess(QObject* parent = NULL);

--- a/src-plugins/process/arithmetic_operation/medItkDivideImageProcess/medItkDivideImageProcessPlugin.h
+++ b/src-plugins/process/arithmetic_operation/medItkDivideImageProcess/medItkDivideImageProcessPlugin.h
@@ -15,7 +15,9 @@
 
 #include <medAbstractDivideImageProcess.h>
 
-class MEDINRIA_EXPORT medItkDivideImageProcessPlugin : public medAbstractDivideImageProcessPlugin
+#include <medPluginExport.h>
+
+class MEDPLUGIN_EXPORT medItkDivideImageProcessPlugin : public medAbstractDivideImageProcessPlugin
 {
     Q_OBJECT
     Q_INTERFACES(medAbstractDivideImageProcessPlugin)

--- a/src-plugins/process/arithmetic_operation/medItkMultiplyImageProcess/medItkMultiplyImageProcess.h
+++ b/src-plugins/process/arithmetic_operation/medItkMultiplyImageProcess/medItkMultiplyImageProcess.h
@@ -15,9 +15,11 @@
 
 #include <medAbstractMultiplyImageProcess.h>
 
+#include <medPluginExport.h>
+
 class medItkMultiplyImageProcessPrivate;
 
-class MEDINRIA_EXPORT medItkMultiplyImageProcess: public medAbstractMultiplyImageProcess
+class MEDPLUGIN_EXPORT medItkMultiplyImageProcess: public medAbstractMultiplyImageProcess
 {
 public:
     medItkMultiplyImageProcess(QObject* parent = NULL);

--- a/src-plugins/process/arithmetic_operation/medItkMultiplyImageProcess/medItkMultiplyImageProcessPlugin.h
+++ b/src-plugins/process/arithmetic_operation/medItkMultiplyImageProcess/medItkMultiplyImageProcessPlugin.h
@@ -15,7 +15,9 @@
 
 #include <medAbstractMultiplyImageProcess.h>
 
-class MEDINRIA_EXPORT medItkMultiplyImageProcessPlugin : public medAbstractMultiplyImageProcessPlugin
+#include <medPluginExport.h>
+
+class MEDPLUGIN_EXPORT medItkMultiplyImageProcessPlugin : public medAbstractMultiplyImageProcessPlugin
 {
     Q_OBJECT
     Q_INTERFACES(medAbstractMultiplyImageProcessPlugin)

--- a/src-plugins/process/arithmetic_operation/medItkSubtractImageProcess/medItkSubtractImageProcess.h
+++ b/src-plugins/process/arithmetic_operation/medItkSubtractImageProcess/medItkSubtractImageProcess.h
@@ -15,9 +15,11 @@
 
 #include <medAbstractSubtractImageProcess.h>
 
+#include <medPluginExport.h>
+
 class medItkSubtractImageProcessPrivate;
 
-class medItkSubtractImageProcess: public medAbstractSubtractImageProcess
+class MEDPLUGIN_EXPORT medItkSubtractImageProcess: public medAbstractSubtractImageProcess
 {
 public:
     medItkSubtractImageProcess(QObject* parent = NULL);

--- a/src-plugins/process/arithmetic_operation/medItkSubtractImageProcess/medItkSubtractImageProcessPlugin.h
+++ b/src-plugins/process/arithmetic_operation/medItkSubtractImageProcess/medItkSubtractImageProcessPlugin.h
@@ -15,7 +15,9 @@
 
 #include <medAbstractSubtractImageProcess.h>
 
-class medItkSubtractImageProcessPlugin : public medAbstractSubtractImageProcessPlugin
+#include <medPluginExport.h>
+
+class MEDPLUGIN_EXPORT medItkSubtractImageProcessPlugin : public medAbstractSubtractImageProcessPlugin
 {
     Q_OBJECT
     Q_INTERFACES(medAbstractSubtractImageProcessPlugin)

--- a/src-plugins/process/morphomath_operation/medItkClosingImageProcess/medItkClosingImageProcess.h
+++ b/src-plugins/process/morphomath_operation/medItkClosingImageProcess/medItkClosingImageProcess.h
@@ -15,9 +15,11 @@
 
 #include <medAbstractClosingImageProcess.h>
 
+#include <medPluginExport.h>
+
 class medItkClosingImageProcessPrivate;
 
-class MEDINRIA_EXPORT medItkClosingImageProcess: public medAbstractClosingImageProcess
+class MEDPLUGIN_EXPORT medItkClosingImageProcess: public medAbstractClosingImageProcess
 {
 public:
     medItkClosingImageProcess(QObject* parent = NULL);

--- a/src-plugins/process/morphomath_operation/medItkClosingImageProcess/medItkClosingImageProcessPlugin.h
+++ b/src-plugins/process/morphomath_operation/medItkClosingImageProcess/medItkClosingImageProcessPlugin.h
@@ -15,7 +15,9 @@
 
 #include <medAbstractClosingImageProcess.h>
 
-class MEDINRIA_EXPORT medItkClosingImageProcessPlugin : public medAbstractClosingImageProcessPlugin
+#include <medPluginExport.h>
+
+class MEDPLUGIN_EXPORT medItkClosingImageProcessPlugin : public medAbstractClosingImageProcessPlugin
 {
     Q_OBJECT
     Q_INTERFACES(medAbstractClosingImageProcessPlugin)

--- a/src-plugins/process/morphomath_operation/medItkDilateImageProcess/medItkDilateImageProcess.h
+++ b/src-plugins/process/morphomath_operation/medItkDilateImageProcess/medItkDilateImageProcess.h
@@ -15,9 +15,11 @@
 
 #include <medAbstractDilateImageProcess.h>
 
+#include <medPluginExport.h>
+
 class medItkDilateImageProcessPrivate;
 
-class MEDINRIA_EXPORT medItkDilateImageProcess: public medAbstractDilateImageProcess
+class MEDPLUGIN_EXPORT medItkDilateImageProcess: public medAbstractDilateImageProcess
 {
 public:
     medItkDilateImageProcess(QObject* parent = NULL);

--- a/src-plugins/process/morphomath_operation/medItkDilateImageProcess/medItkDilateImageProcessPlugin.h
+++ b/src-plugins/process/morphomath_operation/medItkDilateImageProcess/medItkDilateImageProcessPlugin.h
@@ -15,7 +15,9 @@
 
 #include <medAbstractDilateImageProcess.h>
 
-class MEDINRIA_EXPORT medItkDilateImageProcessPlugin : public medAbstractDilateImageProcessPlugin
+#include <medPluginExport.h>
+
+class MEDPLUGIN_EXPORT medItkDilateImageProcessPlugin : public medAbstractDilateImageProcessPlugin
 {
     Q_OBJECT
     Q_INTERFACES(medAbstractDilateImageProcessPlugin)

--- a/src-plugins/process/morphomath_operation/medItkErodeImageProcess/medItkErodeImageProcess.h
+++ b/src-plugins/process/morphomath_operation/medItkErodeImageProcess/medItkErodeImageProcess.h
@@ -15,9 +15,11 @@
 
 #include <medAbstractErodeImageProcess.h>
 
+#include <medPluginExport.h>
+
 class medItkErodeImageProcessPrivate;
 
-class MEDINRIA_EXPORT medItkErodeImageProcess: public medAbstractErodeImageProcess
+class MEDPLUGIN_EXPORT medItkErodeImageProcess: public medAbstractErodeImageProcess
 {
 public:
     medItkErodeImageProcess(QObject* parent = NULL);

--- a/src-plugins/process/morphomath_operation/medItkErodeImageProcess/medItkErodeImageProcessPlugin.h
+++ b/src-plugins/process/morphomath_operation/medItkErodeImageProcess/medItkErodeImageProcessPlugin.h
@@ -15,7 +15,9 @@
 
 #include <medAbstractErodeImageProcess.h>
 
-class MEDINRIA_EXPORT medItkErodeImageProcessPlugin : public medAbstractErodeImageProcessPlugin
+#include <medPluginExport.h>
+
+class MEDPLUGIN_EXPORT medItkErodeImageProcessPlugin : public medAbstractErodeImageProcessPlugin
 {
     Q_OBJECT
     Q_INTERFACES(medAbstractErodeImageProcessPlugin)

--- a/src-plugins/process/morphomath_operation/medItkOpeningImageProcess/medItkOpeningImageProcess.h
+++ b/src-plugins/process/morphomath_operation/medItkOpeningImageProcess/medItkOpeningImageProcess.h
@@ -15,9 +15,11 @@
 
 #include <medAbstractOpeningImageProcess.h>
 
+#include <medPluginExport.h>
+
 class medItkOpeningImageProcessPrivate;
 
-class MEDINRIA_EXPORT medItkOpeningImageProcess: public medAbstractOpeningImageProcess
+class MEDPLUGIN_EXPORT medItkOpeningImageProcess: public medAbstractOpeningImageProcess
 {
 public:
     medItkOpeningImageProcess(QObject* parent = NULL);

--- a/src-plugins/process/morphomath_operation/medItkOpeningImageProcess/medItkOpeningImageProcessPlugin.h
+++ b/src-plugins/process/morphomath_operation/medItkOpeningImageProcess/medItkOpeningImageProcessPlugin.h
@@ -15,7 +15,9 @@
 
 #include <medAbstractOpeningImageProcess.h>
 
-class MEDINRIA_EXPORT medItkOpeningImageProcessPlugin : public medAbstractOpeningImageProcessPlugin
+#include <medPluginExport.h>
+
+class MEDPLUGIN_EXPORT medItkOpeningImageProcessPlugin : public medAbstractOpeningImageProcessPlugin
 {
     Q_OBJECT
     Q_INTERFACES(medAbstractOpeningImageProcessPlugin)

--- a/src/medCore/gui/area/medAbstractArea.h
+++ b/src/medCore/gui/area/medAbstractArea.h
@@ -16,9 +16,9 @@
 #include <QWidget>
 #include <QString>
 
-#include <medInriaExport.h>
+#include <medCoreExport.h>
 
-class MEDINRIA_EXPORT medAbstractArea : public QWidget
+class MEDCORE_EXPORT medAbstractArea : public QWidget
 {
     Q_OBJECT
 

--- a/src/medCore/gui/area/medAbstractAreaPlugin.h
+++ b/src/medCore/gui/area/medAbstractAreaPlugin.h
@@ -18,9 +18,9 @@
 
 #include <medAbstractArea.h>
 
-#include <medInriaExport.h>
+#include <medCoreExport.h>
 
-class MEDINRIA_EXPORT medAbstractAreaPlugin : public QObject
+class MEDCORE_EXPORT medAbstractAreaPlugin : public QObject
 {
     Q_OBJECT
 
@@ -42,10 +42,10 @@ public:
 
 Q_DECLARE_INTERFACE(medAbstractAreaPlugin, DTK_DECLARE_PLUGIN_INTERFACE(medAbstractArea))
 
-class MEDINRIA_EXPORT medAbstractAreaPluginFactory : public dtkCorePluginFactory<medAbstractArea>
+class MEDCORE_EXPORT medAbstractAreaPluginFactory : public dtkCorePluginFactory<medAbstractArea>
 {
 };
 
-class MEDINRIA_EXPORT medAbstractAreaPluginManager : public dtkCorePluginManager<medAbstractAreaPlugin>
+class MEDCORE_EXPORT medAbstractAreaPluginManager : public dtkCorePluginManager<medAbstractAreaPlugin>
 {
 };

--- a/src/medCore/gui/medGuiLayer.h
+++ b/src/medCore/gui/medGuiLayer.h
@@ -15,19 +15,19 @@
 
 #include <medAbstractAreaPlugin.h>
 
-#include <medInriaExport.h>
+#include <medCoreExport.h>
 
 namespace medGuiLayer
 {
     namespace pluginManager
     {
-        MEDINRIA_EXPORT void initialize(const QString& path = QString());
+        MEDCORE_EXPORT void initialize(const QString& path = QString());
     }
 
     namespace area
     {
-        MEDINRIA_EXPORT medAbstractAreaPluginManager& pluginManager(void);
-        MEDINRIA_EXPORT medAbstractAreaPluginFactory& pluginFactory(void);
-        MEDINRIA_EXPORT void initialize(const QString& path);
+        MEDCORE_EXPORT medAbstractAreaPluginManager& pluginManager(void);
+        MEDCORE_EXPORT medAbstractAreaPluginFactory& pluginFactory(void);
+        MEDCORE_EXPORT void initialize(const QString& path);
     }
 }

--- a/src/medCore/medCoreExport.h
+++ b/src/medCore/medCoreExport.h
@@ -12,11 +12,11 @@
 =========================================================================*/
 
 #ifdef WIN32
-    #ifdef MEDINRIA_EXPORTS
-        #define MEDINRIA_EXPORT __declspec(dllexport)
+    #ifdef medCore_EXPORTS
+        #define MEDCORE_EXPORT __declspec(dllexport)
     #else
-        #define MEDINRIA_EXPORT __declspec(dllimport)
+        #define MEDCORE_EXPORT __declspec(dllimport)
     #endif
 #else
-    #define MEDINRIA_EXPORT
+    #define MEDCORE_EXPORT
 #endif

--- a/src/medCore/medPluginExport.h
+++ b/src/medCore/medPluginExport.h
@@ -2,7 +2,7 @@
 
  medInria
 
- Copyright (c) INRIA 2013 - 2014. All rights reserved.
+ Copyright (c) PLUGIN 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
 
   This software is distributed WITHOUT ANY WARRANTY; without even
@@ -11,20 +11,12 @@
 
 =========================================================================*/
 
-#pragma once
-
-#include <QRegExp>
-#include <QVariant>
-
-#include <medCoreLegacyExport.h>
-
-class MEDCORELEGACY_EXPORT medStyleSheetParser
-{
-public:
-    medStyleSheetParser(QString qss);
-
-    QString result() const;
-
-private:
-    QString output;
-};
+#ifdef WIN32
+    #ifdef MEDPLUGIN_EXPORTS
+        #define MEDPLUGIN_EXPORT __declspec(dllexport)
+    #else
+        #define MEDPLUGIN_EXPORT __declspec(dllimport)
+    #endif
+#else
+    #define MEDPLUGIN_EXPORT
+#endif

--- a/src/medCore/process/arithmetic_operation/medAbstractAddImageProcess.h
+++ b/src/medCore/process/arithmetic_operation/medAbstractAddImageProcess.h
@@ -17,9 +17,9 @@
 
 #include <dtkCore>
 
-#include <medInriaExport.h>
+#include <medCoreExport.h>
 
-class MEDINRIA_EXPORT  medAbstractAddImageProcess: public medAbstractArithmeticOperationProcess
+class MEDCORE_EXPORT  medAbstractAddImageProcess: public medAbstractArithmeticOperationProcess
 {
     Q_OBJECT
 public:
@@ -27,6 +27,6 @@ public:
 };
 
 DTK_DECLARE_OBJECT        (medAbstractAddImageProcess*)
-DTK_DECLARE_PLUGIN        (medAbstractAddImageProcess, MEDINRIA_EXPORT)
-DTK_DECLARE_PLUGIN_FACTORY(medAbstractAddImageProcess, MEDINRIA_EXPORT)
-DTK_DECLARE_PLUGIN_MANAGER(medAbstractAddImageProcess, MEDINRIA_EXPORT)
+DTK_DECLARE_PLUGIN        (medAbstractAddImageProcess, MEDCORE_EXPORT)
+DTK_DECLARE_PLUGIN_FACTORY(medAbstractAddImageProcess, MEDCORE_EXPORT)
+DTK_DECLARE_PLUGIN_MANAGER(medAbstractAddImageProcess, MEDCORE_EXPORT)

--- a/src/medCore/process/arithmetic_operation/medAbstractArithmeticOperationProcess.h
+++ b/src/medCore/process/arithmetic_operation/medAbstractArithmeticOperationProcess.h
@@ -15,13 +15,13 @@
 
 #include <medAbstractProcess.h>
 
-#include <medInriaExport.h>
+#include <medCoreExport.h>
 
 class medAbstractImageData;
 class medViewContainerSplitter;
 
 class medAbstractArithmeticOperationProcessPrivate;
-class MEDINRIA_EXPORT  medAbstractArithmeticOperationProcess : public medAbstractProcess
+class MEDCORE_EXPORT  medAbstractArithmeticOperationProcess : public medAbstractProcess
 {
     Q_OBJECT
 

--- a/src/medCore/process/arithmetic_operation/medAbstractDivideImageProcess.h
+++ b/src/medCore/process/arithmetic_operation/medAbstractDivideImageProcess.h
@@ -17,9 +17,9 @@
 
 #include <dtkCore>
 
-#include <medInriaExport.h>
+#include <medCoreExport.h>
 
-class MEDINRIA_EXPORT medAbstractDivideImageProcess: public medAbstractArithmeticOperationProcess
+class MEDCORE_EXPORT medAbstractDivideImageProcess: public medAbstractArithmeticOperationProcess
 {
     Q_OBJECT
 public:
@@ -27,6 +27,6 @@ public:
 };
 
 DTK_DECLARE_OBJECT        (medAbstractDivideImageProcess*)
-DTK_DECLARE_PLUGIN        (medAbstractDivideImageProcess, MEDINRIA_EXPORT)
-DTK_DECLARE_PLUGIN_FACTORY(medAbstractDivideImageProcess, MEDINRIA_EXPORT)
-DTK_DECLARE_PLUGIN_MANAGER(medAbstractDivideImageProcess, MEDINRIA_EXPORT)
+DTK_DECLARE_PLUGIN        (medAbstractDivideImageProcess, MEDCORE_EXPORT)
+DTK_DECLARE_PLUGIN_FACTORY(medAbstractDivideImageProcess, MEDCORE_EXPORT)
+DTK_DECLARE_PLUGIN_MANAGER(medAbstractDivideImageProcess, MEDCORE_EXPORT)

--- a/src/medCore/process/arithmetic_operation/medAbstractMultiplyImageProcess.h
+++ b/src/medCore/process/arithmetic_operation/medAbstractMultiplyImageProcess.h
@@ -17,9 +17,9 @@
 
 #include <dtkCore>
 
-#include <medInriaExport.h>
+#include <medCoreExport.h>
 
-class MEDINRIA_EXPORT medAbstractMultiplyImageProcess: public medAbstractArithmeticOperationProcess
+class MEDCORE_EXPORT medAbstractMultiplyImageProcess: public medAbstractArithmeticOperationProcess
 {
     Q_OBJECT
 public:
@@ -27,6 +27,6 @@ public:
 };
 
 DTK_DECLARE_OBJECT        (medAbstractMultiplyImageProcess*)
-DTK_DECLARE_PLUGIN        (medAbstractMultiplyImageProcess, MEDINRIA_EXPORT)
-DTK_DECLARE_PLUGIN_FACTORY(medAbstractMultiplyImageProcess, MEDINRIA_EXPORT)
-DTK_DECLARE_PLUGIN_MANAGER(medAbstractMultiplyImageProcess, MEDINRIA_EXPORT)
+DTK_DECLARE_PLUGIN        (medAbstractMultiplyImageProcess, MEDCORE_EXPORT)
+DTK_DECLARE_PLUGIN_FACTORY(medAbstractMultiplyImageProcess, MEDCORE_EXPORT)
+DTK_DECLARE_PLUGIN_MANAGER(medAbstractMultiplyImageProcess, MEDCORE_EXPORT)

--- a/src/medCore/process/arithmetic_operation/medAbstractSubtractImageProcess.h
+++ b/src/medCore/process/arithmetic_operation/medAbstractSubtractImageProcess.h
@@ -17,9 +17,9 @@
 
 #include <dtkCore>
 
-#include <medInriaExport.h>
+#include <medCoreExport.h>
 
-class medAbstractSubtractImageProcess: public medAbstractArithmeticOperationProcess
+class MEDCORE_EXPORT medAbstractSubtractImageProcess: public medAbstractArithmeticOperationProcess
 {
     Q_OBJECT
 public:
@@ -27,6 +27,6 @@ public:
 };
 
 DTK_DECLARE_OBJECT        (medAbstractSubtractImageProcess*)
-DTK_DECLARE_PLUGIN        (medAbstractSubtractImageProcess, MEDINRIA_EXPORT)
-DTK_DECLARE_PLUGIN_FACTORY(medAbstractSubtractImageProcess, MEDINRIA_EXPORT)
-DTK_DECLARE_PLUGIN_MANAGER(medAbstractSubtractImageProcess, MEDINRIA_EXPORT)
+DTK_DECLARE_PLUGIN        (medAbstractSubtractImageProcess, MEDCORE_EXPORT)
+DTK_DECLARE_PLUGIN_FACTORY(medAbstractSubtractImageProcess, MEDCORE_EXPORT)
+DTK_DECLARE_PLUGIN_MANAGER(medAbstractSubtractImageProcess, MEDCORE_EXPORT)

--- a/src/medCore/process/medAbstractProcess.h
+++ b/src/medCore/process/medAbstractProcess.h
@@ -17,12 +17,12 @@
 #include <QRunnable>
 #include <QPushButton>
 
-#include <medInriaExport.h>
+#include <medCoreExport.h>
 
 class medAbstractParameter;
 class medViewContainerSplitter;
 
-struct MEDINRIA_EXPORT medProcessDetails
+struct MEDCORE_EXPORT medProcessDetails
 {
     QString name;
     QString version;
@@ -30,7 +30,7 @@ struct MEDINRIA_EXPORT medProcessDetails
 };
 
 class medAbstractProcessPrivate;
-class MEDINRIA_EXPORT medAbstractProcess: public QObject, public QRunnable
+class MEDCORE_EXPORT medAbstractProcess: public QObject, public QRunnable
 {
     Q_OBJECT
 public:

--- a/src/medCore/process/medProcessLayer.h
+++ b/src/medCore/process/medProcessLayer.h
@@ -19,7 +19,7 @@
 #include <medAbstractMultiplyImageProcess.h>
 #include <medAbstractDivideImageProcess.h>
 
-#include <medInriaExport.h>
+#include <medCoreExport.h>
 
 #include <medAbstractErodeImageProcess.h>
 #include <medAbstractDilateImageProcess.h>
@@ -28,41 +28,41 @@
 
 namespace medProcessLayer
 {
-    MEDINRIA_EXPORT medProcessDetails readDetailsFromJson(QString const& filePath);
+    MEDCORE_EXPORT medProcessDetails readDetailsFromJson(QString const& filePath);
 
     namespace pluginManager
     {
-        MEDINRIA_EXPORT void initialize(const QString& path = QString(), bool verbose = true);
+        MEDCORE_EXPORT void initialize(const QString& path = QString(), bool verbose = true);
     }
 
     namespace arithmeticalOperation
     {
         namespace addImage
         {
-            MEDINRIA_EXPORT medAbstractAddImageProcessPluginManager& pluginManager(void);
-            MEDINRIA_EXPORT medAbstractAddImageProcessPluginFactory& pluginFactory(void);
-            MEDINRIA_EXPORT void initialize(const QString& path, bool verbose = true);
+            MEDCORE_EXPORT medAbstractAddImageProcessPluginManager& pluginManager(void);
+            MEDCORE_EXPORT medAbstractAddImageProcessPluginFactory& pluginFactory(void);
+            MEDCORE_EXPORT void initialize(const QString& path, bool verbose = true);
 
         }
         namespace subtractImage
         {
-            MEDINRIA_EXPORT medAbstractSubtractImageProcessPluginManager& pluginManager(void);
-            MEDINRIA_EXPORT medAbstractSubtractImageProcessPluginFactory& pluginFactory(void);
-            MEDINRIA_EXPORT void initialize(const QString& path, bool verbose = true);
+            MEDCORE_EXPORT medAbstractSubtractImageProcessPluginManager& pluginManager(void);
+            MEDCORE_EXPORT medAbstractSubtractImageProcessPluginFactory& pluginFactory(void);
+            MEDCORE_EXPORT void initialize(const QString& path, bool verbose = true);
 
         }
         namespace multiplyImage
         {
-            MEDINRIA_EXPORT medAbstractMultiplyImageProcessPluginManager& pluginManager(void);
-            MEDINRIA_EXPORT medAbstractMultiplyImageProcessPluginFactory& pluginFactory(void);
-            MEDINRIA_EXPORT void initialize(const QString& path, bool verbose = true);
+            MEDCORE_EXPORT medAbstractMultiplyImageProcessPluginManager& pluginManager(void);
+            MEDCORE_EXPORT medAbstractMultiplyImageProcessPluginFactory& pluginFactory(void);
+            MEDCORE_EXPORT void initialize(const QString& path, bool verbose = true);
 
         }
         namespace divideImage
         {
-            MEDINRIA_EXPORT medAbstractDivideImageProcessPluginManager& pluginManager(void);
-            MEDINRIA_EXPORT medAbstractDivideImageProcessPluginFactory& pluginFactory(void);
-            MEDINRIA_EXPORT void initialize(const QString& path, bool verbose = true);
+            MEDCORE_EXPORT medAbstractDivideImageProcessPluginManager& pluginManager(void);
+            MEDCORE_EXPORT medAbstractDivideImageProcessPluginFactory& pluginFactory(void);
+            MEDCORE_EXPORT void initialize(const QString& path, bool verbose = true);
         }
     }
 
@@ -70,27 +70,27 @@ namespace medProcessLayer
     {
         namespace erodeImage
         {
-            MEDINRIA_EXPORT medAbstractErodeImageProcessPluginManager& pluginManager(void);
-            MEDINRIA_EXPORT medAbstractErodeImageProcessPluginFactory& pluginFactory(void);
-            MEDINRIA_EXPORT void initialize(const QString& path, bool verbose = true);
+            MEDCORE_EXPORT medAbstractErodeImageProcessPluginManager& pluginManager(void);
+            MEDCORE_EXPORT medAbstractErodeImageProcessPluginFactory& pluginFactory(void);
+            MEDCORE_EXPORT void initialize(const QString& path, bool verbose = true);
         }
         namespace dilateImage
         {
-            MEDINRIA_EXPORT medAbstractDilateImageProcessPluginManager& pluginManager(void);
-            MEDINRIA_EXPORT medAbstractDilateImageProcessPluginFactory& pluginFactory(void);
-            MEDINRIA_EXPORT void initialize(const QString& path, bool verbose = true);
+            MEDCORE_EXPORT medAbstractDilateImageProcessPluginManager& pluginManager(void);
+            MEDCORE_EXPORT medAbstractDilateImageProcessPluginFactory& pluginFactory(void);
+            MEDCORE_EXPORT void initialize(const QString& path, bool verbose = true);
         }
         namespace openingImage
         {
-            MEDINRIA_EXPORT medAbstractOpeningImageProcessPluginManager& pluginManager(void);
-            MEDINRIA_EXPORT medAbstractOpeningImageProcessPluginFactory& pluginFactory(void);
-            MEDINRIA_EXPORT void initialize(const QString& path, bool verbose = true);
+            MEDCORE_EXPORT medAbstractOpeningImageProcessPluginManager& pluginManager(void);
+            MEDCORE_EXPORT medAbstractOpeningImageProcessPluginFactory& pluginFactory(void);
+            MEDCORE_EXPORT void initialize(const QString& path, bool verbose = true);
         }
         namespace closingImage
         {
-            MEDINRIA_EXPORT medAbstractClosingImageProcessPluginManager& pluginManager(void);
-            MEDINRIA_EXPORT medAbstractClosingImageProcessPluginFactory& pluginFactory(void);
-            MEDINRIA_EXPORT void initialize(const QString& path, bool verbose = true);
+            MEDCORE_EXPORT medAbstractClosingImageProcessPluginManager& pluginManager(void);
+            MEDCORE_EXPORT medAbstractClosingImageProcessPluginFactory& pluginFactory(void);
+            MEDCORE_EXPORT void initialize(const QString& path, bool verbose = true);
         }
     }
 }

--- a/src/medCore/process/morphomath_operation/medAbstractClosingImageProcess.h
+++ b/src/medCore/process/morphomath_operation/medAbstractClosingImageProcess.h
@@ -19,7 +19,7 @@
 
 #include <medCoreExport.h>
 
-class medAbstractClosingImageProcess: public medAbstractMorphomathOperationProcess
+class MEDCORE_EXPORT medAbstractClosingImageProcess: public medAbstractMorphomathOperationProcess
 {
     Q_OBJECT
 public:

--- a/src/medCore/process/morphomath_operation/medAbstractDilateImageProcess.h
+++ b/src/medCore/process/morphomath_operation/medAbstractDilateImageProcess.h
@@ -19,7 +19,7 @@
 
 #include <medCoreExport.h>
 
-class medAbstractDilateImageProcess: public medAbstractMorphomathOperationProcess
+class MEDCORE_EXPORT medAbstractDilateImageProcess: public medAbstractMorphomathOperationProcess
 {
     Q_OBJECT
 public:

--- a/src/medCore/process/morphomath_operation/medAbstractErodeImageProcess.h
+++ b/src/medCore/process/morphomath_operation/medAbstractErodeImageProcess.h
@@ -19,7 +19,7 @@
 
 #include <medCoreExport.h>
 
-class medAbstractErodeImageProcess: public medAbstractMorphomathOperationProcess
+class MEDCORE_EXPORT medAbstractErodeImageProcess: public medAbstractMorphomathOperationProcess
 {
     Q_OBJECT
 public:

--- a/src/medCore/process/morphomath_operation/medAbstractMorphomathOperationProcess.h
+++ b/src/medCore/process/morphomath_operation/medAbstractMorphomathOperationProcess.h
@@ -15,12 +15,14 @@
 
 #include <medAbstractProcess.h>
 
+#include <medCoreExport.h>
+
 class medAbstractImageData;
 class medViewContainerSplitter;
 class medDoubleParameter;
 
 class medAbstractMorphomathOperationProcessPrivate;
-class medAbstractMorphomathOperationProcess : public medAbstractProcess
+class MEDCORE_EXPORT medAbstractMorphomathOperationProcess : public medAbstractProcess
 {
     Q_OBJECT
 

--- a/src/medCore/process/morphomath_operation/medAbstractOpeningImageProcess.h
+++ b/src/medCore/process/morphomath_operation/medAbstractOpeningImageProcess.h
@@ -19,7 +19,7 @@
 
 #include <medCoreExport.h>
 
-class medAbstractOpeningImageProcess: public medAbstractMorphomathOperationProcess
+class MEDCORE_EXPORT medAbstractOpeningImageProcess: public medAbstractMorphomathOperationProcess
 {
     Q_OBJECT
 public:

--- a/src/medCoreLegacy/data/annotationData/medAnnotationData.h
+++ b/src/medCoreLegacy/data/annotationData/medAnnotationData.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,17 +13,17 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <medAttachedData.h>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractData;
 
-/** 
+/**
  * Base class for annotations : a specialization of medAttachedData.
- * 
+ *
  */
-class MEDCORE_EXPORT medAnnotationData : public medAttachedData
+class MEDCORELEGACY_EXPORT medAnnotationData : public medAttachedData
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/data/annotationData/medImageMaskAnnotationData.h
+++ b/src/medCoreLegacy/data/annotationData/medImageMaskAnnotationData.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,8 +13,6 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <medAnnotationData.h>
 #include <medAbstractImageData.h>
 
@@ -22,14 +20,16 @@
 
 #include <QtCore>
 
+#include <medCoreLegacyExport.h>
+
 /**
  * Implementation of an overlay image to be used to mark voxels as inside, outside or unknown.
  * Can be added to an image data as an annotation, in which case the size of this mask should
  * match the size of the image.
- * 
+ *
  * The class contains a medAbstractImageData containing the actual mask data. This can be manipulated.
  */
-class MEDCORE_EXPORT medImageMaskAnnotationData : public medAnnotationData
+class MEDCORELEGACY_EXPORT medImageMaskAnnotationData : public medAnnotationData
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/data/annotationData/medSeedPointAnnotationData.h
+++ b/src/medCoreLegacy/data/annotationData/medSeedPointAnnotationData.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,17 +13,18 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <medAnnotationData.h>
+
 #include <QtWidgets>
 #include <QVector3D>
+
+#include <medCoreLegacyExport.h>
 
 /** Defines a set of seed points that may be attached to a data
  * One of the points may be in a selected state.
  * A singleViewContainer size and color is set, the selected point has a different color.
  */
-class MEDCORE_EXPORT medSeedPointAnnotationData : public medAnnotationData
+class MEDCORELEGACY_EXPORT medSeedPointAnnotationData : public medAnnotationData
 {
     Q_OBJECT
     MED_DATA_INTERFACE("medSeedPointAnnotationData", "medSeedPointAnnotationData")

--- a/src/medCoreLegacy/data/medAbstractData.h
+++ b/src/medCoreLegacy/data/medAbstractData.h
@@ -15,7 +15,7 @@
 
 #include <dtkCoreSupport/dtkAbstractData.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class medAbstractDataPrivate;
 
@@ -25,7 +25,7 @@ class medDataIndex;
 /**
  * Extending dtkAbstractData class to hold more specific information
  */
-class MEDCORE_EXPORT medAbstractData : public dtkAbstractData
+class MEDCORELEGACY_EXPORT medAbstractData : public dtkAbstractData
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/data/medAbstractDataFactory.h
+++ b/src/medCoreLegacy/data/medAbstractDataFactory.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -16,8 +16,9 @@
 #include <dtkCoreSupport/dtkAbstractDataFactory.h>
 #include <medAbstractData.h>
 
+#include <medCoreLegacyExport.h>
 
-class MEDCORE_EXPORT medAbstractDataFactory : public dtkAbstractDataFactory
+class MEDCORELEGACY_EXPORT medAbstractDataFactory : public dtkAbstractDataFactory
 {
 public:
     static medAbstractDataFactory *instance();

--- a/src/medCoreLegacy/data/medAbstractDiffusionModelImageData.h
+++ b/src/medCoreLegacy/data/medAbstractDiffusionModelImageData.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,14 +13,15 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 #include <medAbstractImageData.h>
 
-class MEDCORE_EXPORT medAbstractDiffusionModelImageData : public medAbstractImageData
+#include <medCoreLegacyExport.h>
+
+class MEDCORELEGACY_EXPORT medAbstractDiffusionModelImageData : public medAbstractImageData
 {
 public:
     medAbstractDiffusionModelImageData();
-    
+
     virtual ~medAbstractDiffusionModelImageData() {}
 
     virtual const QString PixelMeaning() const;

--- a/src/medCoreLegacy/data/medAbstractFibersData.h
+++ b/src/medCoreLegacy/data/medAbstractFibersData.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,12 +13,13 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 #include <medAbstractData.h>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractFibersDataPrivate;
 
-class MEDCORE_EXPORT medAbstractFibersData : public medAbstractData
+class MEDCORELEGACY_EXPORT medAbstractFibersData : public medAbstractData
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/data/medAbstractImageData.h
+++ b/src/medCoreLegacy/data/medAbstractImageData.h
@@ -16,10 +16,11 @@
 #include <typeinfo>
 #include <vector>
 
-#include <medCoreExport.h>
 #include <medAbstractData.h>
 
-class MEDCORE_EXPORT medAbstractImageData: public medAbstractData
+#include <medCoreLegacyExport.h>
+
+class MEDCORELEGACY_EXPORT medAbstractImageData: public medAbstractData
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/data/medAbstractMaskData.h
+++ b/src/medCoreLegacy/data/medAbstractMaskData.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,8 +15,9 @@
 
 #include <medAbstractData.h>
 
+#include <medCoreLegacyExport.h>
 
-class MEDCORE_EXPORT medAbstractMaskData : public medAbstractData
+class MEDCORELEGACY_EXPORT medAbstractMaskData : public medAbstractData
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/data/medAbstractMeshData.h
+++ b/src/medCoreLegacy/data/medAbstractMeshData.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,14 +13,15 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 #include <medAbstractData.h>
+
+#include <medCoreLegacyExport.h>
 
 //class medAbstractDataVertex;
 //class medAbstractDataEdge;
 class medAbstractMeshDataPrivate;
 
-class MEDCORE_EXPORT medAbstractMeshData : public medAbstractData
+class MEDCORELEGACY_EXPORT medAbstractMeshData : public medAbstractData
 {
     Q_OBJECT
 
@@ -35,7 +36,7 @@ public:
     virtual int countVertices()
     { return 0; }
     virtual int countEdges()
-    { return 0; }    
+    { return 0; }
 
 private:
     medAbstractMeshDataPrivate *d;

--- a/src/medCoreLegacy/data/medAbstractTypedDiffusionModelImageData.h
+++ b/src/medCoreLegacy/data/medAbstractTypedDiffusionModelImageData.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,7 +13,6 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 #include <medAbstractDiffusionModelImageData.h>
 
 template <unsigned DIM,typename T>
@@ -22,9 +21,9 @@ class medAbstractTypedDiffusionModelImageData: public medAbstractDiffusionModelI
 public:
 
     medAbstractTypedDiffusionModelImageData(): medAbstractDiffusionModelImageData() {}
-    
+
     virtual ~medAbstractTypedDiffusionModelImageData() {}
-    
+
     virtual int                                Dimension() const { return DIM;       }
     virtual const medAbstractImageData::PixId& PixelType() const { return typeid(T); }
 };

--- a/src/medCoreLegacy/data/medAbstractTypedImageData.h
+++ b/src/medCoreLegacy/data/medAbstractTypedImageData.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,7 +13,6 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 #include <medAbstractImageData.h>
 
 template <unsigned DIM,typename T>

--- a/src/medCoreLegacy/data/medAttachedData.h
+++ b/src/medCoreLegacy/data/medAttachedData.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -14,14 +14,15 @@
 #pragma once
 
 #include <medAbstractData.h>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medAttachedDataPrivate;
 
 /**
  * Class to store attachments to datasets
  */
-class MEDCORE_EXPORT medAttachedData : public medAbstractData
+class MEDCORELEGACY_EXPORT medAttachedData : public medAbstractData
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/data/medDataReaderWriter.h
+++ b/src/medCoreLegacy/data/medDataReaderWriter.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -18,9 +18,9 @@
 #include <dtkCoreSupport/dtkAbstractDataWriter.h>
 #include <medAbstractData.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
-struct MEDCORE_EXPORT medDataReaderWriter {
+struct MEDCORELEGACY_EXPORT medDataReaderWriter {
 
     typedef dtkSmartPointer<dtkAbstractDataReader> Reader;
     typedef dtkSmartPointer<dtkAbstractDataWriter> Writer;

--- a/src/medCoreLegacy/data/medMetaDataKeys.cpp
+++ b/src/medCoreLegacy/data/medMetaDataKeys.cpp
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,74 +13,76 @@
 
 #include <medMetaDataKeys.h>
 
+#include <medCoreLegacyExport.h>
+
 namespace medMetaDataKeys {
 
-    MEDCORE_EXPORT Key::Registery Key::registery;
+    MEDCORELEGACY_EXPORT Key::Registery Key::registery;
 
     /** Define the actual keys to use */
 
-    MEDCORE_EXPORT const Key TransferSyntaxUID("TransferSyntaxUID");
-    MEDCORE_EXPORT const Key ContainsBasicInfo("ContainsBasicInfo");
+    MEDCORELEGACY_EXPORT const Key TransferSyntaxUID("TransferSyntaxUID");
+    MEDCORELEGACY_EXPORT const Key ContainsBasicInfo("ContainsBasicInfo");
 
     // PATIENT
-    MEDCORE_EXPORT const Key PatientID("PatientID");
-    MEDCORE_EXPORT const Key PatientName("PatientName", "Patient Name");
-    MEDCORE_EXPORT const Key Age("Age", "Age", QVariant::UInt);
-    MEDCORE_EXPORT const Key BirthDate("BirthDate", "Birth Date"/*, QVariant::Date*/);
-    MEDCORE_EXPORT const Key Gender("Gender", "Gender", QVariant::Char);
-    MEDCORE_EXPORT const Key Description("Description"); //what?
+    MEDCORELEGACY_EXPORT const Key PatientID("PatientID");
+    MEDCORELEGACY_EXPORT const Key PatientName("PatientName", "Patient Name");
+    MEDCORELEGACY_EXPORT const Key Age("Age", "Age", QVariant::UInt);
+    MEDCORELEGACY_EXPORT const Key BirthDate("BirthDate", "Birth Date"/*, QVariant::Date*/);
+    MEDCORELEGACY_EXPORT const Key Gender("Gender", "Gender", QVariant::Char);
+    MEDCORELEGACY_EXPORT const Key Description("Description"); //what?
 
     // STUDY
-    MEDCORE_EXPORT const Key StudyID("StudyID", "Study ID");
-    MEDCORE_EXPORT const Key StudyDicomID("StudyDicomID", "Study Dicom ID");
-    MEDCORE_EXPORT const Key StudyDescription("StudyDescription", "Study Description");
-    MEDCORE_EXPORT const Key Institution("Institution");
-    MEDCORE_EXPORT const Key Referee("Referee");
-    MEDCORE_EXPORT const Key StudyDate("StudyDate", "Study Date"/*, QVariant::Date*/);
-    MEDCORE_EXPORT const Key StudyTime("StudyTime", "Study Time"/*, QVariant::Date*/);
+    MEDCORELEGACY_EXPORT const Key StudyID("StudyID", "Study ID");
+    MEDCORELEGACY_EXPORT const Key StudyDicomID("StudyDicomID", "Study Dicom ID");
+    MEDCORELEGACY_EXPORT const Key StudyDescription("StudyDescription", "Study Description");
+    MEDCORELEGACY_EXPORT const Key Institution("Institution");
+    MEDCORELEGACY_EXPORT const Key Referee("Referee");
+    MEDCORELEGACY_EXPORT const Key StudyDate("StudyDate", "Study Date"/*, QVariant::Date*/);
+    MEDCORELEGACY_EXPORT const Key StudyTime("StudyTime", "Study Time"/*, QVariant::Date*/);
 
     // SERIES
-    MEDCORE_EXPORT const Key SeriesID("SeriesID", "Series ID");
-    MEDCORE_EXPORT const Key SeriesDicomID("SeriesDicomID", "Series Dicom ID");
-    MEDCORE_EXPORT const Key SeriesNumber("SeriesNumber", "Series Number");
-    MEDCORE_EXPORT const Key Modality("Modality");
-    MEDCORE_EXPORT const Key Performer("Performer");
-    MEDCORE_EXPORT const Key Report("Report");
-    MEDCORE_EXPORT const Key Protocol("Protocol");
-    MEDCORE_EXPORT const Key SeriesDescription("SeriesDescription", "Series Description");
-    MEDCORE_EXPORT const Key SeriesDate("SeriesDate", "Series Date"/*, QVariant::Date*/);
-    MEDCORE_EXPORT const Key SeriesTime("SeriesTime", "Series Time"/*, QVariant::Date*/);
-    MEDCORE_EXPORT const Key SeriesThumbnail("SeriesThumbnail", "Series Thumbnail");
+    MEDCORELEGACY_EXPORT const Key SeriesID("SeriesID", "Series ID");
+    MEDCORELEGACY_EXPORT const Key SeriesDicomID("SeriesDicomID", "Series Dicom ID");
+    MEDCORELEGACY_EXPORT const Key SeriesNumber("SeriesNumber", "Series Number");
+    MEDCORELEGACY_EXPORT const Key Modality("Modality");
+    MEDCORELEGACY_EXPORT const Key Performer("Performer");
+    MEDCORELEGACY_EXPORT const Key Report("Report");
+    MEDCORELEGACY_EXPORT const Key Protocol("Protocol");
+    MEDCORELEGACY_EXPORT const Key SeriesDescription("SeriesDescription", "Series Description");
+    MEDCORELEGACY_EXPORT const Key SeriesDate("SeriesDate", "Series Date"/*, QVariant::Date*/);
+    MEDCORELEGACY_EXPORT const Key SeriesTime("SeriesTime", "Series Time"/*, QVariant::Date*/);
+    MEDCORELEGACY_EXPORT const Key SeriesThumbnail("SeriesThumbnail", "Series Thumbnail");
 
     // IMAGE
 
-    MEDCORE_EXPORT const Key SOPInstanceUID("SOPInstanceUID", "SOP Instance UID");
-    MEDCORE_EXPORT const Key Columns("Columns","Columns",QVariant::UInt);
-    MEDCORE_EXPORT const Key Rows("Rows","Rows",QVariant::UInt);
-    MEDCORE_EXPORT const Key Dimensions("Dimensions","Dimensions",QVariant::Int);
-    MEDCORE_EXPORT const Key NumberOfDimensions("NumberOfDimensions", "Number Of Dimensions");
-    MEDCORE_EXPORT const Key Orientation("Orientation");
-    MEDCORE_EXPORT const Key Origin("Origin");
-    MEDCORE_EXPORT const Key SliceThickness("SliceThickness", "Slice Thickness");
-    MEDCORE_EXPORT const Key ImportationDate("ImportationDate", "Importation Date");
-    MEDCORE_EXPORT const Key AcquisitionDate("AcquisitionDate", "Acquisition Date");
-    MEDCORE_EXPORT const Key AcquisitionTime("AcquisitionTime", "Acquisition Time");
-    MEDCORE_EXPORT const Key Comments("Comments");
-    MEDCORE_EXPORT const Key FilePaths("FilePaths", "File Paths");
-    MEDCORE_EXPORT const Key Status("Status");
-    MEDCORE_EXPORT const Key SequenceName("SequenceName", "Sequence Name");
-    MEDCORE_EXPORT const Key Size("Size","Size",QVariant::UInt, false);
-    MEDCORE_EXPORT const Key VolumeUID("VolumeUID", "Volume UID");
-    MEDCORE_EXPORT const Key Spacing("Spacing");
-    MEDCORE_EXPORT const Key XSpacing("XSpacing", "X Spacing");
-    MEDCORE_EXPORT const Key YSpacing("YSpacing", "Y Spacing");
-    MEDCORE_EXPORT const Key ZSpacing("ZSpacing", "Z Spacing");
-    MEDCORE_EXPORT const Key NumberOfComponents("NumberOfComponents", "Number Of Components");
-    MEDCORE_EXPORT const Key ComponentType("ComponentType", "Component Type");
-    MEDCORE_EXPORT const Key PixelType("PixelType", "Pixel Type");
-    MEDCORE_EXPORT const Key medDataType("medDataType", "Dtk Data Type");
-    MEDCORE_EXPORT const Key PreferredDataReader("PreferredDataReader", "Preferred Data Reader");
-    MEDCORE_EXPORT const Key ImageID("ImageID");
-    MEDCORE_EXPORT const Key ThumbnailPath("ThumbnailPath", "Thumbnail Path");
+    MEDCORELEGACY_EXPORT const Key SOPInstanceUID("SOPInstanceUID", "SOP Instance UID");
+    MEDCORELEGACY_EXPORT const Key Columns("Columns","Columns",QVariant::UInt);
+    MEDCORELEGACY_EXPORT const Key Rows("Rows","Rows",QVariant::UInt);
+    MEDCORELEGACY_EXPORT const Key Dimensions("Dimensions","Dimensions",QVariant::Int);
+    MEDCORELEGACY_EXPORT const Key NumberOfDimensions("NumberOfDimensions", "Number Of Dimensions");
+    MEDCORELEGACY_EXPORT const Key Orientation("Orientation");
+    MEDCORELEGACY_EXPORT const Key Origin("Origin");
+    MEDCORELEGACY_EXPORT const Key SliceThickness("SliceThickness", "Slice Thickness");
+    MEDCORELEGACY_EXPORT const Key ImportationDate("ImportationDate", "Importation Date");
+    MEDCORELEGACY_EXPORT const Key AcquisitionDate("AcquisitionDate", "Acquisition Date");
+    MEDCORELEGACY_EXPORT const Key AcquisitionTime("AcquisitionTime", "Acquisition Time");
+    MEDCORELEGACY_EXPORT const Key Comments("Comments");
+    MEDCORELEGACY_EXPORT const Key FilePaths("FilePaths", "File Paths");
+    MEDCORELEGACY_EXPORT const Key Status("Status");
+    MEDCORELEGACY_EXPORT const Key SequenceName("SequenceName", "Sequence Name");
+    MEDCORELEGACY_EXPORT const Key Size("Size","Size",QVariant::UInt, false);
+    MEDCORELEGACY_EXPORT const Key VolumeUID("VolumeUID", "Volume UID");
+    MEDCORELEGACY_EXPORT const Key Spacing("Spacing");
+    MEDCORELEGACY_EXPORT const Key XSpacing("XSpacing", "X Spacing");
+    MEDCORELEGACY_EXPORT const Key YSpacing("YSpacing", "Y Spacing");
+    MEDCORELEGACY_EXPORT const Key ZSpacing("ZSpacing", "Z Spacing");
+    MEDCORELEGACY_EXPORT const Key NumberOfComponents("NumberOfComponents", "Number Of Components");
+    MEDCORELEGACY_EXPORT const Key ComponentType("ComponentType", "Component Type");
+    MEDCORELEGACY_EXPORT const Key PixelType("PixelType", "Pixel Type");
+    MEDCORELEGACY_EXPORT const Key medDataType("medDataType", "Dtk Data Type");
+    MEDCORELEGACY_EXPORT const Key PreferredDataReader("PreferredDataReader", "Preferred Data Reader");
+    MEDCORELEGACY_EXPORT const Key ImageID("ImageID");
+    MEDCORELEGACY_EXPORT const Key ThumbnailPath("ThumbnailPath", "Thumbnail Path");
 };
 

--- a/src/medCoreLegacy/data/medMetaDataKeys.h
+++ b/src/medCoreLegacy/data/medMetaDataKeys.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,7 +15,8 @@
 
 #include <vector>
 #include <medAbstractData.h>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 namespace medMetaDataKeys {
 
@@ -25,7 +26,8 @@ namespace medMetaDataKeys {
     * It allows compile-time verification that the keyword is correct.
     */
 
-    class MEDCORE_EXPORT Key {
+    class MEDCORELEGACY_EXPORT Key
+    {
     public:
         typedef std::vector<const Key*> Registery;
 
@@ -86,69 +88,69 @@ namespace medMetaDataKeys {
 
     /** Define the actual keys to use */
 
-    extern MEDCORE_EXPORT const Key TransferSyntaxUID;
-    extern MEDCORE_EXPORT const Key ContainsBasicInfo;
+    extern MEDCORELEGACY_EXPORT const Key TransferSyntaxUID;
+    extern MEDCORELEGACY_EXPORT const Key ContainsBasicInfo;
 
     // PATIENT
-    extern MEDCORE_EXPORT const Key PatientID;
-    extern MEDCORE_EXPORT const Key PatientName;
-    extern MEDCORE_EXPORT const Key Age;
-    extern MEDCORE_EXPORT const Key BirthDate;
-    extern MEDCORE_EXPORT const Key Gender;
-    extern MEDCORE_EXPORT const Key Description; //what?
+    extern MEDCORELEGACY_EXPORT const Key PatientID;
+    extern MEDCORELEGACY_EXPORT const Key PatientName;
+    extern MEDCORELEGACY_EXPORT const Key Age;
+    extern MEDCORELEGACY_EXPORT const Key BirthDate;
+    extern MEDCORELEGACY_EXPORT const Key Gender;
+    extern MEDCORELEGACY_EXPORT const Key Description; //what?
 
     // STUDY
-    extern MEDCORE_EXPORT const Key StudyID;
-    extern MEDCORE_EXPORT const Key StudyDicomID;
-    extern MEDCORE_EXPORT const Key StudyDescription;
-    extern MEDCORE_EXPORT const Key Institution;
-    extern MEDCORE_EXPORT const Key Referee;
-    extern MEDCORE_EXPORT const Key StudyDate;
-    extern MEDCORE_EXPORT const Key StudyTime;
+    extern MEDCORELEGACY_EXPORT const Key StudyID;
+    extern MEDCORELEGACY_EXPORT const Key StudyDicomID;
+    extern MEDCORELEGACY_EXPORT const Key StudyDescription;
+    extern MEDCORELEGACY_EXPORT const Key Institution;
+    extern MEDCORELEGACY_EXPORT const Key Referee;
+    extern MEDCORELEGACY_EXPORT const Key StudyDate;
+    extern MEDCORELEGACY_EXPORT const Key StudyTime;
 
     // SERIES
-    extern MEDCORE_EXPORT const Key SeriesID;
-    extern MEDCORE_EXPORT const Key SeriesDicomID;
-    extern MEDCORE_EXPORT const Key SeriesStoreId;
-    extern MEDCORE_EXPORT const Key SeriesNumber;
-    extern MEDCORE_EXPORT const Key Modality;
-    extern MEDCORE_EXPORT const Key Performer;
-    extern MEDCORE_EXPORT const Key Report;
-    extern MEDCORE_EXPORT const Key Protocol;
-    extern MEDCORE_EXPORT const Key SeriesDescription;
-    extern MEDCORE_EXPORT const Key SeriesDate;
-    extern MEDCORE_EXPORT const Key SeriesTime;
-    extern MEDCORE_EXPORT const Key SeriesThumbnail;
+    extern MEDCORELEGACY_EXPORT const Key SeriesID;
+    extern MEDCORELEGACY_EXPORT const Key SeriesDicomID;
+    extern MEDCORELEGACY_EXPORT const Key SeriesStoreId;
+    extern MEDCORELEGACY_EXPORT const Key SeriesNumber;
+    extern MEDCORELEGACY_EXPORT const Key Modality;
+    extern MEDCORELEGACY_EXPORT const Key Performer;
+    extern MEDCORELEGACY_EXPORT const Key Report;
+    extern MEDCORELEGACY_EXPORT const Key Protocol;
+    extern MEDCORELEGACY_EXPORT const Key SeriesDescription;
+    extern MEDCORELEGACY_EXPORT const Key SeriesDate;
+    extern MEDCORELEGACY_EXPORT const Key SeriesTime;
+    extern MEDCORELEGACY_EXPORT const Key SeriesThumbnail;
 
     // IMAGE
-    extern MEDCORE_EXPORT const Key SOPInstanceUID;
-    extern MEDCORE_EXPORT const Key Columns;
-    extern MEDCORE_EXPORT const Key Rows;
-    extern MEDCORE_EXPORT const Key Dimensions;
-    extern MEDCORE_EXPORT const Key NumberOfDimensions;
-    extern MEDCORE_EXPORT const Key Orientation;
-    extern MEDCORE_EXPORT const Key Origin;
-    extern MEDCORE_EXPORT const Key SliceThickness;
-    extern MEDCORE_EXPORT const Key ImportationDate;
-    extern MEDCORE_EXPORT const Key AcquisitionDate;
-    extern MEDCORE_EXPORT const Key AcquisitionTime;
-    extern MEDCORE_EXPORT const Key Comments;
-    extern MEDCORE_EXPORT const Key FilePaths;
-    extern MEDCORE_EXPORT const Key Status;
-    extern MEDCORE_EXPORT const Key SequenceName;
-    extern MEDCORE_EXPORT const Key Size;
-    extern MEDCORE_EXPORT const Key VolumeUID;
-    extern MEDCORE_EXPORT const Key Spacing;
-    extern MEDCORE_EXPORT const Key XSpacing;
-    extern MEDCORE_EXPORT const Key YSpacing;
-    extern MEDCORE_EXPORT const Key ZSpacing;
-    extern MEDCORE_EXPORT const Key NumberOfComponents;
-    extern MEDCORE_EXPORT const Key ComponentType;
-    extern MEDCORE_EXPORT const Key PixelType;
-    extern MEDCORE_EXPORT const Key medDataType;
-    extern MEDCORE_EXPORT const Key PreferredDataReader;
-    extern MEDCORE_EXPORT const Key ImageID;
-    extern MEDCORE_EXPORT const Key ThumbnailPath;
+    extern MEDCORELEGACY_EXPORT const Key SOPInstanceUID;
+    extern MEDCORELEGACY_EXPORT const Key Columns;
+    extern MEDCORELEGACY_EXPORT const Key Rows;
+    extern MEDCORELEGACY_EXPORT const Key Dimensions;
+    extern MEDCORELEGACY_EXPORT const Key NumberOfDimensions;
+    extern MEDCORELEGACY_EXPORT const Key Orientation;
+    extern MEDCORELEGACY_EXPORT const Key Origin;
+    extern MEDCORELEGACY_EXPORT const Key SliceThickness;
+    extern MEDCORELEGACY_EXPORT const Key ImportationDate;
+    extern MEDCORELEGACY_EXPORT const Key AcquisitionDate;
+    extern MEDCORELEGACY_EXPORT const Key AcquisitionTime;
+    extern MEDCORELEGACY_EXPORT const Key Comments;
+    extern MEDCORELEGACY_EXPORT const Key FilePaths;
+    extern MEDCORELEGACY_EXPORT const Key Status;
+    extern MEDCORELEGACY_EXPORT const Key SequenceName;
+    extern MEDCORELEGACY_EXPORT const Key Size;
+    extern MEDCORELEGACY_EXPORT const Key VolumeUID;
+    extern MEDCORELEGACY_EXPORT const Key Spacing;
+    extern MEDCORELEGACY_EXPORT const Key XSpacing;
+    extern MEDCORELEGACY_EXPORT const Key YSpacing;
+    extern MEDCORELEGACY_EXPORT const Key ZSpacing;
+    extern MEDCORELEGACY_EXPORT const Key NumberOfComponents;
+    extern MEDCORELEGACY_EXPORT const Key ComponentType;
+    extern MEDCORELEGACY_EXPORT const Key PixelType;
+    extern MEDCORELEGACY_EXPORT const Key medDataType;
+    extern MEDCORELEGACY_EXPORT const Key PreferredDataReader;
+    extern MEDCORELEGACY_EXPORT const Key ImageID;
+    extern MEDCORELEGACY_EXPORT const Key ThumbnailPath;
 };
 
 

--- a/src/medCoreLegacy/database/medAbstractDatabaseImporter.h
+++ b/src/medCoreLegacy/database/medAbstractDatabaseImporter.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,16 +13,16 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <QtCore>
 #include <QtSql/QtSql>
 
-#include <medAbstractData.h>
 #include <dtkCoreSupport/dtkSmartPointer.h>
 
+#include <medAbstractData.h>
 #include <medJobItem.h>
 #include <medDataIndex.h>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractDatabaseImporterPrivate;
 class medAbstractData;
@@ -38,7 +38,7 @@ class medAbstractData;
 * To implement your own database importer, implement  the pure virtual methods, and override the run() method if neccessary.
 * For example, see @medDatabaseImporter and @medDatabaseNonPersistentReader
 **/
-class MEDCORE_EXPORT medAbstractDatabaseImporter : public medJobItem
+class MEDCORELEGACY_EXPORT medAbstractDatabaseImporter : public medJobItem
 {
     Q_OBJECT
 
@@ -71,10 +71,10 @@ public slots:
 protected:
     virtual void internalRun ( void ) ;
 
-    QString file ( void );   
-    bool isCancelled ( void );   
-    bool indexWithoutImporting ( void );  
-    QMap<int, QString> volumeIdToImageFile ( void );    
+    QString file ( void );
+    bool isCancelled ( void );
+    bool indexWithoutImporting ( void );
+    QMap<int, QString> volumeIdToImageFile ( void );
     QString callerUuid ( void );
     medDataIndex index(void) const;
 

--- a/src/medCoreLegacy/database/medAbstractDatabaseItem.h
+++ b/src/medCoreLegacy/database/medAbstractDatabaseItem.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -14,11 +14,12 @@
 #pragma once
 
 #include <QVariant>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medDataIndex;
 
-class MEDCORE_EXPORT medAbstractDatabaseItem
+class MEDCORELEGACY_EXPORT medAbstractDatabaseItem
 {
 
 public:
@@ -49,13 +50,13 @@ public:
 
     virtual const medDataIndex & dataIndex () const = 0;
     virtual void setDataIndex (const medDataIndex &) = 0;
-	
+
     virtual QVariant attribute(int column) = 0;
     virtual QVariant value(int column) = 0;
-    
+
     virtual QList<QVariant> attributes() = 0;
     virtual QList<QVariant> values() = 0;
-    
+
     virtual int rowOf(medAbstractDatabaseItem *child) const = 0;
 
 };

--- a/src/medCoreLegacy/database/medAbstractDbController.h
+++ b/src/medCoreLegacy/database/medAbstractDbController.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,17 +13,17 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 #include <medDataIndex.h>
-
 #include <medMetaDataKeys.h>
 #include <medAbstractData.h>
+
+#include <medCoreLegacyExport.h>
 
 class medImportJobWatcher;
 class medDataIndex;
 class medJobItem;
 
-class MEDCORE_EXPORT medAbstractDbController : public QObject
+class MEDCORELEGACY_EXPORT medAbstractDbController : public QObject
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/database/medDataIndex.h
+++ b/src/medCoreLegacy/database/medDataIndex.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,7 +15,7 @@
 
 #include <QtCore>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class QMimeData;
 
@@ -27,7 +27,7 @@ class QMimeData;
  *
  *  The integer value NOT_VALID is reserved to indicate unset or invalid data.
  *  */
-class MEDCORE_EXPORT medDataIndex
+class MEDCORELEGACY_EXPORT medDataIndex
 {
 public:
     enum {NOT_VALID = -1 };
@@ -61,12 +61,12 @@ public:
 
     static bool isMatch( const medDataIndex& index1, const medDataIndex& index2);
 
-    friend MEDCORE_EXPORT bool operator==(const medDataIndex& index1, const medDataIndex& index2);
-    friend MEDCORE_EXPORT bool operator!=(const medDataIndex& index1, const medDataIndex& index2);
+    friend MEDCORELEGACY_EXPORT bool operator==(const medDataIndex& index1, const medDataIndex& index2);
+    friend MEDCORELEGACY_EXPORT bool operator!=(const medDataIndex& index1, const medDataIndex& index2);
 
-    friend MEDCORE_EXPORT bool operator<(const medDataIndex& index1, const medDataIndex& index2);
-    friend MEDCORE_EXPORT QDebug operator<<(QDebug debug, const medDataIndex& index);
-    friend MEDCORE_EXPORT QDebug operator<<(QDebug debug,       medDataIndex *index);
+    friend MEDCORELEGACY_EXPORT bool operator<(const medDataIndex& index1, const medDataIndex& index2);
+    friend MEDCORELEGACY_EXPORT QDebug operator<<(QDebug debug, const medDataIndex& index);
+    friend MEDCORELEGACY_EXPORT QDebug operator<<(QDebug debug,       medDataIndex *index);
 
     QMimeData * createMimeData();
     static medDataIndex readMimeData(const QMimeData * mimeData);
@@ -87,18 +87,18 @@ private:
 // Convenience operators
 // /////////////////////////////////////////////////////////////////
 
-MEDCORE_EXPORT bool operator==(const medDataIndex& index1, const medDataIndex& index2);
-MEDCORE_EXPORT bool operator!=(const medDataIndex& index1, const medDataIndex& index2);
-MEDCORE_EXPORT bool operator<(const medDataIndex& index1, const medDataIndex& index2);
+MEDCORELEGACY_EXPORT bool operator==(const medDataIndex& index1, const medDataIndex& index2);
+MEDCORELEGACY_EXPORT bool operator!=(const medDataIndex& index1, const medDataIndex& index2);
+MEDCORELEGACY_EXPORT bool operator<(const medDataIndex& index1, const medDataIndex& index2);
 
-MEDCORE_EXPORT QDebug operator<<(QDebug debug, const medDataIndex& index);
-MEDCORE_EXPORT QDebug operator<<(QDebug debug,       medDataIndex *index);
+MEDCORELEGACY_EXPORT QDebug operator<<(QDebug debug, const medDataIndex& index);
+MEDCORELEGACY_EXPORT QDebug operator<<(QDebug debug,       medDataIndex *index);
 
 // /////////////////////////////////////////////////////////////////
 // Hash functions
 // /////////////////////////////////////////////////////////////////
 
-MEDCORE_EXPORT uint qHash(const medDataIndex &key);
+MEDCORELEGACY_EXPORT uint qHash(const medDataIndex &key);
 
 // /////////////////////////////////////////////////////////////////
 // Meta type registration

--- a/src/medCoreLegacy/database/medDataManager.h
+++ b/src/medCoreLegacy/database/medDataManager.h
@@ -18,14 +18,15 @@
 #include <QPixmap>
 #include <QUuid>
 
-#include <medCoreExport.h>
 #include <medDataIndex.h>
+
+#include <medCoreLegacyExport.h>
 
 class medDataManagerPrivate;
 class medAbstractData;
 class medAbstractDbController;
 
-class MEDCORE_EXPORT medDataManager : public QObject
+class MEDCORELEGACY_EXPORT medDataManager : public QObject
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/database/medDatabaseController.h
+++ b/src/medCoreLegacy/database/medDatabaseController.h
@@ -16,8 +16,9 @@
 #include <QtSql/QSqlDatabase>
 #include <QtSql/QSqlQuery>
 
-#include <medCoreExport.h>
 #include <medAbstractDbController.h>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractData;
 class medDatabaseControllerPrivate;
@@ -26,7 +27,7 @@ class medJobItem;
 /**
  * Concrete dbController implementation adhering to abstract base class
  */
-class MEDCORE_EXPORT medDatabaseController: public medAbstractDbController
+class MEDCORELEGACY_EXPORT medDatabaseController: public medAbstractDbController
 {
     Q_OBJECT
 
@@ -59,7 +60,7 @@ public:
     bool isConnected() const;
 
     virtual QList<medDataIndex> patients() const;
-    virtual QList<medDataIndex> studies(const medDataIndex& index ) const; 
+    virtual QList<medDataIndex> studies(const medDataIndex& index ) const;
     virtual QList<medDataIndex> series(const medDataIndex& index) const;
     virtual QList<medDataIndex> images(const medDataIndex& index ) const;
     virtual QPixmap thumbnail(const medDataIndex& index) const;

--- a/src/medCoreLegacy/database/medDatabaseExporter.h
+++ b/src/medCoreLegacy/database/medDatabaseExporter.h
@@ -13,15 +13,16 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 #include <QtCore>
 
 #include <medJobItem.h>
 
+#include <medCoreLegacyExport.h>
+
 class medAbstractData;
 class medDatabaseExporterPrivate;
 
-class MEDCORE_EXPORT medDatabaseExporter : public medJobItem
+class MEDCORELEGACY_EXPORT medDatabaseExporter : public medJobItem
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/database/medDatabaseImporter.h
+++ b/src/medCoreLegacy/database/medDatabaseImporter.h
@@ -13,12 +13,12 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <QtSql/QSqlDatabase>
 
 #include <medAbstractDatabaseImporter.h>
 #include <medDataIndex.h>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractData;
 
@@ -33,7 +33,7 @@ class medAbstractData;
 * medInria database (and as a result they can end up being aggregated by volume)
 * or they can be just indexed (by indicating so using the parameters in the constructor)
 **/
-class MEDCORE_EXPORT medDatabaseImporter : public medAbstractDatabaseImporter
+class MEDCORELEGACY_EXPORT medDatabaseImporter : public medAbstractDatabaseImporter
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/database/medDatabaseItem.h
+++ b/src/medCoreLegacy/database/medDatabaseItem.h
@@ -13,7 +13,6 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 
 #include <QtDebug>
 #include <QtGui>
@@ -21,9 +20,11 @@
 #include <medDataIndex.h>
 #include <medAbstractDatabaseItem.h>
 
+#include <medCoreLegacyExport.h>
+
 class medDatabaseItemPrivate;
 
-class MEDCORE_EXPORT medDatabaseItem : public medAbstractDatabaseItem
+class MEDCORELEGACY_EXPORT medDatabaseItem : public medAbstractDatabaseItem
 {
 public:
      medDatabaseItem(medDataIndex index, const QList<QVariant>& attributes, const QList<QVariant>& data, medAbstractDatabaseItem *parent = 0);

--- a/src/medCoreLegacy/database/medDatabaseModel.h
+++ b/src/medCoreLegacy/database/medDatabaseModel.h
@@ -13,16 +13,16 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <QtCore/QAbstractItemModel>
 #include <QtGui>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractDatabaseItem;
 class medDatabaseModelPrivate;
 class medDataIndex;
 
-class MEDCORE_EXPORT medDatabaseModel : public QAbstractItemModel
+class MEDCORELEGACY_EXPORT medDatabaseModel : public QAbstractItemModel
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/database/medDatabaseNonPersistentController.h
+++ b/src/medCoreLegacy/database/medDatabaseNonPersistentController.h
@@ -14,11 +14,12 @@
 #pragma once
 
 #include <medAbstractDbController.h>
-#include <medCoreExport.h>
 #include <medDataIndex.h>
 
 #include <QtCore/QObject>
 #include <QtCore/QList>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractData;
 class medDatabaseNonPersistentItem;
@@ -26,7 +27,7 @@ class medDatabaseNonPersistentControllerPrivate;
 class medImportJobWatcher;
 
 
-class MEDCORE_EXPORT medDatabaseNonPersistentController: public medAbstractDbController
+class MEDCORELEGACY_EXPORT medDatabaseNonPersistentController: public medAbstractDbController
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/database/medDatabaseNonPersistentImporter.h
+++ b/src/medCoreLegacy/database/medDatabaseNonPersistentImporter.h
@@ -13,12 +13,12 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <QtCore/QObject>
 
 #include <medDataIndex.h>
 #include <medAbstractDatabaseImporter.h>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractData;
 
@@ -28,7 +28,7 @@ class medAbstractData;
 * This class inherits from medJobItem and is meant to be run by the medJobManager.
 *
 */
-class MEDCORE_EXPORT medDatabaseNonPersistentImporter : public medAbstractDatabaseImporter
+class MEDCORELEGACY_EXPORT medDatabaseNonPersistentImporter : public medAbstractDatabaseImporter
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/database/medDatabaseNonPersistentItem.h
+++ b/src/medCoreLegacy/database/medDatabaseNonPersistentItem.h
@@ -13,18 +13,18 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <medDataIndex.h>
 
 #include <QtCore/QObject>
 #include <QtCore/QList>
 
+#include <medCoreLegacyExport.h>
+
 class medAbstractData;
 
 class medDatabaseNonPersistentItemPrivate;
 
-class MEDCORE_EXPORT medDatabaseNonPersistentItem : public QObject
+class MEDCORELEGACY_EXPORT medDatabaseNonPersistentItem : public QObject
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/database/medDatabaseProxyModel.h
+++ b/src/medCoreLegacy/database/medDatabaseProxyModel.h
@@ -13,18 +13,16 @@
 
 #pragma once
 
-
-#include <medCoreExport.h>
-
 #include <QSortFilterProxyModel>
 #include <QVector>
 #include <QtCore>
 
+#include <medCoreLegacyExport.h>
 
 /**
  * Proxy model that sits between a model and a view and filters + sorts items
  */
-class MEDCORE_EXPORT medDatabaseProxyModel : public QSortFilterProxyModel
+class MEDCORELEGACY_EXPORT medDatabaseProxyModel : public QSortFilterProxyModel
 {
     Q_OBJECT
 public:

--- a/src/medCoreLegacy/database/medDatabaseReader.h
+++ b/src/medCoreLegacy/database/medDatabaseReader.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -16,11 +16,13 @@
 #include <QtCore/QObject>
 #include <dtkCoreSupport/dtkSmartPointer.h>
 
+#include <medCoreLegacyExport.h>
+
 class medAbstractData;
 class medDatabaseReaderPrivate;
 class medDataIndex;
 
-class medDatabaseReader : public QObject
+class MEDCORELEGACY_EXPORT medDatabaseReader : public QObject
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/database/medDatabaseRemover.h
+++ b/src/medCoreLegacy/database/medDatabaseRemover.h
@@ -18,7 +18,7 @@
 #include <medDataIndex.h>
 #include <medJobItem.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class medDatabaseRemoverPrivate;
 
@@ -26,9 +26,9 @@ class medDatabaseRemoverPrivate;
  * @class medDatabaseRemover
  * @brief Removes given data from the database.
  */
-class MEDCORE_EXPORT medDatabaseRemover : public medJobItem
+class MEDCORELEGACY_EXPORT medDatabaseRemover : public medJobItem
 {
-    Q_OBJECT;
+    Q_OBJECT
 
 public:
      medDatabaseRemover(const medDataIndex &index);

--- a/src/medCoreLegacy/database/medStorage.h
+++ b/src/medCoreLegacy/database/medStorage.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -16,9 +16,9 @@
 #include <QtCore>
 #include <QString>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
-class MEDCORE_EXPORT medStorage
+class MEDCORELEGACY_EXPORT medStorage
 {
 public:
      medStorage();

--- a/src/medCoreLegacy/gui/commonWidgets/medButton.h
+++ b/src/medCoreLegacy/gui/commonWidgets/medButton.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,16 +13,16 @@
 
 #pragma once
 
-#include <medCoreExport.h>
+#include <QWidget>
 
-#include <QtWidgets/QWidget>
+#include <medCoreLegacyExport.h>
 
 class medButtonPrivate;
 
 /**
  * @brief General custom button that loads shows an icon.
  */
-class MEDCORE_EXPORT medButton : public QWidget
+class MEDCORELEGACY_EXPORT medButton : public QWidget
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/commonWidgets/medDropSite.h
+++ b/src/medCoreLegacy/gui/commonWidgets/medDropSite.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,15 +13,15 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
-#include <QtWidgets/QLabel>
+#include <QLabel>
 
 #include <medDataIndex.h>
 
+#include <medCoreLegacyExport.h>
+
 class medDropSitePrivate;
 
-class MEDCORE_EXPORT medDropSite : public QLabel
+class MEDCORELEGACY_EXPORT medDropSite : public QLabel
 {
     Q_OBJECT
 
@@ -49,7 +49,7 @@ signals:
 
     /** Signal emitted when the user clicks on the medDropSite. */
     void clicked();
-    
+
 protected:
     void dragEnterEvent(QDragEnterEvent *event);
     void dragMoveEvent(QDragMoveEvent *event);
@@ -57,7 +57,7 @@ protected:
     void dropEvent(QDropEvent *event);
     void paintEvent(QPaintEvent *event);
     void mousePressEvent(QMouseEvent* event);
-    
+
 private:
     medDropSitePrivate *d;
 };

--- a/src/medCoreLegacy/gui/commonWidgets/medGroupBox.h
+++ b/src/medCoreLegacy/gui/commonWidgets/medGroupBox.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,17 +13,18 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <QGroupBox>
 #include <QChildEvent>
+
+#include <medCoreLegacyExport.h>
+
 class medGroupBoxPrivate;
 
 /**
  * @brief Extends a QGroupBox to make it collapsible.
  *
  */
-class MEDCORE_EXPORT medGroupBox : public QGroupBox
+class MEDCORELEGACY_EXPORT medGroupBox : public QGroupBox
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/commonWidgets/medListWidget.h
+++ b/src/medCoreLegacy/gui/commonWidgets/medListWidget.h
@@ -13,15 +13,17 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 #include <QtGui>
 #include <QDebug>
+#include <QListWidget>
+
+#include <medCoreLegacyExport.h>
 
 /**
   * QListWidget doesn't seem to be able to resize itself to its content
   * medListWidget should do so.
   */
-class MEDCORE_EXPORT medListWidget : public QListWidget
+class MEDCORELEGACY_EXPORT medListWidget : public QListWidget
 {
 public:
     medListWidget(QWidget *parent = 0):QListWidget(parent)

--- a/src/medCoreLegacy/gui/commonWidgets/medProgressionStack.h
+++ b/src/medCoreLegacy/gui/commonWidgets/medProgressionStack.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,9 +13,9 @@
 
 #pragma once
 
-#include <medCoreExport.h>
+#include <QWidget>
 
-#include <QtWidgets/QWidget>
+#include <medCoreLegacyExport.h>
 
 class medJobItem;
 class medProgressionStackPrivate;
@@ -26,7 +26,7 @@ class medProgressionStackPrivate;
  * All visible jobs will be managed here. The class stores pointers in hashTables to identify the sender of status messages
  * It provides methods to communicate with the jobItems (e.g. to cancel the job)
  */
-class MEDCORE_EXPORT medProgressionStack : public QWidget
+class MEDCORELEGACY_EXPORT medProgressionStack : public QWidget
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/commonWidgets/medSliderSpinboxPair.h
+++ b/src/medCoreLegacy/gui/commonWidgets/medSliderSpinboxPair.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,11 +13,11 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 #include <QtGui>
-#include <medCoreExport.h>
 
-class MEDCORE_EXPORT medSliderSpinboxPair: public QWidget {
+#include <medCoreLegacyExport.h>
+
+class MEDCORELEGACY_EXPORT medSliderSpinboxPair: public QWidget {
 
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/commonWidgets/medStatusBar.h
+++ b/src/medCoreLegacy/gui/commonWidgets/medStatusBar.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -16,8 +16,9 @@
 #include <QStatusBar>
 #include <QWidget>
 #include <QBoxLayout>
-#include <medCoreExport.h>
 #include <medMessageController.h>
+
+#include <medCoreLegacyExport.h>
 
 class medStatusBarPrivate;
 
@@ -26,7 +27,7 @@ class medStatusBarPrivate;
 * @author Alexandre Abadie
 * @brief  This is extended QStatusBar that can display custom messages.
 */
-class MEDCORE_EXPORT medStatusBar : public QStatusBar
+class MEDCORELEGACY_EXPORT medStatusBar : public QStatusBar
 {
     Q_OBJECT
 public:

--- a/src/medCoreLegacy/gui/database/medDatabaseCompactWidget.h
+++ b/src/medCoreLegacy/gui/database/medDatabaseCompactWidget.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -14,18 +14,18 @@
 #pragma once
 
 #include <QWidget>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medDatabaseCompactWidgetPrivate;
 class medDatabaseView;
 class medDatabasePreview;
 class medDataIndex;
 
-
 /**
 * @brief
 */
-class MEDCORE_EXPORT medDatabaseCompactWidget: public QWidget
+class MEDCORELEGACY_EXPORT medDatabaseCompactWidget: public QWidget
 {
     Q_OBJECT
 public :

--- a/src/medCoreLegacy/gui/database/medDatabaseEditItemDialog.h
+++ b/src/medCoreLegacy/gui/database/medDatabaseEditItemDialog.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -14,40 +14,39 @@
 #pragma once
 
 #include <medDataIndex.h>
+
 #include <QDialog>
 
+#include <medCoreLegacyExport.h>
 
 class medAbstractDatabaseItem;
-
 class medDatabaseEditItemDialogPrivate;
-
-
 /**
  * @brief
  */
-class medDatabaseEditItemDialog: public QDialog
+class MEDCORELEGACY_EXPORT medDatabaseEditItemDialog: public QDialog
 {
     Q_OBJECT
 
 public:
-    medDatabaseEditItemDialog(QList<QString> attributes, QList<QVariant> data, QWidget *parent, 
+    medDatabaseEditItemDialog(QList<QString> attributes, QList<QVariant> data, QWidget *parent,
          bool displayPersistency=false,  bool persistent=false);
 
     virtual ~medDatabaseEditItemDialog();
 
     QVariant value(QString attribute);
-    
+
     bool isPersistent();
 
 public slots:
-    
+
     void setValue(const QString &value);
     void setCharValue(const QString &value);
     void setValue(const int &value);
     void setValue(const QDate &value);
-    
+
     void cancel();
-    
+
     void validate();
 
 

--- a/src/medCoreLegacy/gui/database/medDatabasePreview.h
+++ b/src/medCoreLegacy/gui/database/medDatabasePreview.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -16,14 +16,14 @@
 #include <QGraphicsView>
 #include <QGraphicsScene>
 #include <QImage>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medDataIndex;
 class QLabel;
 
-
 class medDatabasePreviewStaticScenePrivate;
-class MEDCORE_EXPORT medDatabasePreviewStaticScene: public QGraphicsScene
+class MEDCORELEGACY_EXPORT medDatabasePreviewStaticScene: public QGraphicsScene
 {
     Q_OBJECT
 public:
@@ -45,7 +45,7 @@ private :
 
 
 class medDatabasePreviewDynamicScenePrivate;
-class MEDCORE_EXPORT medDatabasePreviewDynamicScene: public medDatabasePreviewStaticScene
+class MEDCORELEGACY_EXPORT medDatabasePreviewDynamicScene: public medDatabasePreviewStaticScene
 {
     Q_OBJECT
 public:
@@ -64,7 +64,7 @@ private:
 
 
 class medDatabasePreviewPrivate;
-class MEDCORE_EXPORT medDatabasePreview: public QGraphicsView
+class MEDCORELEGACY_EXPORT medDatabasePreview: public QGraphicsView
 {
     Q_OBJECT
 public :

--- a/src/medCoreLegacy/gui/database/medDatabaseSearchPanel.h
+++ b/src/medCoreLegacy/gui/database/medDatabaseSearchPanel.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -14,8 +14,8 @@
 #pragma once
 
 #include <medToolBox.h>
-#include <medCoreExport.h>
 
+#include <medCoreLegacyExport.h>
 
 class medDatabaseSearchPanelPrivate;
 
@@ -39,7 +39,7 @@ private:
 
 };
 
-class MEDCORE_EXPORT medDatabaseSearchPanel : public medToolBox
+class MEDCORELEGACY_EXPORT medDatabaseSearchPanel : public medToolBox
 {
     Q_OBJECT
 public:

--- a/src/medCoreLegacy/gui/database/medDatabaseView.h
+++ b/src/medCoreLegacy/gui/database/medDatabaseView.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,16 +13,16 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <QtGui>
 #include <QtWidgets>
+
+#include <medCoreLegacyExport.h>
 
 class medDataIndex;
 class medDatabaseModel;
 class medDatabaseViewPrivate;
 
-class MEDCORE_EXPORT medDatabaseView : public QTreeView
+class MEDCORELEGACY_EXPORT medDatabaseView : public QTreeView
 {
     Q_OBJECT
 
@@ -40,7 +40,7 @@ signals:
 
     /** Signal emitted when user clicks on a study item. */
     void studyClicked(const medDataIndex &index);
-    
+
     /** Signal emitted when user clicks on a series item. */
     void seriesClicked(const medDataIndex &index);
 

--- a/src/medCoreLegacy/gui/factories/medSettingsWidgetFactory.h
+++ b/src/medCoreLegacy/gui/factories/medSettingsWidgetFactory.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,9 +13,10 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 #include <dtkCoreSupport/dtkAbstractFactory.h>
 #include <QtCore>
+
+#include <medCoreLegacyExport.h>
 
 class medSettingsWidget;
 class medSettingsWidgetFactoryPrivate;
@@ -24,7 +25,7 @@ struct medSettingDetails;
 /**
  * @brief This factory creates Widgets that are pages in the medSettingsEditor widget.
 */
-class MEDCORE_EXPORT medSettingsWidgetFactory : public dtkAbstractFactory
+class MEDCORELEGACY_EXPORT medSettingsWidgetFactory : public dtkAbstractFactory
 {
   Q_OBJECT
 
@@ -97,7 +98,7 @@ private:
  * and a function to allocate memory.
  *
  */
-struct MEDCORE_EXPORT medSettingDetails{
+struct MEDCORELEGACY_EXPORT medSettingDetails{
     QString name; /** Readable name*/
     QString description; /** (tooltip) short description */
     medSettingsWidgetFactory::medSettingsWidgetCreator creator; /** function pointer allocating memory for the widget*/

--- a/src/medCoreLegacy/gui/factories/medToolBoxFactory.h
+++ b/src/medCoreLegacy/gui/factories/medToolBoxFactory.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,11 +13,11 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <dtkCoreSupport/dtkAbstractFactory.h>
 
 #include <QtCore>
+
+#include <medCoreLegacyExport.h>
 
 class medToolBox;
 class medToolBoxFactoryPrivate;
@@ -43,7 +43,7 @@ struct medToolBoxDetails;
  * The details for each toolbox are stored in a struct of type medToolBoxDetails.
  */
 
-class MEDCORE_EXPORT medToolBoxFactory : public dtkAbstractFactory
+class MEDCORELEGACY_EXPORT medToolBoxFactory : public dtkAbstractFactory
 {
     Q_OBJECT
 
@@ -115,7 +115,7 @@ private:
  * and a function to allocate memory.
  *
  */
-struct MEDCORE_EXPORT medToolBoxDetails{
+struct MEDCORELEGACY_EXPORT medToolBoxDetails{
     QString name; /** Readable name*/
     QString description; /** (tooltip) short description of the Toolbox */
     QStringList categories; /** List of categories the toolbox falls in*/

--- a/src/medCoreLegacy/gui/factories/medWorkspaceFactory.h
+++ b/src/medCoreLegacy/gui/factories/medWorkspaceFactory.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,16 +13,16 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <dtkCoreSupport/dtkAbstractFactory.h>
 
 #include <QtCore>
 
+#include <medCoreLegacyExport.h>
+
 class medAbstractWorkspaceLegacy;
 class medWorkspaceFactoryPrivate;
 
-class MEDCORE_EXPORT medWorkspaceFactory : public dtkAbstractFactory
+class MEDCORELEGACY_EXPORT medWorkspaceFactory : public dtkAbstractFactory
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/lookUpTables/medClutEditor.h
+++ b/src/medCoreLegacy/gui/lookUpTables/medClutEditor.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,10 +13,10 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <QtGui>
 #include <QtWidgets>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractData;
 class medAbstractImageView;
@@ -35,7 +35,7 @@ class medClutEditorVertex : public QObject, public QGraphicsItem
 
 public:
     medClutEditorVertex(QPointF value, QPointF coord, QColor color = Qt::white,
-			QGraphicsItem *parent = 0);
+            QGraphicsItem *parent = 0);
     medClutEditorVertex( const medClutEditorVertex & other,
                          QGraphicsItem *parent = 0);
     ~medClutEditorVertex();
@@ -53,7 +53,7 @@ public:
     void initiateMove();
     void finalizeMove();
     void forceGeometricalConstraints( const QRectF & limits,
-				      bool inManhattan = false );
+                      bool inManhattan = false );
 
     void interpolate( medClutEditorVertex * pred, medClutEditorVertex * next );
 
@@ -107,7 +107,7 @@ public:
 
     void initiateMoveSelection();
     void constrainMoveSelection( medClutEditorVertex * driver,
-				 bool inManhattan = false );
+                 bool inManhattan = false );
     void finalizeMoveSelection();
     void updateCoordinates();
 
@@ -141,7 +141,7 @@ signals:
     void vertexChanged();
     void vertexRemoved();
     void vertexAdded();
-    
+
 // public slots:
 //     void onDeleteVertex(medClutEditorVertex * v);
 
@@ -251,7 +251,7 @@ protected:
 
 class medClutEditorPrivate;
 
-class MEDCORE_EXPORT medClutEditor : public QWidget
+class MEDCORELEGACY_EXPORT medClutEditor : public QWidget
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/medAbstractWorkspaceLegacy.h
+++ b/src/medCoreLegacy/gui/medAbstractWorkspaceLegacy.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -16,8 +16,7 @@
 #include <QtCore>
 #include <QtGui>
 
-#include <medCoreExport.h>
-
+#include <medCoreLegacyExport.h>
 struct QUuid;
 class QListWidgetItem;
 class QAction;
@@ -46,7 +45,7 @@ class medViewParameterGroup;
 class medLayerParameterGroup;
 
 class medAbstractWorkspaceLegacyPrivate;
-class MEDCORE_EXPORT medAbstractWorkspaceLegacy : public QObject
+class MEDCORELEGACY_EXPORT medAbstractWorkspaceLegacy : public QObject
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/medLayoutChooser.h
+++ b/src/medCoreLegacy/gui/medLayoutChooser.h
@@ -13,13 +13,13 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <QTableWidget>
+
+#include <medCoreLegacyExport.h>
 
 class medLayoutChooserPrivate;
 
-class MEDCORE_EXPORT medLayoutChooser : public QTableWidget
+class MEDCORELEGACY_EXPORT medLayoutChooser : public QTableWidget
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/medLinkMenu.h
+++ b/src/medCoreLegacy/gui/medLinkMenu.h
@@ -13,17 +13,17 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 #include <QtGui>
 #include <QtWidgets>
 
 #include <medAbstractParameterGroup.h>
 
+#include <medCoreLegacyExport.h>
 
 class medLinkMenuPrivate;
 
 
-class MEDCORE_EXPORT medLinkMenu : public QPushButton
+class MEDCORELEGACY_EXPORT medLinkMenu : public QPushButton
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/medPacsSelector.h
+++ b/src/medCoreLegacy/gui/medPacsSelector.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,10 +15,11 @@
 
 class medToolBoxPacsSelectorPrivate;
 
-#include <medCoreExport.h>
 #include <QWidget>
 
-class MEDCORE_EXPORT medPacsSelector : public QWidget
+#include <medCoreLegacyExport.h>
+
+class MEDCORELEGACY_EXPORT medPacsSelector : public QWidget
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/medTabbedViewContainers.h
+++ b/src/medCoreLegacy/gui/medTabbedViewContainers.h
@@ -16,7 +16,8 @@
 #include <QtGui>
 #include <QUuid>
 #include <QtWidgets>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractData;
 class medAbstractView;
@@ -31,7 +32,7 @@ class medTabbedViewContainersPrivate;
  * There is one such stack per medViewWorkspace.
  *
 */
-class MEDCORE_EXPORT medTabbedViewContainers : public QTabWidget
+class MEDCORELEGACY_EXPORT medTabbedViewContainers : public QTabWidget
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/medToolBoxContainer.h
+++ b/src/medCoreLegacy/gui/medToolBoxContainer.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,14 +13,14 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <QtWidgets/QScrollArea>
+
+#include <medCoreLegacyExport.h>
 
 class medToolBox;
 class medToolBoxContainerPrivate;
 
-class MEDCORE_EXPORT medToolBoxContainer : public QScrollArea
+class MEDCORELEGACY_EXPORT medToolBoxContainer : public QScrollArea
 {
     Q_OBJECT
 
@@ -32,9 +32,9 @@ public:
     void removeToolBox(medToolBox *toolBox);
     void insertToolBox(int index, medToolBox* toolBox);
     void clear();
-    
+
     QList<medToolBox*> toolBoxes() const;
-    
+
 private:
     medToolBoxContainerPrivate *d;
 };

--- a/src/medCoreLegacy/gui/settingsWidgets/medDatabaseSettingsWidget.h
+++ b/src/medCoreLegacy/gui/settingsWidgets/medDatabaseSettingsWidget.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,13 +13,14 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 #include <medSettingsWidget.h>
 #include <QWidget>
 
+#include <medCoreLegacyExport.h>
+
 class medDatabaseSettingsWidgetPrivate;
 
-class MEDCORE_EXPORT medDatabaseSettingsWidget : public medSettingsWidget
+class MEDCORELEGACY_EXPORT medDatabaseSettingsWidget : public medSettingsWidget
 {
     Q_OBJECT
     MED_SETTINGS_INTERFACE("Database","Database Settings")

--- a/src/medCoreLegacy/gui/settingsWidgets/medSettingsEditor.h
+++ b/src/medCoreLegacy/gui/settingsWidgets/medSettingsEditor.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,9 +13,10 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 #include <QWidget>
 #include <QTabWidget>
+
+#include <medCoreLegacyExport.h>
 
 class medSettingsEditorPrivate;
 
@@ -28,7 +29,7 @@ class medSettingsEditorPrivate;
  * There is also an alternative advanced tree listing all the sections and keys from the application qSetting.
  *
 */
-class MEDCORE_EXPORT medSettingsEditor : public QWidget
+class MEDCORELEGACY_EXPORT medSettingsEditor : public QWidget
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/settingsWidgets/medSettingsWidget.h
+++ b/src/medCoreLegacy/gui/settingsWidgets/medSettingsWidget.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,8 +13,9 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 #include <QWidget>
+
+#include <medCoreLegacyExport.h>
 
 class medSettingsWidgetPrivate;
 
@@ -24,7 +25,7 @@ class medSettingsWidgetPrivate;
  * All the pages in the medSettingsEditor must inherit from this class.
  *
 */
-class MEDCORE_EXPORT medSettingsWidget : public QWidget
+class MEDCORELEGACY_EXPORT medSettingsWidget : public QWidget
 {
     Q_OBJECT
 public:

--- a/src/medCoreLegacy/gui/settingsWidgets/medStartupSettingsWidget.h
+++ b/src/medCoreLegacy/gui/settingsWidgets/medStartupSettingsWidget.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,13 +13,14 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 #include <medSettingsWidget.h>
 #include <QWidget>
 
+#include <medCoreLegacyExport.h>
+
 class medStartupSettingsWidgetPrivate;
 
-class MEDCORE_EXPORT medStartupSettingsWidget : public medSettingsWidget
+class MEDCORELEGACY_EXPORT medStartupSettingsWidget : public medSettingsWidget
 {
     Q_OBJECT
     MED_SETTINGS_INTERFACE("Start Up","Startup settings")

--- a/src/medCoreLegacy/gui/toolboxes/medActionsToolBox.h
+++ b/src/medCoreLegacy/gui/toolboxes/medActionsToolBox.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,11 +15,12 @@
 
 #include <medDataIndex.h>
 #include <medToolBox.h>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medActionsToolBoxPrivate;
 
-class MEDCORE_EXPORT medActionsToolBox : public medToolBox
+class MEDCORELEGACY_EXPORT medActionsToolBox : public medToolBox
 {
     Q_OBJECT
 public:
@@ -51,14 +52,14 @@ signals:
 
     /** Emitted when the 'Save' button is clicked. */
     void saveClicked();
-    
-    /** Emitted when the 'new Patient' button is clicked. */   
+
+    /** Emitted when the 'new Patient' button is clicked. */
     void newPatientClicked();
-    
-    /** Emitted when the 'new Study' button is clicked. */   
+
+    /** Emitted when the 'new Study' button is clicked. */
     void newStudyClicked();
-    
-    /** Emitted when the 'Edit' button is clicked. */   
+
+    /** Emitted when the 'Edit' button is clicked. */
     void editClicked();
 
 public slots:

--- a/src/medCoreLegacy/gui/toolboxes/medBrowserPacsHostToolBox.h
+++ b/src/medCoreLegacy/gui/toolboxes/medBrowserPacsHostToolBox.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -14,11 +14,12 @@
 #pragma once
 
 #include <medToolBox.h>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medBrowserPacsHostToolBoxPrivate;
 
-class MEDCORE_EXPORT medBrowserPacsHostToolBox : public medToolBox
+class MEDCORELEGACY_EXPORT medBrowserPacsHostToolBox : public medToolBox
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/toolboxes/medBrowserPacsNodesToolBox.h
+++ b/src/medCoreLegacy/gui/toolboxes/medBrowserPacsNodesToolBox.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -14,11 +14,12 @@
 #pragma once
 
 #include <medToolBox.h>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medBrowserPacsNodesToolBoxPrivate;
 
-class MEDCORE_EXPORT medBrowserPacsNodesToolBox : public medToolBox
+class MEDCORELEGACY_EXPORT medBrowserPacsNodesToolBox : public medToolBox
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/toolboxes/medBrowserPacsSearchToolBox.h
+++ b/src/medCoreLegacy/gui/toolboxes/medBrowserPacsSearchToolBox.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -14,11 +14,12 @@
 #pragma once
 
 #include <medToolBox.h>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medBrowserPacsSearchToolBoxPrivate;
 
-class MEDCORE_EXPORT medBrowserPacsSearchToolBox : public medToolBox
+class MEDCORELEGACY_EXPORT medBrowserPacsSearchToolBox : public medToolBox
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/toolboxes/medCompositeDataSetImporterAbstractToolBox.h
+++ b/src/medCoreLegacy/gui/toolboxes/medCompositeDataSetImporterAbstractToolBox.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -14,14 +14,15 @@
 #pragma once
 
 #include <medToolBox.h>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medCompositeDataSetImporterSelectorToolBox;
 class medCompositeDataSetImporterAbstractToolBoxPrivate;
 class dtkAbstractProcess;
 class medAbstractData;
 
-class MEDCORE_EXPORT medCompositeDataSetImporterAbstractToolBox : public medToolBox
+class MEDCORELEGACY_EXPORT medCompositeDataSetImporterAbstractToolBox : public medToolBox
 {
     Q_OBJECT
 public:
@@ -35,8 +36,8 @@ public:
 
 public slots:
     virtual bool import() = 0;
-    virtual void reset()  {};
-    virtual void load() {};
+    virtual void reset()  {}
+    virtual void load() {}
 
 protected:
     medCompositeDataSetImporterSelectorToolBox *parent();

--- a/src/medCoreLegacy/gui/toolboxes/medCompositeDataSetImporterSelectorToolBox.h
+++ b/src/medCoreLegacy/gui/toolboxes/medCompositeDataSetImporterSelectorToolBox.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,9 +15,11 @@
 
 #include <medToolBox.h>
 
+#include <medCoreLegacyExport.h>
+
 class medCompositeDataSetImporterSelectorToolBoxPrivate;
 
-class MEDCORE_EXPORT medCompositeDataSetImporterSelectorToolBox : public medToolBox
+class MEDCORELEGACY_EXPORT medCompositeDataSetImporterSelectorToolBox : public medToolBox
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/toolboxes/medDiffusionAbstractToolBox.h
+++ b/src/medCoreLegacy/gui/toolboxes/medDiffusionAbstractToolBox.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,13 +13,14 @@
 
 #pragma once
 
-#include "medToolBox.h"
-#include "medCoreExport.h"
+#include <medToolBox.h>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractDiffusionProcess;
 class dtkPlugin;
 
-class MEDCORE_EXPORT medDiffusionAbstractToolBox : public medToolBox
+class MEDCORELEGACY_EXPORT medDiffusionAbstractToolBox : public medToolBox
 {
     Q_OBJECT
 public:
@@ -33,18 +34,18 @@ public:
      *
      */
     virtual dtkPlugin *plugin()const = 0;
-    
+
     virtual QString processName() = 0;
     virtual void setProcessParameters(medAbstractDiffusionProcess *process) = 0;
 };
 
-class MEDCORE_EXPORT medDiffusionScalarMapsAbstractToolBox : public medDiffusionAbstractToolBox
+class MEDCORELEGACY_EXPORT medDiffusionScalarMapsAbstractToolBox : public medDiffusionAbstractToolBox
 {
     Q_OBJECT
 public:
     medDiffusionScalarMapsAbstractToolBox(QWidget *parentToolBox = 0);
     virtual ~medDiffusionScalarMapsAbstractToolBox();
-    
+
 signals:
     void processStartRequested();
 };

--- a/src/medCoreLegacy/gui/toolboxes/medDiffusionSelectorToolBox.h
+++ b/src/medCoreLegacy/gui/toolboxes/medDiffusionSelectorToolBox.h
@@ -13,17 +13,17 @@
 
 #pragma once
 
-#include "medToolBox.h"
-#include "medCoreExport.h"
-
+#include <medToolBox.h>
 #include <medAbstractImageData.h>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractDiffusionProcess;
 class medAbstractImageData;
 class medDiffusionSelectorToolBoxPrivate;
 class medDataIndex;
 
-class MEDCORE_EXPORT medDiffusionSelectorToolBox : public medToolBox
+class MEDCORELEGACY_EXPORT medDiffusionSelectorToolBox : public medToolBox
 {
     Q_OBJECT
 public:

--- a/src/medCoreLegacy/gui/toolboxes/medFilteringAbstractToolBox.h
+++ b/src/medCoreLegacy/gui/toolboxes/medFilteringAbstractToolBox.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,14 +13,15 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 #include <medToolBox.h>
+
+#include <medCoreLegacyExport.h>
 
 class medFilteringSelectorToolBox;
 class medFilteringAbstractToolBoxPrivate;
 class medAbstractData;
 
-class MEDCORE_EXPORT medFilteringAbstractToolBox : public medToolBox
+class MEDCORELEGACY_EXPORT medFilteringAbstractToolBox : public medToolBox
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/toolboxes/medFilteringSelectorToolBox.h
+++ b/src/medCoreLegacy/gui/toolboxes/medFilteringSelectorToolBox.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,9 +13,10 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 #include <medToolBox.h>
 #include <medDataIndex.h>
+
+#include <medCoreLegacyExport.h>
 
 class medFilteringSelectorToolBoxPrivate;
 class medAbstractData;
@@ -26,7 +27,7 @@ class medFilteringAbstractToolBox;
  *
  * This toolbox provides a comboBox to switch between filtering process plugins and buttons to store results in a file or database.
  */
-class MEDCORE_EXPORT medFilteringSelectorToolBox : public medToolBox
+class MEDCORELEGACY_EXPORT medFilteringSelectorToolBox : public medToolBox
 {
     Q_OBJECT
 public:

--- a/src/medCoreLegacy/gui/toolboxes/medRegistrationAbstractToolBox.h
+++ b/src/medCoreLegacy/gui/toolboxes/medRegistrationAbstractToolBox.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -14,12 +14,13 @@
 #pragma once
 
 #include <medToolBox.h>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medRegistrationSelectorToolBox;
 class medRegistrationAbstractToolBoxPrivate;
 
-class MEDCORE_EXPORT medRegistrationAbstractToolBox : public medToolBox
+class MEDCORELEGACY_EXPORT medRegistrationAbstractToolBox : public medToolBox
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/toolboxes/medRegistrationSelectorToolBox.h
+++ b/src/medCoreLegacy/gui/toolboxes/medRegistrationSelectorToolBox.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -14,8 +14,9 @@
 #pragma once
 
 #include <medToolBox.h>
-#include <medCoreExport.h>
 #include <medJobItem.h>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractRegistrationProcess;
 class medAbstractImageView;
@@ -23,7 +24,7 @@ class medAbstractImageData;
 class medDataIndex;
 class medRegistrationSelectorToolBoxPrivate;
 
-class MEDCORE_EXPORT medRegistrationSelectorToolBox : public medToolBox
+class MEDCORELEGACY_EXPORT medRegistrationSelectorToolBox : public medToolBox
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/toolboxes/medSegmentationAbstractToolBox.h
+++ b/src/medCoreLegacy/gui/toolboxes/medSegmentationAbstractToolBox.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -14,14 +14,15 @@
 #pragma once
 
 #include <medToolBox.h>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractData;
 class medSegmentationSelectorToolBox;
 class medSegmentationAbstractToolBoxPrivate;
 
 //! Base class for custom segmentation algoithms
-class MEDCORE_EXPORT medSegmentationAbstractToolBox : public medToolBox
+class MEDCORELEGACY_EXPORT medSegmentationAbstractToolBox : public medToolBox
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/toolboxes/medSegmentationSelectorToolBox.h
+++ b/src/medCoreLegacy/gui/toolboxes/medSegmentationSelectorToolBox.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -14,13 +14,14 @@
 #pragma once
 
 #include <medToolBox.h>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medViewEventFilter;
 class medSegmentationAbstractToolBox;
 
 class medSegmentationSelectorToolBoxPrivate;
-class MEDCORE_EXPORT medSegmentationSelectorToolBox : public medToolBox
+class MEDCORELEGACY_EXPORT medSegmentationSelectorToolBox : public medToolBox
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/toolboxes/medToolBox.h
+++ b/src/medCoreLegacy/gui/toolboxes/medToolBox.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,10 +13,10 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <QtGui>
 #include <QtWidgets>
+
+#include <medCoreLegacyExport.h>
 
 class dtkAbstractView;
 class medAbstractData;
@@ -34,7 +34,7 @@ class dtkPlugin;
  * They can be minimized, hidden, updated when a view is selected, etc...
  *
 */
-class MEDCORE_EXPORT medToolBox : public QWidget
+class MEDCORELEGACY_EXPORT medToolBox : public QWidget
 {
     Q_OBJECT
 
@@ -100,7 +100,7 @@ public slots:
 
 protected slots:
     void onAboutButtonClicked();
-    
+
 private:
     medToolBoxPrivate *d;
 };

--- a/src/medCoreLegacy/gui/toolboxes/medToolBoxBody.h
+++ b/src/medCoreLegacy/gui/toolboxes/medToolBoxBody.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,15 +13,15 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <QtGui>
 #include <QtWidgets>
+
+#include <medCoreLegacyExport.h>
 
 class medToolBoxBodyPrivate;
 class medToolBoxTab;
 
-class MEDCORE_EXPORT medToolBoxBody : public QFrame
+class MEDCORELEGACY_EXPORT medToolBoxBody : public QFrame
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/toolboxes/medToolBoxHeader.h
+++ b/src/medCoreLegacy/gui/toolboxes/medToolBoxHeader.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,10 +13,11 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <QtGui>
 #include <QtWidgets>
+
+#include <medCoreLegacyExport.h>
+
 
 class medToolBoxHeaderPrivate;
 class medButton;
@@ -27,7 +28,7 @@ class medButton;
  * This is a QFrame that draws a rectangle, a title, and reacts to mousePressEvent()s.
  *
 */
-class MEDCORE_EXPORT medToolBoxHeader : public QFrame
+class MEDCORELEGACY_EXPORT medToolBoxHeader : public QFrame
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/toolboxes/medToolBoxTab.h
+++ b/src/medCoreLegacy/gui/toolboxes/medToolBoxTab.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,14 +13,14 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <QtGui>
 #include <QtWidgets>
 
+#include <medCoreLegacyExport.h>
+
 class medToolBoxTabPrivate;
 
-class MEDCORE_EXPORT medToolBoxTab : public QTabWidget
+class MEDCORELEGACY_EXPORT medToolBoxTab : public QTabWidget
 {
     Q_OBJECT
     Q_PROPERTY(int height READ height WRITE setFixedHeight)

--- a/src/medCoreLegacy/gui/viewContainers/medViewContainer.h
+++ b/src/medCoreLegacy/gui/viewContainers/medViewContainer.h
@@ -15,8 +15,7 @@
 
 #include <QFrame>
 
-#include <medCoreExport.h>
-
+#include <medCoreLegacyExport.h>
 
 struct QUuid;
 class medAbstractView;
@@ -27,7 +26,7 @@ class medViewContainerSplitter;
 class medAbstractParameter;
 
 class medViewContainerPrivate;
-class MEDCORE_EXPORT medViewContainer: public QFrame
+class MEDCORELEGACY_EXPORT medViewContainer: public QFrame
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/viewContainers/medViewContainerManager.h
+++ b/src/medCoreLegacy/gui/viewContainers/medViewContainerManager.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,14 +15,15 @@
 
 #include <QObject>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
+
 
 struct QUuid;
 class medViewContainer;
 
 class medViewContainerManagerPrivate;
 
-class MEDCORE_EXPORT medViewContainerManager : public QObject
+class MEDCORELEGACY_EXPORT medViewContainerManager : public QObject
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/gui/viewContainers/medViewContainerSplitter.h
+++ b/src/medCoreLegacy/gui/viewContainers/medViewContainerSplitter.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,13 +15,13 @@
 
 #include <QSplitter>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class medViewContainer;
 class medDataIndex;
 struct QUuid;
 
-class MEDCORE_EXPORT medViewContainerSplitter: public QSplitter
+class MEDCORELEGACY_EXPORT medViewContainerSplitter: public QSplitter
 {
     Q_OBJECT
 public:

--- a/src/medCoreLegacy/medAbstractDataSource.h
+++ b/src/medCoreLegacy/medAbstractDataSource.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,7 +15,8 @@
 
 #include <QWidget>
 #include <QtCore>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medToolBox;
 class medDataIndex;
@@ -28,7 +29,7 @@ class medAbstractData;
  * a source selection widget and several ToolBoxes.
  * All dynamic data source implementation should derive from this class.
  **/
-class MEDCORE_EXPORT medAbstractDataSource : public QObject
+class MEDCORELEGACY_EXPORT medAbstractDataSource : public QObject
 {
     Q_OBJECT
 
@@ -53,10 +54,10 @@ public:
 
     /** Returns all ToolBoxes owned by the source data plugin*/
     virtual QList<medToolBox*> getToolBoxes() = 0;
-	
-	/** Returns a short description of the data source */
-	virtual QString description() const = 0;
-	
+
+    /** Returns a short description of the data source */
+    virtual QString description() const = 0;
+
 signals:
     /** A source data may emit a signal to a file on disk when it successfully received the data and is ready for importing*/
     void dataToImportReceived(QString pathToData);

--- a/src/medCoreLegacy/medAbstractDataSourceFactory.h
+++ b/src/medCoreLegacy/medAbstractDataSourceFactory.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,9 +13,10 @@
 
 #pragma once
 
-#include <medCoreExport.h>
 #include <dtkCoreSupport/dtkAbstractFactory.h>
 #include <QtCore>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractDataSource;
 class medAbstractDataSourceFactoryPrivate;
@@ -25,7 +26,7 @@ class medAbstractDataSourceFactoryPrivate;
  * @brief Dynamic source plugins (e.g. Shanoir, PACS, ...) factory
  * medAbstractSourceDataPlugin register to this factory.
  **/
-class MEDCORE_EXPORT medAbstractDataSourceFactory : public dtkAbstractFactory
+class MEDCORELEGACY_EXPORT medAbstractDataSourceFactory : public dtkAbstractFactory
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/medCoreLegacyExport.h
+++ b/src/medCoreLegacy/medCoreLegacyExport.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -12,11 +12,11 @@
 =========================================================================*/
 
 #ifdef WIN32
-    #ifdef medCore_EXPORTS
-        #define MEDCORE_EXPORT __declspec(dllexport) 
+    #ifdef medCoreLegacy_EXPORTS
+        #define MEDCORELEGACY_EXPORT __declspec(dllexport)
     #else
-        #define MEDCORE_EXPORT __declspec(dllimport) 
+        #define MEDCORELEGACY_EXPORT __declspec(dllimport)
     #endif
 #else
-    #define MEDCORE_EXPORT	
+    #define MEDCORELEGACY_EXPORT
 #endif

--- a/src/medCoreLegacy/medJobItem.h
+++ b/src/medCoreLegacy/medJobItem.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,7 +15,7 @@
 
 #include <QtCore>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 /**
  * @class medJobItem
@@ -41,7 +41,7 @@
  *   QThreadPool::globalInstance()->start(dynamic_cast<QRunnable*>(runProcess));
  *   @endcode
  */
-class MEDCORE_EXPORT medJobItem :  public QObject, public QRunnable
+class MEDCORELEGACY_EXPORT medJobItem :  public QObject, public QRunnable
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/medJobManager.h
+++ b/src/medCoreLegacy/medJobManager.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,8 +15,9 @@
 
 #include <QtCore/QObject>
 
-#include <medCoreExport.h>
 #include <medDataIndex.h>
+
+#include <medCoreLegacyExport.h>
 
 class medJobManagerPrivate;
 class medJobItem;
@@ -32,7 +33,7 @@ class medJobItem;
  *
  * @see medJobItem
  */
-class MEDCORE_EXPORT medJobManager : public QObject
+class MEDCORELEGACY_EXPORT medJobManager : public QObject
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/medMessageController.h
+++ b/src/medCoreLegacy/medMessageController.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -17,7 +17,7 @@
 #include <QtGui>
 #include <QtWidgets>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class medMessageControllerPrivate;
 
@@ -25,7 +25,7 @@ class medMessageControllerPrivate;
 // medMessage
 // /////////////////////////////////////////////////////////////////
 
-class MEDCORE_EXPORT medMessage : public QWidget
+class MEDCORELEGACY_EXPORT medMessage : public QWidget
 {
     Q_OBJECT
 
@@ -35,7 +35,7 @@ public:
     void startTimer();
     void stopTimer();
 
-	    
+
 protected:
     QLabel *icon;
     QTimer *timer;
@@ -81,7 +81,7 @@ public:
 // /////////////////////////////////////////////////////////////////
 
 
-class MEDCORE_EXPORT medMessageProgress : public medMessage
+class MEDCORELEGACY_EXPORT medMessageProgress : public medMessage
 {
     Q_OBJECT
 
@@ -106,7 +106,7 @@ public slots:
 // medMessageController
 // /////////////////////////////////////////////////////////////////
 
-class MEDCORE_EXPORT medMessageController : public QObject
+class MEDCORELEGACY_EXPORT medMessageController : public QObject
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/medPluginManager.h
+++ b/src/medCoreLegacy/medPluginManager.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -17,7 +17,7 @@
 
 #include <dtkCoreSupport/dtkPluginManager.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class medPluginManagerPrivate;
 
@@ -25,7 +25,7 @@ class medPluginManagerPrivate;
  * @brief Load and unload plugins for medInria.
  *
 */
-class MEDCORE_EXPORT medPluginManager : public dtkPluginManager
+class MEDCORELEGACY_EXPORT medPluginManager : public dtkPluginManager
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/medSettingsManager.h
+++ b/src/medCoreLegacy/medSettingsManager.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,13 +15,13 @@
 
 #include <QtCore>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class medSettingsManagerPrivate;
 
 
 
-class MEDCORE_EXPORT medSettingsManager : public QObject
+class MEDCORELEGACY_EXPORT medSettingsManager : public QObject
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/medViewEventFilter.h
+++ b/src/medCoreLegacy/medViewEventFilter.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -20,8 +20,9 @@
 
 #include <dtkCoreSupport/dtkAbstractObject.h>
 
-#include <medCoreExport.h>
 #include <QMouseEvent>
+
+#include <medCoreLegacyExport.h>
 
 //Forward declarations
 class medAbstractView;
@@ -36,9 +37,9 @@ class QGraphicsSceneMouseEvent;
  *
  * (see QObject::eventFilter & QObject::installEventFilter)
  */
-class MEDCORE_EXPORT medViewEventFilter : public dtkAbstractObject
+class MEDCORELEGACY_EXPORT medViewEventFilter : public dtkAbstractObject
 {
-    Q_OBJECT;
+    Q_OBJECT
 
 public:
              medViewEventFilter(dtkAbstractObject * parent = NULL);

--- a/src/medCoreLegacy/parameters/medAbstractParameter.h
+++ b/src/medCoreLegacy/parameters/medAbstractParameter.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -18,12 +18,12 @@
 #include <QVector3D>
 #include <QVector4D>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class QLabel;
 
 class medAbstractParameterPrivate;
-class MEDCORE_EXPORT medAbstractParameter : public QObject
+class MEDCORELEGACY_EXPORT medAbstractParameter : public QObject
 {
     Q_OBJECT
 
@@ -64,13 +64,13 @@ signals:
     void aboutToBeDestroyed();
 
 private:
-  medAbstractParameterPrivate *d; 
+  medAbstractParameterPrivate *d;
 };
 
 
 //--------------------------------------------------------------------------
 //  medAbstractTriggerParameter
-class MEDCORE_EXPORT medAbstractTriggerParameter : public medAbstractParameter
+class MEDCORELEGACY_EXPORT medAbstractTriggerParameter : public medAbstractParameter
 {
     Q_OBJECT
 public:
@@ -85,7 +85,7 @@ signals:
 };
 //--------------------------------------------------------------------------
 //  medAbstractStringParameter
-class MEDCORE_EXPORT medAbstractStringParameter : public medAbstractParameter
+class MEDCORELEGACY_EXPORT medAbstractStringParameter : public medAbstractParameter
 {
     Q_OBJECT
 public:
@@ -109,7 +109,7 @@ protected:
 };
 //--------------------------------------------------------------------------
 //  medAbstractIntParameter
-class MEDCORE_EXPORT medAbstractIntParameter : public medAbstractParameter
+class MEDCORELEGACY_EXPORT medAbstractIntParameter : public medAbstractParameter
 {
     Q_OBJECT
 public:
@@ -134,7 +134,7 @@ protected:
 };
 //--------------------------------------------------------------------------
 //  medAbstractDoubleParameter
-class MEDCORE_EXPORT medAbstractDoubleParameter : public medAbstractParameter
+class MEDCORELEGACY_EXPORT medAbstractDoubleParameter : public medAbstractParameter
 {
     Q_OBJECT
 public:
@@ -158,7 +158,7 @@ protected:
 };
 //--------------------------------------------------------------------------
 //  medAbstractBoolParameter
-class MEDCORE_EXPORT medAbstractBoolParameter : public medAbstractParameter
+class MEDCORELEGACY_EXPORT medAbstractBoolParameter : public medAbstractParameter
 {
     Q_OBJECT
 public:
@@ -185,7 +185,7 @@ protected:
 
 //--------------------------------------------------------------------------
 //  medAbstractGroupParameter
-class MEDCORE_EXPORT medAbstractGroupParameter : public medAbstractParameter
+class MEDCORELEGACY_EXPORT medAbstractGroupParameter : public medAbstractParameter
 {
     Q_OBJECT
 public:
@@ -208,7 +208,7 @@ public:
 
 class QVector2D;
 
-class MEDCORE_EXPORT medAbstractVector2DParameter : public medAbstractParameter
+class MEDCORELEGACY_EXPORT medAbstractVector2DParameter : public medAbstractParameter
 {
     Q_OBJECT
 
@@ -240,7 +240,7 @@ protected:
 
 class QVector3D;
 
-class MEDCORE_EXPORT medAbstractVector3DParameter : public medAbstractParameter
+class MEDCORELEGACY_EXPORT medAbstractVector3DParameter : public medAbstractParameter
 {
     Q_OBJECT
 
@@ -274,7 +274,7 @@ protected:
 
 class QVector4D;
 
-class MEDCORE_EXPORT medAbstractVector4DParameter : public medAbstractParameter
+class MEDCORELEGACY_EXPORT medAbstractVector4DParameter : public medAbstractParameter
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/parameters/medAbstractParameterGroup.h
+++ b/src/medCoreLegacy/parameters/medAbstractParameterGroup.h
@@ -14,13 +14,13 @@
 #pragma once
 
 #include <QtCore>
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class medAbstractView;
 class medAbstractLayeredView;
 class medAbstractParameterGroupPrivate;
 
-class MEDCORE_EXPORT medAbstractParameterGroup : public QObject
+class MEDCORELEGACY_EXPORT medAbstractParameterGroup : public QObject
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/parameters/medBoolGroupParameter.h
+++ b/src/medCoreLegacy/parameters/medBoolGroupParameter.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,18 +13,18 @@
 
 #pragma once
 
+#include <QBoxLayout>
+
 #include <medAbstractParameter.h>
 
-#include <medCoreExport.h>
-
-#include <QBoxLayout>
+#include <medCoreLegacyExport.h>
 
 class QWidget;
 
 class medBoolParameter;
 
 class medBoolGroupParameterPrivate;
-class MEDCORE_EXPORT medBoolGroupParameter : public medAbstractGroupParameter
+class MEDCORELEGACY_EXPORT medBoolGroupParameter : public medAbstractGroupParameter
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/parameters/medBoolParameter.h
+++ b/src/medCoreLegacy/parameters/medBoolParameter.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,7 +15,7 @@
 
 #include <medAbstractParameter.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class QCheckBox;
 class QPushButton;
@@ -24,7 +24,7 @@ class QSize;
 class QIcon;
 
 class medBoolParameterPrivate;
-class MEDCORE_EXPORT medBoolParameter : public medAbstractBoolParameter
+class MEDCORELEGACY_EXPORT medBoolParameter : public medAbstractBoolParameter
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/parameters/medCompositeParameter.h
+++ b/src/medCoreLegacy/parameters/medCompositeParameter.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -14,13 +14,14 @@
 #pragma once
 
 #include <medAbstractParameter.h>
+
 #include <QVariant>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class medCompositeParameterPrivate;
 
-class MEDCORE_EXPORT medCompositeParameter : public medAbstractParameter
+class MEDCORELEGACY_EXPORT medCompositeParameter : public medAbstractParameter
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/parameters/medDataListParameter.h
+++ b/src/medCoreLegacy/parameters/medDataListParameter.h
@@ -14,9 +14,10 @@
 #pragma once
 
 #include <medAbstractParameter.h>
+
 #include <QIcon>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class QComboBox;
 class QWidget;
@@ -25,7 +26,7 @@ class QStringList;
 class medDataIndex;
 
 class medDataListParameterPrivate;
-class MEDCORE_EXPORT medDataListParameter: public medAbstractParameter
+class MEDCORELEGACY_EXPORT medDataListParameter: public medAbstractParameter
 {
     Q_OBJECT
 
@@ -44,7 +45,7 @@ public:
 
 signals:
     void valuesChanged (QList <medDataIndex>);
-    
+
 private:
     medDataListParameterPrivate* d;
 };

--- a/src/medCoreLegacy/parameters/medDoubleParameter.h
+++ b/src/medCoreLegacy/parameters/medDoubleParameter.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,7 +15,7 @@
 
 #include <medAbstractParameter.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class QWidget;
 class QDoubleSpinBox;
@@ -23,7 +23,7 @@ class QSlider;
 
 
 class medDoubleParameterPrivate;
-class MEDCORE_EXPORT medDoubleParameter : public medAbstractDoubleParameter
+class MEDCORELEGACY_EXPORT medDoubleParameter : public medAbstractDoubleParameter
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/parameters/medIntParameter.h
+++ b/src/medCoreLegacy/parameters/medIntParameter.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,7 +15,7 @@
 
 #include <medAbstractParameter.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class QWidget;
 class QSpinBox;
@@ -23,7 +23,7 @@ class QSlider;
 
 
 class medIntParameterPrivate;
-class MEDCORE_EXPORT medIntParameter : public medAbstractIntParameter
+class MEDCORELEGACY_EXPORT medIntParameter : public medAbstractIntParameter
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/parameters/medLayerParameterGroup.h
+++ b/src/medCoreLegacy/parameters/medLayerParameterGroup.h
@@ -15,11 +15,12 @@
 
 #include <medAbstractParameterGroup.h>
 #include <medAbstractData.h>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medLayerParameterGroupPrivate;
 
-class MEDCORE_EXPORT medLayerParameterGroup : public medAbstractParameterGroup
+class MEDCORELEGACY_EXPORT medLayerParameterGroup : public medAbstractParameterGroup
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/parameters/medParameterGroupManager.h
+++ b/src/medCoreLegacy/parameters/medParameterGroupManager.h
@@ -15,7 +15,7 @@
 
 #include <QObject>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class medAbstractView;
 class medAbstractLayeredView;
@@ -26,7 +26,7 @@ class medAbstractData;
 
 class medParameterGroupManagerPrivate;
 
-class MEDCORE_EXPORT medParameterGroupManager : public QObject
+class MEDCORELEGACY_EXPORT medParameterGroupManager : public QObject
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/parameters/medParameterPool.h
+++ b/src/medCoreLegacy/parameters/medParameterPool.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -18,14 +18,13 @@
 #include <QVector2D>
 #include <QLabel>
 
-#include <medCoreExport.h>
-
+#include <medCoreLegacyExport.h>
 class medAbstractParameter;
 class medDataIndex;
 class medStringListParameter;
 
 class medParameterPoolPrivate;
-class MEDCORE_EXPORT medParameterPool : public QObject
+class MEDCORELEGACY_EXPORT medParameterPool : public QObject
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/parameters/medParameterPoolManager.h
+++ b/src/medCoreLegacy/parameters/medParameterPoolManager.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,7 +15,8 @@
 
 #include <QtCore/QObject>
 #include <QtCore/QHash>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medParameterPoolManagerPrivate;
 
@@ -24,7 +25,7 @@ class medAbstractParameter;
 class medParameterPool;
 class medAbstractView;
 
-class MEDCORE_EXPORT medParameterPoolManager : public QObject
+class MEDCORELEGACY_EXPORT medParameterPoolManager : public QObject
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/parameters/medPoolIndicator.h
+++ b/src/medCoreLegacy/parameters/medPoolIndicator.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,12 +13,12 @@
 
 #include <QLabel>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class medStringListParameter;
 
 class medPoolIndiactorPrivate;
-class MEDCORE_EXPORT medPoolIndicator: public QWidget
+class MEDCORELEGACY_EXPORT medPoolIndicator: public QWidget
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/parameters/medStringListParameter.h
+++ b/src/medCoreLegacy/parameters/medStringListParameter.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -16,14 +16,14 @@
 #include <medAbstractParameter.h>
 #include <QIcon>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class QComboBox;
 class QWidget;
 class QStringList;
 
 class medStringListParameterPrivate;
-class MEDCORE_EXPORT medStringListParameter: public medAbstractStringParameter
+class MEDCORELEGACY_EXPORT medStringListParameter: public medAbstractStringParameter
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/parameters/medTimeLineParameter.h
+++ b/src/medCoreLegacy/parameters/medTimeLineParameter.h
@@ -15,14 +15,14 @@
 
 #include <medAbstractParameter.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class QWidget;
 
 class medBoolParameter;
 
 class medTimeLineParameterPrivate;
-class MEDCORE_EXPORT medTimeLineParameter : public medAbstractGroupParameter
+class MEDCORELEGACY_EXPORT medTimeLineParameter : public medAbstractGroupParameter
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/parameters/medTriggerParameter.h
+++ b/src/medCoreLegacy/parameters/medTriggerParameter.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,7 +13,7 @@
 
 #include <medAbstractParameter.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class QIcon;
 class QPushButton;
@@ -21,7 +21,7 @@ class QSize;
 class QWidget;
 
 class medTriggerParameterPrivate;
-class MEDCORE_EXPORT medTriggerParameter : public medAbstractTriggerParameter
+class MEDCORELEGACY_EXPORT medTriggerParameter : public medAbstractTriggerParameter
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/parameters/medVector2DParameter.h
+++ b/src/medCoreLegacy/parameters/medVector2DParameter.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -14,12 +14,13 @@
 #pragma once
 
 #include <medAbstractParameter.h>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medVector2DParameterPrivate;
 class QVector2D;
 
-class MEDCORE_EXPORT medVector2DParameter : public medAbstractVector2DParameter
+class MEDCORELEGACY_EXPORT medVector2DParameter : public medAbstractVector2DParameter
 {
 public:
     medVector2DParameter(QString name = "Unknow Vector 2D parameter", QObject* parent = 0);

--- a/src/medCoreLegacy/parameters/medVector3DParameter.h
+++ b/src/medCoreLegacy/parameters/medVector3DParameter.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -14,12 +14,13 @@
 #pragma once
 
 #include <medAbstractParameter.h>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medVector3DParameterPrivate;
 class QVector3D;
 
-class MEDCORE_EXPORT medVector3DParameter : public medAbstractVector3DParameter
+class MEDCORELEGACY_EXPORT medVector3DParameter : public medAbstractVector3DParameter
 {
 public:
     medVector3DParameter(QString name = "Unknow Vector 3D parameter", QObject* parent = 0);

--- a/src/medCoreLegacy/parameters/medViewParameterGroup.h
+++ b/src/medCoreLegacy/parameters/medViewParameterGroup.h
@@ -14,11 +14,12 @@
 #pragma once
 
 #include <medAbstractParameterGroup.h>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medViewParameterGroupPrivate;
 
-class MEDCORE_EXPORT medViewParameterGroup : public medAbstractParameterGroup
+class MEDCORELEGACY_EXPORT medViewParameterGroup : public medAbstractParameterGroup
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/process/medAbstractDiffusionProcess.h
+++ b/src/medCoreLegacy/process/medAbstractDiffusionProcess.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,13 +13,13 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <medAbstractProcessLegacy.h>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractData;
 
-class MEDCORE_EXPORT medAbstractDiffusionProcess : public medAbstractProcessLegacy
+class MEDCORELEGACY_EXPORT medAbstractDiffusionProcess : public medAbstractProcessLegacy
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/process/medAbstractProcessLegacy.h
+++ b/src/medCoreLegacy/process/medAbstractProcessLegacy.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -16,7 +16,7 @@
 #include <dtkCoreSupport/dtkAbstractProcess.h>
 #include <medAbstractData.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class medAbstractProcessLegacyPrivate;
 
@@ -24,7 +24,7 @@ class medAbstractProcessLegacyPrivate;
 /**
  * Extending dtkAbstractProcess class to hold more specific information
  */
-class MEDCORE_EXPORT medAbstractProcessLegacy : public dtkAbstractProcess
+class MEDCORELEGACY_EXPORT medAbstractProcessLegacy : public dtkAbstractProcess
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/process/medAbstractRegistrationProcess.h
+++ b/src/medCoreLegacy/process/medAbstractRegistrationProcess.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -13,13 +13,13 @@
 
 #pragma once
 
-#include <medCoreExport.h>
-
 #include <medAbstractProcessLegacy.h>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractData;
 
-class MEDCORE_EXPORT medAbstractRegistrationProcess : public medAbstractProcessLegacy
+class MEDCORELEGACY_EXPORT medAbstractRegistrationProcess : public medAbstractProcessLegacy
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/process/medRunnableProcess.h
+++ b/src/medCoreLegacy/process/medRunnableProcess.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,7 +15,7 @@
 
 #include <medJobItem.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class medRunnableProcessPrivate;
 class dtkAbstractProcess;
@@ -30,7 +30,7 @@ class dtkAbstractProcess;
  * As for any medJobItem, a non-blocking connection is needed for
  * QThreadPool::waitForDone()
  */
-class MEDCORE_EXPORT medRunnableProcess : public medJobItem
+class MEDCORELEGACY_EXPORT medRunnableProcess : public medJobItem
 {
     Q_OBJECT
 
@@ -51,7 +51,7 @@ public slots:
 
 protected:
     virtual void internalRun();
-    
+
 private:
     medRunnableProcessPrivate *d;
 };

--- a/src/medCoreLegacy/views/interactors/medAbstractImageViewInteractor.h
+++ b/src/medCoreLegacy/views/interactors/medAbstractImageViewInteractor.h
@@ -16,14 +16,14 @@
 #include <medAbstractLayeredViewInteractor.h>
 #include <medImageViewEnum.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class medAbstractImageView;
 class medDoubleParameter;
 class medCompositeParameter;
 
 class medAbstractImageViewInteractorPrivate;
-class MEDCORE_EXPORT medAbstractImageViewInteractor : public medAbstractLayeredViewInteractor
+class MEDCORELEGACY_EXPORT medAbstractImageViewInteractor : public medAbstractLayeredViewInteractor
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/views/interactors/medAbstractInteractor.h
+++ b/src/medCoreLegacy/views/interactors/medAbstractInteractor.h
@@ -15,13 +15,13 @@
 
 #include <dtkCoreSupport/dtkAbstractViewInteractor.h>
 
-#include <medCoreExport.h>
-
 #include <QWidget>
 
 #include <medAbstractView.h>
 #include <medAbstractData.h>
 #include <medImageViewEnum.h>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractParameter;
 class medBoolParameter;
@@ -34,7 +34,7 @@ class medAbstractInteractorPrivate;
  * A medAbstractInteractor belongs to a medAbstractView and is responsible for managing
  * all the interactions for a type of medAbstractData in the medAbstractView.
  **/
-class MEDCORE_EXPORT medAbstractInteractor : public dtkAbstractViewInteractor
+class MEDCORELEGACY_EXPORT medAbstractInteractor : public dtkAbstractViewInteractor
 {
     Q_OBJECT
 
@@ -47,7 +47,7 @@ public:
 
     virtual void setInputData(medAbstractData *data);
     virtual medAbstractData *inputData() const;
-    
+
     virtual QWidget* toolBoxWidget();
     virtual QWidget* toolBarWidget();
     virtual QWidget* layerWidget();

--- a/src/medCoreLegacy/views/interactors/medAbstractLayeredViewInteractor.h
+++ b/src/medCoreLegacy/views/interactors/medAbstractLayeredViewInteractor.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,13 +15,13 @@
 
 #include <medAbstractViewInteractor.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class medAbstractLayeredView;
 class medAbstractBoolParameter;
 
 class medAbstractLayeredViewInteractorPrivate;
-class MEDCORE_EXPORT medAbstractLayeredViewInteractor : public medAbstractViewInteractor
+class MEDCORELEGACY_EXPORT medAbstractLayeredViewInteractor : public medAbstractViewInteractor
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/views/interactors/medAbstractViewInteractor.h
+++ b/src/medCoreLegacy/views/interactors/medAbstractViewInteractor.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -14,12 +14,11 @@
 #pragma once
 
 #include <medAbstractInteractor.h>
-
-#include <medCoreExport.h>
-
 #include <medAbstractView.h>
 
-class MEDCORE_EXPORT medAbstractViewInteractor : public medAbstractInteractor
+#include <medCoreLegacyExport.h>
+
+class MEDCORELEGACY_EXPORT medAbstractViewInteractor : public medAbstractInteractor
 {
     Q_OBJECT
 public:

--- a/src/medCoreLegacy/views/medAbstractImageView.h
+++ b/src/medCoreLegacy/views/medAbstractImageView.h
@@ -19,7 +19,7 @@
 #include <medAbstractImageViewNavigator.h>
 #include <medImageViewEnum.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class QVector3D;
 
@@ -43,7 +43,7 @@ class medAbstractImageViewPrivate;
  * @brief Base class for image view types in medInria
  * medAbstractImageView specializes a medAbstractLayeredView.
  **/
-class MEDCORE_EXPORT medAbstractImageView: public medAbstractLayeredView
+class MEDCORELEGACY_EXPORT medAbstractImageView: public medAbstractLayeredView
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/views/medAbstractLayeredView.h
+++ b/src/medCoreLegacy/views/medAbstractLayeredView.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,7 +15,7 @@
 
 #include <medAbstractView.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 #include <dtkCoreSupport/dtkSmartPointer.h>
 
@@ -30,7 +30,7 @@ class medStringListParameter;
 class medDataListParameter;
 
 class medAbstractLayeredViewPrivate;
-class MEDCORE_EXPORT medAbstractLayeredView : public medAbstractView
+class MEDCORELEGACY_EXPORT medAbstractLayeredView : public medAbstractView
 {
     Q_OBJECT
 
@@ -90,7 +90,7 @@ protected:
     virtual bool initialiseNavigators();
     virtual void removeInteractors(medAbstractData *data);
 
-    virtual QList<medAbstractParameter*> interactorsParameters(unsigned int layer);  
+    virtual QList<medAbstractParameter*> interactorsParameters(unsigned int layer);
 
 private slots:
     void updateDataListParameter(unsigned int layer);

--- a/src/medCoreLegacy/views/medAbstractView.h
+++ b/src/medCoreLegacy/views/medAbstractView.h
@@ -14,7 +14,8 @@
 #pragma once
 
 #include <dtkCoreSupport/dtkAbstractView.h>
-#include <medCoreExport.h>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractViewPrivate;
 
@@ -44,7 +45,7 @@ class medViewBackend {
  * medAbstractView specializes a dtkAbstractView in the context of medInria.
  * A medAbstractView contains medAbstractInteractor and medAbstractNavigator.
  **/
-class MEDCORE_EXPORT medAbstractView: public dtkAbstractView
+class MEDCORELEGACY_EXPORT medAbstractView: public dtkAbstractView
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/views/medViewFactory.h
+++ b/src/medCoreLegacy/views/medViewFactory.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,7 +15,7 @@
 
 #include <dtkCoreSupport/dtkAbstractFactory.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 #include <QStringList>
 
@@ -33,7 +33,7 @@ typedef medAbstractNavigator *(*addNavigatorCreator)(medAbstractView *parent);
 typedef medAbstractInteractor *(*addInteractorCreator)(medAbstractView *parent);
 
 class medViewFactoryPrivate;
-class MEDCORE_EXPORT medViewFactory : public dtkAbstractFactory
+class MEDCORELEGACY_EXPORT medViewFactory : public dtkAbstractFactory
 {
     Q_OBJECT
 public:

--- a/src/medCoreLegacy/views/navigators/medAbstractImageViewNavigator.h
+++ b/src/medCoreLegacy/views/navigators/medAbstractImageViewNavigator.h
@@ -16,7 +16,7 @@
 #include <medAbstractLayeredViewNavigator.h>
 #include <medImageViewEnum.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class medAbstractImageView;
 class medCompositeParameter;
@@ -24,7 +24,7 @@ class medAbstractVector3DParameter;
 class medTimeLineParameter;
 
 class medAbstractImageViewNavigatorPrivate;
-class MEDCORE_EXPORT medAbstractImageViewNavigator : public medAbstractLayeredViewNavigator
+class MEDCORELEGACY_EXPORT medAbstractImageViewNavigator : public medAbstractLayeredViewNavigator
 {
     Q_OBJECT
 
@@ -44,7 +44,7 @@ public slots:
     virtual void setOrientation(medImageView::Orientation orientation) = 0;
     virtual void setCamera(QHash<QString,QVariant>) = 0;
     virtual void moveToPosition (const QVector3D &position) = 0;
-    
+
     virtual void setCurrentTime (const double &time);
 
 private slots:

--- a/src/medCoreLegacy/views/navigators/medAbstractLayeredViewNavigator.h
+++ b/src/medCoreLegacy/views/navigators/medAbstractLayeredViewNavigator.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,9 +15,9 @@
 
 #include <medAbstractViewNavigator.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
-class MEDCORE_EXPORT medAbstractLayeredViewNavigator : public medAbstractViewNavigator
+class MEDCORELEGACY_EXPORT medAbstractLayeredViewNavigator : public medAbstractViewNavigator
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/views/navigators/medAbstractNavigator.h
+++ b/src/medCoreLegacy/views/navigators/medAbstractNavigator.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,8 +15,9 @@
 
 #include <dtkCoreSupport/dtkAbstractViewNavigator.h>
 
-#include <medCoreExport.h>
 #include <medImageViewEnum.h>
+
+#include <medCoreLegacyExport.h>
 
 class medAbstractView;
 class medAbstractParameter;
@@ -24,7 +25,7 @@ class medBoolParameter;
 
 
 class medAbstractNavigatorPrivate;
-class MEDCORE_EXPORT medAbstractNavigator : public dtkAbstractViewNavigator
+class MEDCORELEGACY_EXPORT medAbstractNavigator : public dtkAbstractViewNavigator
 {
     Q_OBJECT
 

--- a/src/medCoreLegacy/views/navigators/medAbstractViewNavigator.h
+++ b/src/medCoreLegacy/views/navigators/medAbstractViewNavigator.h
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -15,14 +15,14 @@
 
 #include <medAbstractNavigator.h>
 
-#include <medCoreExport.h>
+#include <medCoreLegacyExport.h>
 
 class medDoubleParameter;
 class medAbstractVector2DParameter;
 
 class medAbstractViewNavigatorPrivate;
 
-class MEDCORE_EXPORT medAbstractViewNavigator : public medAbstractNavigator
+class MEDCORELEGACY_EXPORT medAbstractViewNavigator : public medAbstractNavigator
 {
     Q_OBJECT
 


### PR DESCRIPTION
At the end only plugins have common MEDPLUGIN_EXPORTS defined macro to determine if symbol have to be exported or imported.
It allow to avoid to have a header in each plugin just to redifine it.