### PR TITLE
Use target_include_directories feature.

### DIFF
--- a/src/app/medInria/CMakeLists.txt
+++ b/src/app/medInria/CMakeLists.txt
@@ -27,18 +27,11 @@ list_source_files(${TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
-## #############################################################################
-## include directorie.
-## #############################################################################
-
 ##  see cmake/module/list_header_directories_to_include.cmake
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
   )
 
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${${PROJECT_NAME}_INCLUDE_DIRS}
-  )
 
 ## #############################################################################
 ## Add preproc if we have revisions from the super project
@@ -103,6 +96,15 @@ if (APPLE)
 endif()
 
 ## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PRIVATE ${${TARGET_NAME}_INCLUDE_DIRS}
+  )
+# PRIVATE beacause application is not supposed to be used somewhere else
+
+## #############################################################################
 ## Links.
 ## #############################################################################
 
@@ -120,10 +122,6 @@ target_link_libraries(${TARGET_NAME}
   medCoreLegacy
   medPacs
   )
-
-qt5_use_modules(${TARGET_NAME} Widgets)
-qt5_use_modules(${TARGET_NAME} Core)
-qt5_use_modules(${TARGET_NAME} Gui)
 
 ## #############################################################################
 ## install

--- a/src/layers/CMakeLists.txt
+++ b/src/layers/CMakeLists.txt
@@ -29,25 +29,3 @@ add_subdirectory(medImageIO)
 add_subdirectory(medRegistration)
 
 add_subdirectory(medVtkInria)
-
-## #############################################################################
-## complete medInria_INCLUDE_DIRS
-## #############################################################################
-
-set(${PROJECT_NAME}_INCLUDE_DIRS
-    ${QT_HEADERS}
-  ${medCore_INCLUDE_DIRS}
-  ${medCoreLegacy_INCLUDE_DIRS}
-  ${medComposer_INCLUDE_DIRS}
-  ${medGui_INCLUDE_DIRS}
-  ${medPacs_INCLUDE_DIRS}
-  ${medTest_INCLUDE_DIRS}
-  ${medSql_INCLUDE_DIRS}
-  ${medLog_INCLUDE_DIRS}
-  ${medImageIO_INCLUDE_DIRS}
-  ${medRegistration_INCLUDE_DIRS}
-  ${medVtkInria_INCLUDE_DIRS}
-  ${${PROJECT_NAME}_INCLUDE_DIRS}
-  PARENT_SCOPE
-  )
-

--- a/src/layers/medComposer/CMakeLists.txt
+++ b/src/layers/medComposer/CMakeLists.txt
@@ -33,18 +33,8 @@ list_source_files(${TARGET_NAME}
   process/morphomath_operation
   )
 
-
-## #############################################################################
-## include directorie.
-## #############################################################################
-
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${medCore_INCLUDE_DIRS}
-  ${medCoreLegacy_INCLUDE_DIRS}
   )
 
 ## #############################################################################
@@ -54,8 +44,18 @@ include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
 
 add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_CFILES}
-#  ${${TARGET_NAME}_QRC}
+  ${${TARGET_NAME}_QRC}
   )
+
+
+## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PUBLIC ${${TARGET_NAME}_INCLUDE_DIRS}
+  )
+
 
 ## #############################################################################
 ## Link

--- a/src/layers/medCore/CMakeLists.txt
+++ b/src/layers/medCore/CMakeLists.txt
@@ -28,19 +28,9 @@ list_source_files(${TARGET_NAME}
   gui/area
   )
 
-
-## #############################################################################
-## include directories.
-## #############################################################################
-
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
   )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${medCoreLegacy_INCLUDE_DIRS}
-  )
-
 
 ## #############################################################################
 ## add library
@@ -49,6 +39,15 @@ include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
 add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_CFILES}
   ${${TARGET_NAME}_QRC}
+  )
+
+
+## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PUBLIC ${${TARGET_NAME}_INCLUDE_DIRS}
   )
 
 

--- a/src/layers/medCoreLegacy/CMakeLists.txt
+++ b/src/layers/medCoreLegacy/CMakeLists.txt
@@ -41,17 +41,9 @@ list_source_files(${TARGET_NAME}
   parameters
   )
 
-set(${TARGET_NAME}_QRC resources/medCoreLegacy.qrc)
-
-## #############################################################################
-## include directories.
-## #############################################################################
-
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
   )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS})
 
 ## #############################################################################
 ## add library
@@ -61,6 +53,15 @@ add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_CFILES}
   ${${TARGET_NAME}_QRC}
   )
+
+## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PUBLIC ${${TARGET_NAME}_INCLUDE_DIRS}
+  )
+
 
 ## #############################################################################
 ## Link

--- a/src/layers/medImageIO/CMakeLists.txt
+++ b/src/layers/medImageIO/CMakeLists.txt
@@ -35,22 +35,9 @@ list_source_files(${TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
-
-## #############################################################################
-## include directorie.
-## #############################################################################
-
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-    ${QT_HEADERS}
-
   )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${DCMTK_INCLUDE_DIRS}
-  ${medCoreLegacy_INCLUDE_DIRS}
-  )
-
 
 ## #############################################################################
 ## add library
@@ -60,6 +47,15 @@ add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_CFILES}
   )
 
+## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PUBLIC ${${TARGET_NAME}_INCLUDE_DIRS}
+  PRIVATE ${DCMTK_INCLUDE_DIRS}
+  )
+
 
 ## #############################################################################
 ## Link
@@ -67,7 +63,8 @@ add_library(${TARGET_NAME} SHARED
 
 
 target_link_libraries(${TARGET_NAME}
-  ${QT_LIBRARIES}
+  Qt5::Core
+  Qt5::Widgets
   dtkCoreSupport
   dtkLog
   medCore

--- a/src/layers/medLog/CMakeLists.txt
+++ b/src/layers/medLog/CMakeLists.txt
@@ -38,16 +38,9 @@ list_source_files(${TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
-
-## #############################################################################
-## include directorie.
-## #############################################################################
-
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
   )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS})
 
 
 ## #############################################################################
@@ -60,11 +53,21 @@ add_library(${TARGET_NAME} SHARED
 
 
 ## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PUBLIC ${${TARGET_NAME}_INCLUDE_DIRS}
+  )
+
+
+## #############################################################################
 ## Link
 ## #############################################################################
 
 target_link_libraries(${TARGET_NAME}
-  ${QT_LIBRARIES}
+  Qt5::Core
+  Qt5::Widgets
   dtkCoreSupport
   dtkLog
   ITKCommon

--- a/src/layers/medPacs/CMakeLists.txt
+++ b/src/layers/medPacs/CMakeLists.txt
@@ -21,21 +21,9 @@ list_source_files(${TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
-find_package(Qt5Widgets)
-
-## #############################################################################
-## include directorie.
-## #############################################################################
-
 list_header_directories_to_include(${TARGET_NAME}
-
   ${${TARGET_NAME}_HEADERS}
   )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-    ${medCoreLegacy_INCLUDE_DIRS}
-    )
-
 
 ## #############################################################################
 ## Add definition
@@ -46,9 +34,6 @@ if (NOT MSVC) #TODO : what is it for ?
   add_definitions(-Wformat=0)
 endif()
 
-add_definitions(${QT_DEFINITIONS})
-add_definitions(-DQT_SHARED)
-add_definitions(-DQT_NO_DEBUG)
 
 ## #############################################################################
 ## add library
@@ -58,23 +43,27 @@ add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_CFILES}
   )
 
-qt5_use_modules(${TARGET_NAME} Widgets)
-qt5_use_modules(${TARGET_NAME} Core)
-qt5_use_modules(${TARGET_NAME} Gui)
 
 ## #############################################################################
 ## Link
 ## #############################################################################
 
 target_link_libraries(${TARGET_NAME}
-    ${QT_LIBRARIES}
+    Qt5::Core
+    Qt5::Widgets
     dtkCoreSupport
     dtkLog
     medCoreLegacy
     )
-qt5_use_modules(${TARGET_NAME} Widgets)
-qt5_use_modules(${TARGET_NAME} Core)
-qt5_use_modules(${TARGET_NAME} Gui)
+
+## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PUBLIC ${${TARGET_NAME}_INCLUDE_DIRS}
+  )
+
 
 ## #############################################################################
 ## install

--- a/src/layers/medRegistration/CMakeLists.txt
+++ b/src/layers/medRegistration/CMakeLists.txt
@@ -37,18 +37,10 @@ list_source_files(${TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
-
-## #############################################################################
-## include directorie.
-## #############################################################################
-
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
   )
 
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${medCoreLegacy_INCLUDE_DIRS}
-  )
 
 ## #############################################################################
 ## add library
@@ -60,13 +52,21 @@ add_library(${TARGET_NAME} SHARED
 
 
 ## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PUBLIC ${${TARGET_NAME}_INCLUDE_DIRS}
+  )
+
+
+## #############################################################################
 ## Link
 ## #############################################################################
 
 target_link_libraries(${TARGET_NAME}
   Qt5::Core
   Qt5::Widgets
-  Qt5::Gui
   dtkCoreSupport
   medCoreLegacy
   dtkLog

--- a/src/layers/medTest/CMakeLists.txt
+++ b/src/layers/medTest/CMakeLists.txt
@@ -49,7 +49,6 @@ add_library(${TARGET_NAME} SHARED
 ## #############################################################################
 
 target_link_libraries(${TARGET_NAME}
-    ${QT_LIBRARIES}
     Qt5::Test
     dtkCoreSupport
     dtkLog

--- a/src/layers/medVtkInria/CMakeLists.txt
+++ b/src/layers/medVtkInria/CMakeLists.txt
@@ -46,6 +46,9 @@ list_source_files(${TARGET_NAME}
   HWShading/helpers
   )
 
+list_header_directories_to_include(${TARGET_NAME}
+  ${${TARGET_NAME}_HEADERS}
+  )
 
 ## #############################################################################
 ## write header shader
@@ -103,23 +106,6 @@ shader_to_header(HWShading/shaders/BuildShadowMapLines.frag
   BuildShadowMapLinesFragmentText
   )
 
-
-## #############################################################################
-## include directories.
-## #############################################################################
-
-list_header_directories_to_include(${TARGET_NAME}
-  ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${Qt5Core_INCLUDE_DIRS}
-  ${Boost_INCLUDE_DIR}
-  ${medCoreLegacy_INCLUDE_DIRS}
-  ${CMAKE_BINARY_DIR}/shaders
-  )
-
-
 ## #############################################################################
 ## add library
 ## #############################################################################
@@ -128,6 +114,17 @@ add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_CFILES}
   )
 
+## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PUBLIC
+  ${${TARGET_NAME}_INCLUDE_DIRS}
+  ${CMAKE_BINARY_DIR}/shaders
+  PRIVATE
+  ${Boost_INCLUDE_DIR}
+  )
 
 ## #############################################################################
 ## Link
@@ -135,6 +132,9 @@ add_library(${TARGET_NAME} SHARED
 
 target_link_libraries(${TARGET_NAME}
   ${OPENGL_LIBRARIES}
+  Qt5::Core
+  Qt5::Widgets
+  medCoreLegacy
   ITKIOImageBase
   ITKIOBMP
   ITKIOLSM

--- a/src/layers/medVtkInria/vtkImageView/vtkImageView2D.cxx
+++ b/src/layers/medVtkInria/vtkImageView/vtkImageView2D.cxx
@@ -4,14 +4,12 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
 
 =========================================================================*/
-
-#include <QtCore/QDebug>
 
 #include "vtkImageView2D.h"
 
@@ -167,7 +165,7 @@ void vtkImage2DDisplay::SetInput(vtkImageData * image)
   else
   {
     this->WindowLevel->SetInputData(image);
-	this->ImageActor->GetMapper()->SetInputConnection( this->WindowLevel->GetOutputPort() );  }
+    this->ImageActor->GetMapper()->SetInputConnection( this->WindowLevel->GetOutputPort() );  }
 }
 
 vtkLookupTable * vtkImage2DDisplay::GetLookupTable() const
@@ -1997,12 +1995,12 @@ void vtkImageView2D::SetInput (vtkActor *actor, int layer, vtkMatrix4x4 *matrix,
 void vtkImageView2D::RemoveLayerActor(vtkActor *actor, int layer)
 {
     vtkRenderer *renderer = this->GetRendererForLayer(layer);
-    
+
     if (!renderer)
         return;
-    
+
     renderer->RemoveActor(actor);
-    
+
     this->SetCurrentLayer(layer);
     this->Slice = this->GetSliceForWorldCoordinates (this->CurrentPoint);
     this->UpdateDisplayExtent();

--- a/src/plugins/legacy/itkDataImage/CMakeLists.txt
+++ b/src/plugins/legacy/itkDataImage/CMakeLists.txt
@@ -59,17 +59,8 @@ list_source_files(${TARGET_NAME}
   readers
   writers
   )
-
-## #############################################################################
-## include directorie.
-## #############################################################################
-
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${${PROJECT_NAME}_INCLUDE_DIRS}
   )
 
 ## #############################################################################
@@ -106,11 +97,20 @@ add_library(${TARGET_NAME} SHARED
 
 
 ## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PRIVATE ${${TARGET_NAME}_INCLUDE_DIRS}
+  )
+
+## #############################################################################
 ## Link
 ## #############################################################################
 
 target_link_libraries(${TARGET_NAME}
-  ${QT_LIBRARIES}
+  Qt5::Core
+  Qt5::Widgets
   dtkCore
   dtkLog
   ITKIOImageBase

--- a/src/plugins/process/arithmetic_operation/medItkAddImageProcess/CMakeLists.txt
+++ b/src/plugins/process/arithmetic_operation/medItkAddImageProcess/CMakeLists.txt
@@ -33,17 +33,8 @@ list_source_files(${TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
-
-## #############################################################################
-## include directories.
-## #############################################################################
-
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${${PROJECT_NAME}_INCLUDE_DIRS}
   )
 
 
@@ -57,13 +48,22 @@ add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_QRC}
   )
 
+## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PRIVATE ${${TARGET_NAME}_INCLUDE_DIRS}
+  )
+# PRIVATE beacause plugins are not supposed to be used somewhere else
 
 ## #############################################################################
 ## Link
 ## #############################################################################
 
 target_link_libraries(${TARGET_NAME}
-  ${QT_LIBRARIES}
+  Qt5::Core
+  Qt5::Widgets
   dtkCore
   dtkLog
   dtkComposer

--- a/src/plugins/process/arithmetic_operation/medItkDivideImageProcess/CMakeLists.txt
+++ b/src/plugins/process/arithmetic_operation/medItkDivideImageProcess/CMakeLists.txt
@@ -33,17 +33,8 @@ list_source_files(${TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
-
-## #############################################################################
-## include directories.
-## #############################################################################
-
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${${PROJECT_NAME}_INCLUDE_DIRS}
   )
 
 
@@ -51,18 +42,27 @@ include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
 ## add library
 ## #############################################################################
 
-
 add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_CFILES}
   ${${TARGET_NAME}_QRC}
   )
 
 ## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PRIVATE ${${TARGET_NAME}_INCLUDE_DIRS}
+  )
+# PRIVATE beacause plugins are not supposed to be used somewhere else
+
+## #############################################################################
 ## Link
 ## #############################################################################
 
 target_link_libraries(${TARGET_NAME}
-  ${QT_LIBRARIES}
+  Qt5::Core
+  Qt5::Widgets
   dtkCore
   dtkLog
   dtkComposer

--- a/src/plugins/process/arithmetic_operation/medItkMultiplyImageProcess/CMakeLists.txt
+++ b/src/plugins/process/arithmetic_operation/medItkMultiplyImageProcess/CMakeLists.txt
@@ -33,17 +33,8 @@ list_source_files(${TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
-
-## #############################################################################
-## include directories.
-## #############################################################################
-
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${${PROJECT_NAME}_INCLUDE_DIRS}
   )
 
 
@@ -57,11 +48,21 @@ add_library(${TARGET_NAME} SHARED
   )
 
 ## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PRIVATE ${${TARGET_NAME}_INCLUDE_DIRS}
+  )
+# PRIVATE beacause plugins are not supposed to be used somewhere else
+
+## #############################################################################
 ## Link
 ## #############################################################################
 
 target_link_libraries(${TARGET_NAME}
-  ${QT_LIBRARIES}
+  Qt5::Core
+  Qt5::Widgets
   dtkCore
   dtkLog
   dtkComposer

--- a/src/plugins/process/arithmetic_operation/medItkSubtractImageProcess/CMakeLists.txt
+++ b/src/plugins/process/arithmetic_operation/medItkSubtractImageProcess/CMakeLists.txt
@@ -32,19 +32,9 @@ list_source_files(${TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
-
-## #############################################################################
-## include directories.
-## #############################################################################
-
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
   )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${${PROJECT_NAME}_INCLUDE_DIRS}
-  )
-
 
 ## #############################################################################
 ## add library
@@ -58,11 +48,22 @@ add_library(${TARGET_NAME} SHARED
 
 
 ## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PRIVATE ${${TARGET_NAME}_INCLUDE_DIRS}
+  )
+# PRIVATE beacause plugins are not supposed to be used somewhere else
+
+
+## #############################################################################
 ## Link
 ## #############################################################################
 
 target_link_libraries(${TARGET_NAME}
-  ${QT_LIBRARIES}
+  Qt5::Core
+  Qt5::Widgets
   dtkCore
   dtkLog
   dtkComposer

--- a/src/plugins/process/morphomath_operation/medItkClosingImageProcess/CMakeLists.txt
+++ b/src/plugins/process/morphomath_operation/medItkClosingImageProcess/CMakeLists.txt
@@ -33,17 +33,8 @@ list_source_files(${TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
-
-## #############################################################################
-## include directories.
-## #############################################################################
-
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${${PROJECT_NAME}_INCLUDE_DIRS}
   )
 
 
@@ -57,11 +48,22 @@ add_library(${TARGET_NAME} SHARED
   )
 
 ## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PRIVATE ${${TARGET_NAME}_INCLUDE_DIRS}
+  )
+# PRIVATE beacause plugins are not supposed to be used somewhere else
+
+
+## #############################################################################
 ## Link
 ## #############################################################################
 
 target_link_libraries(${TARGET_NAME}
-  ${QT_LIBRARIES}
+  Qt5::Core
+  Qt5::Widgets
   dtkCore
   dtkLog
   dtkComposer

--- a/src/plugins/process/morphomath_operation/medItkDilateImageProcess/CMakeLists.txt
+++ b/src/plugins/process/morphomath_operation/medItkDilateImageProcess/CMakeLists.txt
@@ -33,17 +33,8 @@ list_source_files(${TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
-
-## #############################################################################
-## include directories.
-## #############################################################################
-
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${${PROJECT_NAME}_INCLUDE_DIRS}
   )
 
 
@@ -51,18 +42,29 @@ include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
 ## add library
 ## #############################################################################
 
-
 add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_CFILES}
   ${${TARGET_NAME}_QRC}
   )
+
+
+## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PRIVATE ${${TARGET_NAME}_INCLUDE_DIRS}
+  )
+# PRIVATE beacause plugins are not supposed to be used somewhere else
+
 
 ## #############################################################################
 ## Link
 ## #############################################################################
 
 target_link_libraries(${TARGET_NAME}
-  ${QT_LIBRARIES}
+  Qt5::Core
+  Qt5::Widgets
   dtkCore
   dtkLog
   dtkComposer

--- a/src/plugins/process/morphomath_operation/medItkErodeImageProcess/CMakeLists.txt
+++ b/src/plugins/process/morphomath_operation/medItkErodeImageProcess/CMakeLists.txt
@@ -33,17 +33,8 @@ list_source_files(${TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
-
-## #############################################################################
-## include directories.
-## #############################################################################
-
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${${PROJECT_NAME}_INCLUDE_DIRS}
   )
 
 
@@ -57,12 +48,24 @@ add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_QRC}
   )
 
+
+## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PRIVATE ${${TARGET_NAME}_INCLUDE_DIRS}
+  )
+# PRIVATE beacause plugins are not supposed to be used somewhere else
+
+
 ## #############################################################################
 ## Link
 ## #############################################################################
 
 target_link_libraries(${TARGET_NAME}
-  ${QT_LIBRARIES}
+  Qt5::Core
+  Qt5::Widgets
   dtkCore
   dtkLog
   dtkComposer

--- a/src/plugins/process/morphomath_operation/medItkOpeningImageProcess/CMakeLists.txt
+++ b/src/plugins/process/morphomath_operation/medItkOpeningImageProcess/CMakeLists.txt
@@ -33,17 +33,8 @@ list_source_files(${TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
-
-## #############################################################################
-## include directories.
-## #############################################################################
-
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${${PROJECT_NAME}_INCLUDE_DIRS}
   )
 
 
@@ -57,11 +48,22 @@ add_library(${TARGET_NAME} SHARED
   )
 
 ## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PRIVATE ${${TARGET_NAME}_INCLUDE_DIRS}
+  )
+# PRIVATE beacause plugins are not supposed to be used somewhere else
+
+
+## #############################################################################
 ## Link
 ## #############################################################################
 
 target_link_libraries(${TARGET_NAME}
-  ${QT_LIBRARIES}
+  Qt5::Core
+  Qt5::Widgets
   dtkCore
   dtkLog
   dtkComposer


### PR DESCRIPTION
Simplify CMakeLists by avoiding us to manually manage all the medFoo_INCLUDE_DIRS variables. 
See : https://cmake.org/cmake/help/v3.2/command/target_include_directories.html

Fix some path issues with qtcreator for auto-completion.