### PR TITLE
Use the metaObject Qt system to retrieve className as identifiers for…

### DIFF
--- a/src-plugins/process/arithmetic_operation/medItkAddImageProcess/medItkAddImageProcessPlugin.cpp
+++ b/src-plugins/process/arithmetic_operation/medItkAddImageProcess/medItkAddImageProcessPlugin.cpp
@@ -19,7 +19,7 @@
 
 void medItkAddImageProcessPlugin::initialize(void)
 {
-    medProcessLayer::arithmeticalOperation::addImage::pluginFactory().record("medItkAddImageProcess",
+    medProcessLayer::arithmeticalOperation::addImage::pluginFactory().record(medItkAddImageProcess::staticMetaObject.className(),
                                                                              medItkAddImageProcessCreator);
 }
 

--- a/src-plugins/process/arithmetic_operation/medItkDivideImageProcess/medItkDivideImageProcessPlugin.cpp
+++ b/src-plugins/process/arithmetic_operation/medItkDivideImageProcess/medItkDivideImageProcessPlugin.cpp
@@ -19,7 +19,7 @@
 
 void medItkDivideImageProcessPlugin::initialize(void)
 {
-    medProcessLayer::arithmeticalOperation::divideImage::pluginFactory().record("medItkDivideImageProcess",
+    medProcessLayer::arithmeticalOperation::divideImage::pluginFactory().record(medItkDivideImageProcess::staticMetaObject.className(),
                                                                                 medItkDivideImageProcessCreator);
 }
 

--- a/src-plugins/process/arithmetic_operation/medItkMultiplyImageProcess/medItkMultiplyImageProcessPlugin.cpp
+++ b/src-plugins/process/arithmetic_operation/medItkMultiplyImageProcess/medItkMultiplyImageProcessPlugin.cpp
@@ -19,7 +19,7 @@
 
 void medItkMultiplyImageProcessPlugin::initialize(void)
 {
-    medProcessLayer::arithmeticalOperation::multiplyImage::pluginFactory().record("medItkMultiplyImageProcess",
+    medProcessLayer::arithmeticalOperation::multiplyImage::pluginFactory().record(medItkMultiplyImageProcess::staticMetaObject.className(),
                                                                                   medItkMultiplyImageProcessCreator);
 }
 

--- a/src-plugins/process/arithmetic_operation/medItkSubtractImageProcess/medItkSubtractImageProcessPlugin.cpp
+++ b/src-plugins/process/arithmetic_operation/medItkSubtractImageProcess/medItkSubtractImageProcessPlugin.cpp
@@ -19,7 +19,7 @@
 
 void medItkSubtractImageProcessPlugin::initialize(void)
 {
-    medProcessLayer::arithmeticalOperation::subtractImage::pluginFactory().record("medItkSubtractImageProcess",
+    medProcessLayer::arithmeticalOperation::subtractImage::pluginFactory().record(medItkSubtractImageProcess::staticMetaObject.className(),
                                                             medItkSubtractImageProcessCreator);
 }
 

--- a/src-plugins/process/morphomath_operation/medItkClosingImageProcess/medItkClosingImageProcessPlugin.cpp
+++ b/src-plugins/process/morphomath_operation/medItkClosingImageProcess/medItkClosingImageProcessPlugin.cpp
@@ -19,7 +19,7 @@
 
 void medItkClosingImageProcessPlugin::initialize(void)
 {
-    medProcessLayer::morphomathOperation::closingImage::pluginFactory().record("medItkClosingImageProcess",
+    medProcessLayer::morphomathOperation::closingImage::pluginFactory().record(medItkClosingImageProcess::staticMetaObject.className(),
                                                                                medItkClosingImageProcessCreator);
 }
 

--- a/src-plugins/process/morphomath_operation/medItkDilateImageProcess/medItkDilateImageProcessPlugin.cpp
+++ b/src-plugins/process/morphomath_operation/medItkDilateImageProcess/medItkDilateImageProcessPlugin.cpp
@@ -19,7 +19,7 @@
 
 void medItkDilateImageProcessPlugin::initialize(void)
 {
-    medProcessLayer::morphomathOperation::dilateImage::pluginFactory().record("medItkDilateImageProcess",
+    medProcessLayer::morphomathOperation::dilateImage::pluginFactory().record(medItkDilateImageProcess::staticMetaObject.className(),
                                                                               medItkDilateImageProcessCreator);
 }
 

--- a/src-plugins/process/morphomath_operation/medItkErodeImageProcess/medItkErodeImageProcessPlugin.cpp
+++ b/src-plugins/process/morphomath_operation/medItkErodeImageProcess/medItkErodeImageProcessPlugin.cpp
@@ -19,7 +19,7 @@
 
 void medItkErodeImageProcessPlugin::initialize(void)
 {
-    medProcessLayer::morphomathOperation::erodeImage::pluginFactory().record("medItkErodeImageProcess",
+    medProcessLayer::morphomathOperation::erodeImage::pluginFactory().record(medItkErodeImageProcess::staticMetaObject.className(),
                                                                              medItkErodeImageProcessCreator);
 }
 

--- a/src-plugins/process/morphomath_operation/medItkOpeningImageProcess/medItkOpeningImageProcessPlugin.cpp
+++ b/src-plugins/process/morphomath_operation/medItkOpeningImageProcess/medItkOpeningImageProcessPlugin.cpp
@@ -19,7 +19,7 @@
 
 void medItkOpeningImageProcessPlugin::initialize(void)
 {
-    medProcessLayer::morphomathOperation::openingImage::pluginFactory().record("medItkOpeningImageProcess",
+    medProcessLayer::morphomathOperation::openingImage::pluginFactory().record(medItkOpeningImageProcess::staticMetaObject.className(),
                                                                                medItkOpeningImageProcessCreator);
 }
 


### PR DESCRIPTION
Use the Qt meta object system to retrieve class name and use it as identifiers for dynamically loaded object.

We can register a type by doing : 
```c++
medFooLayer::foo::pluginFactory().record(medConcreteFoo::staticMetaObject.className(),
                                                                    medConcreteFooCreator);
```

And we can retrieve the identifier from an abstract pointer by doing  :
```c++
medAbstractFoo *foo = concreteObject
QString identifier = foo->metaObject()->className()
```


This avoid us to have to defined a static method to return A QString as identifier for each dynamically loadable type .