### PR TITLE
View bug correction

### DIFF
--- a/src/app/medInria/medApplication.cpp
+++ b/src/app/medInria/medApplication.cpp
@@ -203,10 +203,6 @@ void medApplication::initialize()
     plugins_dir = qApp->applicationDirPath() + "/../PlugIns";
 #else
     plugins_dir = qApp->applicationDirPath() + "/../plugins";
-    char pchTmp[1024];
-    int len = 1024;
-    GetCurrentDirectory(len, pchTmp);
-    pchTmp;
 #endif
     defaultPath = plugins_dir.absolutePath();
 

--- a/src/app/medInria/medApplication.cpp
+++ b/src/app/medInria/medApplication.cpp
@@ -203,6 +203,10 @@ void medApplication::initialize()
     plugins_dir = qApp->applicationDirPath() + "/../PlugIns";
 #else
     plugins_dir = qApp->applicationDirPath() + "/../plugins";
+    char pchTmp[1024];
+    int len = 1024;
+    GetCurrentDirectory(len, pchTmp);
+    pchTmp;
 #endif
     defaultPath = plugins_dir.absolutePath();
 

--- a/src/app/medInria/medFilteringWorkspace.cpp
+++ b/src/app/medInria/medFilteringWorkspace.cpp
@@ -42,6 +42,7 @@ struct SingleFiltersGathering
     medAbstractImageDenoisingProcessPluginFactory* denoisingFactory;
     medAbstractRelaxometryEstimationProcessPluginFactory* relaxometryFactory;
     medAbstractSymmetryPlaneAlignmentProcessPluginFactory* symmetryFactory;
+    medAbstractBiasCorrectionProcessPluginFactory* biasCorrectionFactory;
 
     medAbstractGaussianFilterProcessPresenterFactory* gaussianFactoryPresenter;
     medAbstractMedianFilterProcessPresenterFactory* medianFactoryPresenter;
@@ -51,6 +52,7 @@ struct SingleFiltersGathering
     medAbstractImageDenoisingProcessPresenterFactory* denoisingFactoryPresenter;
     medAbstractRelaxometryEstimationProcessPresenterFactory* relaxometryFactoryPresenter;
     medAbstractSymmetryPlaneAlignmentProcessPresenterFactory* symmetryFactoryPresenter;
+    medAbstractBiasCorrectionProcessPresenterFactory* biasCorrectionFactoryPresenter;
 
     QString pluginKey;
     medAbstractProcess* myProcess;
@@ -65,6 +67,7 @@ struct SingleFiltersGathering
         denoisingFactory = 0;
         relaxometryFactory = 0;
         symmetryFactory = 0;
+        biasCorrectionFactory = 0;
 
         gaussianFactoryPresenter = 0;
         medianFactoryPresenter = 0;
@@ -74,6 +77,7 @@ struct SingleFiltersGathering
         denoisingFactoryPresenter = 0;
         relaxometryFactoryPresenter = 0;
         symmetryFactoryPresenter = 0;
+        biasCorrectionFactoryPresenter = 0;
 
         myProcess = 0;
     }
@@ -104,6 +108,9 @@ struct SingleFiltersGathering
         else if(symmetryFactory)
             myProcess = symmetryFactory->create(pluginKey);
 
+        else if (biasCorrectionFactory)
+           myProcess = biasCorrectionFactory->create(pluginKey);
+
         return myProcess;
     }
 
@@ -130,8 +137,11 @@ struct SingleFiltersGathering
         else if(relaxometryFactoryPresenter)
             return relaxometryFactoryPresenter->create(myProcess);
 
-        else if(symmetryFactoryPresenter)
-            return symmetryFactoryPresenter->create(myProcess);
+        else if (symmetryFactoryPresenter)
+           return symmetryFactoryPresenter->create(myProcess);
+
+        else if (biasCorrectionFactoryPresenter)
+           return biasCorrectionFactoryPresenter->create(myProcess);
 
         return 0;
     }
@@ -609,6 +619,22 @@ void medFilteringWorkspace::setProcessType(int index)
 
                     d->singleFiltersVector.push_back(aSolution);
                 }
+            }
+
+            plugins = medCore::singleFilterOperation::biasCorrection::pluginFactory().keys();
+            foreach(QString pluginKey, plugins)
+            {
+               medAbstractProcess *process = medCore::singleFilterOperation::biasCorrection::pluginFactory().create(pluginKey);
+               if (process)
+               {
+                  d->processSelectorComboBox->addItem(process->caption(), pluginKey);
+                  SingleFiltersGathering aSolution;
+                  aSolution.pluginKey = pluginKey;
+                  aSolution.biasCorrectionFactory = &medCore::singleFilterOperation::biasCorrection::pluginFactory();
+                  aSolution.biasCorrectionFactoryPresenter = &medWidgets::singleFilterOperation::biasCorrection::presenterFactory();
+
+                  d->singleFiltersVector.push_back(aSolution);
+               }
             }
 
             break;

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
@@ -191,9 +191,6 @@ public:
     virtual vtkActor* AddDataSet (vtkPointSet* arg, vtkProperty* prop = NULL);
     virtual void RemoveDataSet (vtkPointSet* arg);
 
-    virtual void AddExtraPlane (vtkImageActor* input);
-    virtual void RemoveExtraPlane (vtkImageActor* input);
-
     virtual void AddLayer (int layer);
     virtual int GetNumberOfLayers() const;
     virtual void RemoveLayer (int layer);
@@ -289,7 +286,9 @@ protected:
         vtkSmartPointer<vtkImage3DDisplay> ImageDisplay;
     };
 
-    vtkSmartPointer<vtkImageMapToColors>        PlanarWindowLevel;
+    vtkSmartPointer<vtkImageMapToColors>        PlanarWindowLevelX;
+    vtkSmartPointer<vtkImageMapToColors>        PlanarWindowLevelY;
+    vtkSmartPointer<vtkImageMapToColors>        PlanarWindowLevelZ;
     // Layer indices start from 0, as they do for the 2d case
     //(API change)
     typedef std::vector<LayerInfo > LayerInfoVecType;

--- a/src/layers/medCore/medCore.cpp
+++ b/src/layers/medCore/medCore.cpp
@@ -303,6 +303,19 @@ namespace singleFilterOperation
             return _private::factory;
         }
     }
+
+    namespace biasCorrection
+    {
+       namespace _private
+       {
+          medAbstractBiasCorrectionProcessPluginFactory factory;
+       }
+
+       medAbstractBiasCorrectionProcessPluginFactory& pluginFactory(void)
+       {
+          return _private::factory;
+       }
+    }
 }
 
 // morphomath

--- a/src/layers/medCore/medCore.h
+++ b/src/layers/medCore/medCore.h
@@ -35,6 +35,7 @@
 #include <medAbstractWindowingFilterProcess.h>
 #include <medAbstractImageDenoisingProcess.h>
 #include <medAbstractRelaxometryEstimationProcess.h>
+#include <medAbstractBiasCorrectionProcess.h>
 
 #include <medAbstractMorphomathOperationProcess.h>
 #include <medAbstractErodeImageProcess.h>
@@ -64,7 +65,8 @@ namespace medCore
     DTK_DECLARE_CONCEPT(medAbstractDiffusionModelEstimationProcess,MEDCORE_EXPORT,diffusionModelEstimation)
     DTK_DECLARE_CONCEPT(medAbstractDiffusionScalarMapsProcess,MEDCORE_EXPORT,diffusionScalarMaps)
     DTK_DECLARE_CONCEPT(medAbstractTractographyProcess,MEDCORE_EXPORT,tractography)
-    DTK_DECLARE_CONCEPT(medAbstractMaskImageProcess,MEDCORE_EXPORT,maskImage)
+    DTK_DECLARE_CONCEPT(medAbstractMaskImageProcess, MEDCORE_EXPORT, maskImage)
+    //DTK_DECLARE_CONCEPT(medAbstractBiasCorrectionProcess, MEDCORE_EXPORT, biasCorrection)
     DTK_DECLARE_CONCEPT(medAbstractDataConverter,MEDCORE_EXPORT,dataConverter)
 
     namespace arithmeticOperation
@@ -160,6 +162,11 @@ namespace medCore
         {
             MEDCORE_EXPORT medAbstractSymmetryPlaneAlignmentProcessPluginFactory& pluginFactory(void);
         }
+
+        namespace biasCorrection
+        {
+           MEDCORE_EXPORT medAbstractBiasCorrectionProcessPluginFactory& pluginFactory(void);
+        }
     }
 
     namespace morphomathOperation
@@ -186,4 +193,5 @@ namespace medCore
         }
     }
 
+ 
 }

--- a/src/layers/medCore/medCore.qrc
+++ b/src/layers/medCore/medCore.qrc
@@ -26,6 +26,7 @@
         <file>process/single_filter/medAbstractImageDenoisingProcess.json</file>
         <file>process/single_filter/medAbstractRelaxometryEstimationProcess.json</file>
         <file>process/single_filter/medAbstractSymmetryPlaneAlignmentProcess.json</file>
+        <file>process/single_filter/medAbstractBiasCorrectionProcess.json</file>
         <file>process/medGenericReaderNode.json</file>
         <file>process/medGenericWriterNode.json</file>
         <file>process/medImageReaderNode.json</file>

--- a/src/layers/medCore/parameter/medStringParameter.cpp
+++ b/src/layers/medCore/parameter/medStringParameter.cpp
@@ -17,6 +17,7 @@ class medStringParameterPrivate
 {
 public:
     QString value;
+    QValidator *poValidator;
 };
 
 medStringParameter::medStringParameter(QString const& name,  QObject *parent)
@@ -39,9 +40,36 @@ void medStringParameter::setValue(const QString & value)
 {
     if(value != d->value)
     {
-        d->value = value;
-        emit valueChanged(d->value);
+       int i = -1;
+       if (d->poValidator == NULL || d->poValidator->validate(d->value, i) == QValidator::Acceptable)
+       {
+          d->value = value;
+          emit valueChanged(d->value);
+       }
     }
+}
+
+void medStringParameter::setValidator(QValidator *pi_poValidator)
+{
+   if (d->poValidator != pi_poValidator)
+   {
+      d->poValidator = pi_poValidator;
+      if (pi_poValidator)
+      {
+         int i = -1;
+         if (d->poValidator->validate(d->value, i) != QValidator::Acceptable)
+         {
+            d->value = "";
+         }
+      }
+      emit validatorChanged(d->poValidator);
+   }
+}
+
+
+QValidator *medStringParameter::getValidator() const
+{
+   return d->poValidator;
 }
 
 void medStringParameter::trigger()

--- a/src/layers/medCore/parameter/medStringParameter.h
+++ b/src/layers/medCore/parameter/medStringParameter.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <medAbstractParameter.h>
+#include <QValidator>
 
 class medStringParameterPrivate;
 class MEDCORE_EXPORT medStringParameter : public medAbstractParameter
@@ -27,6 +28,10 @@ public:
     virtual medParameterType type() const {return medParameterType::MED_PARAMETER_STRING;}
 
     QString value() const;
+
+    void setValidator(QValidator *pi_poValidator);
+    QValidator *getValidator() const;
+
 public slots:
     void setValue(QString const& value);
 
@@ -34,6 +39,7 @@ public slots:
 
 signals:
     void valueChanged(QString const& value);
+    void validatorChanged(QValidator *const& poValidator);
 
 private:
     const QScopedPointer<medStringParameterPrivate> d;

--- a/src/layers/medCore/process/single_filter/medAbstractBiasCorrectionProcess.h
+++ b/src/layers/medCore/process/single_filter/medAbstractBiasCorrectionProcess.h
@@ -1,0 +1,32 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2017. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#pragma once
+
+#include <medAbstractSingleFilterOperationProcess.h>
+
+#include <dtkCore>
+
+#include <medCoreExport.h>
+
+class MEDCORE_EXPORT medAbstractBiasCorrectionProcess: public medAbstractSingleFilterOperationProcess
+{
+    Q_OBJECT
+public:
+    medAbstractBiasCorrectionProcess(QObject *parent): medAbstractSingleFilterOperationProcess(parent) {}
+
+protected:
+    virtual QString outputNameAddon() const {return "bias correction filter";}
+};
+
+DTK_DECLARE_PLUGIN_FACTORY(medAbstractBiasCorrectionProcess, MEDCORE_EXPORT)

--- a/src/layers/medCore/process/single_filter/medAbstractBiasCorrectionProcess.json
+++ b/src/layers/medCore/process/single_filter/medAbstractBiasCorrectionProcess.json
@@ -1,8 +1,8 @@
 {
-          "title" : "BiasCorrection filter",
+          "title" : "Bias correction filter",
            "kind" : "process",
-           "type" : "medAbstractBiasCorrectionFilterProcess",
-           "tags" : ["biascorrection","filter", "operation"],
+           "type" : "medAbstractBiasCorrectionProcess",
+           "tags" : ["bias correction","filter", "operation"],
     "description" : "<p>Bias correction filter</p>",
          "inputs" : ["scalarImage"],
         "outputs" : ["scalarImage"]

--- a/src/layers/medCore/process/single_filter/medAbstractBiasCorrectionProcess.json
+++ b/src/layers/medCore/process/single_filter/medAbstractBiasCorrectionProcess.json
@@ -1,0 +1,9 @@
+{
+          "title" : "BiasCorrection filter",
+           "kind" : "process",
+           "type" : "medAbstractBiasCorrectionFilterProcess",
+           "tags" : ["biascorrection","filter", "operation"],
+    "description" : "<p>Bias correction filter</p>",
+         "inputs" : ["scalarImage"],
+        "outputs" : ["scalarImage"]
+}

--- a/src/layers/medWidgets/medWidgets.cpp
+++ b/src/layers/medWidgets/medWidgets.cpp
@@ -386,6 +386,19 @@ namespace singleFilterOperation
             return _private::factory;
         }
     }
+
+    namespace biasCorrection
+    {
+       namespace _private
+       {
+          medAbstractBiasCorrectionProcessPresenterFactory factory;
+       }
+
+       medAbstractBiasCorrectionProcessPresenterFactory& presenterFactory()
+       {
+          return _private::factory;
+       }
+    }
 }
 
 } // end of medWidgets

--- a/src/layers/medWidgets/medWidgets.h
+++ b/src/layers/medWidgets/medWidgets.h
@@ -32,6 +32,7 @@
 #include <medAbstractImageDenoisingProcessPresenter.h>
 #include <medAbstractRelaxometryEstimationProcessPresenter.h>
 #include <medAbstractSymmetryPlaneAlignmentProcessPresenter.h>
+#include <medAbstractBiasCorrectionProcessPresenter.h>
 
 #include <medWidgetsExport.h>
 
@@ -145,12 +146,22 @@ namespace medWidgets
         {
             MEDWIDGETS_EXPORT medAbstractSymmetryPlaneAlignmentProcessPresenterFactory& presenterFactory();
         }
+        namespace biasCorrection
+        {
+           MEDWIDGETS_EXPORT medAbstractBiasCorrectionProcessPresenterFactory& presenterFactory();
+        }
     }
 
     namespace maskImage
     {
         MEDWIDGETS_EXPORT medAbstractMaskImageProcessPresenterFactory& presenterFactory();
     }
+/*
+
+    namespace biasCorrection
+    {
+       MEDWIDGETS_EXPORT medAbstractBiasCorrectionProcessPresenterFactory& presenterFactory();
+    }*/
 
     namespace dwiMasking
     {

--- a/src/layers/medWidgets/parameter/medDoubleParameterPresenter.cpp
+++ b/src/layers/medWidgets/parameter/medDoubleParameterPresenter.cpp
@@ -94,18 +94,18 @@ QWidget* medDoubleParameterPresenter::buildWidget()
 QDoubleSpinBox* medDoubleParameterPresenter::buildSpinBox()
 {
     QDoubleSpinBox *spinBox = new medDoubleSpinBox;
+
+    spinBox->setToolTip(d->parameter->description());
+    spinBox->setRange(d->parameter->minimum(), d->parameter->maximum());
+    spinBox->setDecimals(d->decimals);
+    spinBox->setSingleStep(d->singleStep);
     spinBox->setValue(d->parameter->value());
+
+    this->_connectWidget(spinBox);
     connect(spinBox, SIGNAL(valueChanged(double)),
            d->parameter, SLOT(setValue(double)));
     connect(d->parameter, &medDoubleParameter::valueChanged,
             spinBox, &QDoubleSpinBox::setValue);
-
-    spinBox->setToolTip(d->parameter->description());
-    this->_connectWidget(spinBox);
-
-    spinBox->setRange(d->parameter->minimum(), d->parameter->maximum());
-    spinBox->setDecimals(d->decimals);
-    spinBox->setSingleStep(d->singleStep);
     connect(d->parameter, &medDoubleParameter::rangeChanged,
             spinBox, &QDoubleSpinBox::setRange);
     connect(this, &medDoubleParameterPresenter::decimalsChanged,
@@ -120,8 +120,7 @@ QProgressBar* medDoubleParameterPresenter::buildProgressBar()
 {
     QProgressBar *progressBar = new QProgressBar;
     progressBar->setValue(_percentFromValue(d->parameter->value()));
-    connect(this, &medDoubleParameterPresenter::valueChanged,
-            progressBar, &QProgressBar::setValue);
+    connect(this, &medDoubleParameterPresenter::valueChanged,progressBar, &QProgressBar::setValue);
 
     progressBar->setToolTip(d->parameter->description());
     this->_connectWidget(progressBar);

--- a/src/layers/medWidgets/parameter/medIntParameterPresenter.cpp
+++ b/src/layers/medWidgets/parameter/medIntParameterPresenter.cpp
@@ -70,17 +70,17 @@ QWidget* medIntParameterPresenter::buildWidget()
 QSpinBox* medIntParameterPresenter::buildSpinBox()
 {
     QSpinBox *spinBox = new QSpinBox;
+
+    spinBox->setToolTip(d->parameter->description());
+    spinBox->setRange(d->parameter->minimum(), d->parameter->maximum());
+    spinBox->setValue(d->parameter->value());
+    spinBox->setSingleStep(d->singleStep);
+
+    this->_connectWidget(spinBox);
     connect(spinBox, SIGNAL(valueChanged(int)),
             d->parameter, SLOT(setValue(int)));
     connect(d->parameter, &medIntParameter::valueChanged,
             spinBox, &QSpinBox::setValue);
-
-    spinBox->setToolTip(d->parameter->description());
-    this->_connectWidget(spinBox);
-
-    spinBox->setRange(d->parameter->minimum(), d->parameter->maximum());
-    spinBox->setValue(d->parameter->value());
-    spinBox->setSingleStep(d->singleStep);
     connect(d->parameter, &medIntParameter::rangeChanged,
             spinBox, &QSpinBox::setRange);
     connect(this, &medIntParameterPresenter::singleStepChanged,
@@ -92,14 +92,14 @@ QSpinBox* medIntParameterPresenter::buildSpinBox()
 QProgressBar* medIntParameterPresenter::buildProgressBar()
 {
     QProgressBar *progressBar = new QProgressBar;
-    progressBar->setValue(d->parameter->value());
-    connect(d->parameter, &medIntParameter::valueChanged,
-            progressBar, &QProgressBar::setValue);
 
     progressBar->setToolTip(d->parameter->description());
-    this->_connectWidget(progressBar);
-
     progressBar->setRange(d->parameter->minimum(), d->parameter->maximum());
+    progressBar->setValue(d->parameter->value());
+
+    this->_connectWidget(progressBar);
+    connect(d->parameter, &medIntParameter::valueChanged,
+            progressBar, &QProgressBar::setValue);
     connect(d->parameter, &medIntParameter::rangeChanged,
             progressBar, &QProgressBar::setRange);
 

--- a/src/layers/medWidgets/parameter/medStringParameterPresenter.cpp
+++ b/src/layers/medWidgets/parameter/medStringParameterPresenter.cpp
@@ -15,6 +15,7 @@
 
 #include <QWidget>
 #include <QLineEdit>
+#include <QValidator>
 
 #include <medStringParameter.h>
 
@@ -55,15 +56,14 @@ QLineEdit* medStringParameterPresenter::buildLineEdit()
 {
     QLineEdit *lineEdit = new QLineEdit;
 
-    lineEdit->setText(d->parameter->value());
-    connect(d->parameter, &medStringParameter::valueChanged,
-            lineEdit, &QLineEdit::setText);
-    connect(lineEdit, &QLineEdit::textEdited,
-            d->parameter, &medStringParameter::setValue);
-
     lineEdit->setToolTip(d->parameter->description());
-    lineEdit->setText(d->parameter->caption());
+    lineEdit->setText(d->parameter->value());
+    lineEdit->setValidator(d->parameter->getValidator());
+
     this->_connectWidget(lineEdit);
+    connect(d->parameter, &medStringParameter::validatorChanged, lineEdit, &QLineEdit::setValidator);
+    connect(d->parameter, &medStringParameter::valueChanged, lineEdit, &QLineEdit::setText);
+    connect(lineEdit, &QLineEdit::textEdited, d->parameter, &medStringParameter::setValue);
 
     return lineEdit;
 }

--- a/src/layers/medWidgets/process/single_filter/medAbstractBiasCorrectionProcessPresenter.cpp
+++ b/src/layers/medWidgets/process/single_filter/medAbstractBiasCorrectionProcessPresenter.cpp
@@ -1,0 +1,32 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2017. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#pragma once
+
+#include <medAbstractBiasCorrectionProcessPresenter.h>
+
+class medAbstractBiasCorrectionProcessPresenterPrivate
+{
+public:
+
+};
+
+medAbstractBiasCorrectionProcessPresenter::medAbstractBiasCorrectionProcessPresenter(medAbstractBiasCorrectionProcess *parent) : medAbstractSingleFilterOperationProcessPresenter(parent)
+{
+
+}
+
+/*QT_NAMESPACE::QWidget* medAbstractBiasCorrectionProcessPresenter::buildToolBoxWidget()
+{
+
+}*/

--- a/src/layers/medWidgets/process/single_filter/medAbstractBiasCorrectionProcessPresenter.h
+++ b/src/layers/medWidgets/process/single_filter/medAbstractBiasCorrectionProcessPresenter.h
@@ -22,10 +22,11 @@
 class MEDWIDGETS_EXPORT medAbstractBiasCorrectionProcessPresenter: public medAbstractSingleFilterOperationProcessPresenter
 {
     Q_OBJECT
+private:
+
 public:
-    medAbstractBiasCorrectionProcessPresenter(medAbstractBiasCorrectionProcess *parent)
-        : medAbstractSingleFilterOperationProcessPresenter(parent)
-    {}
+    medAbstractBiasCorrectionProcessPresenter(medAbstractBiasCorrectionProcess *parent);
+    virtual QWidget* buildToolBoxWidget() = 0;
     virtual medAbstractBiasCorrectionProcess* process() const = 0;
 };
 

--- a/src/layers/medWidgets/process/single_filter/medAbstractBiasCorrectionProcessPresenter.h
+++ b/src/layers/medWidgets/process/single_filter/medAbstractBiasCorrectionProcessPresenter.h
@@ -1,0 +1,32 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2017. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#pragma once
+
+#include <medAbstractSingleFilterOperationProcessPresenter.h>
+#include <medProcessPresenterFactory.h>
+#include <medAbstractBiasCorrectionProcess.h>
+
+#include <medWidgetsExport.h>
+
+class MEDWIDGETS_EXPORT medAbstractBiasCorrectionProcessPresenter: public medAbstractSingleFilterOperationProcessPresenter
+{
+    Q_OBJECT
+public:
+    medAbstractBiasCorrectionProcessPresenter(medAbstractBiasCorrectionProcess *parent)
+        : medAbstractSingleFilterOperationProcessPresenter(parent)
+    {}
+    virtual medAbstractBiasCorrectionProcess* process() const = 0;
+};
+
+MED_DECLARE_PROCESS_PRESENTER_FACTORY(medAbstractBiasCorrectionProcess, MEDWIDGETS_EXPORT)

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -51,6 +51,7 @@ set(PLUGIN_LIST
   legacy/itkProcessRegistrationDiffeomorphicDemons                       ON
   legacy/medVtkView                                                      ON
   process/arithmetic_operation                                           ON
+  process/bias_correction                                                ON
   process/dwi_basic_thresholding                                         ON
   process/morphomath_operation                                           ON
   process/mask_image                                                     ON

--- a/src/plugins/process/bias_correction/CMakeLists.txt
+++ b/src/plugins/process/bias_correction/CMakeLists.txt
@@ -1,0 +1,76 @@
+################################################################################
+#
+# medInria
+#
+# Copyright (c) INRIA 2013 - 2014. All rights reserved.
+# See LICENSE.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.
+#
+################################################################################
+
+set(TARGET_NAME medItkBiasCorrectionProcessPlugin)
+
+## #############################################################################
+## Resolve dependencies
+## #############################################################################
+
+find_package(ITK)
+include(${ITK_USE_FILE})
+
+## #############################################################################
+## List Sources
+## #############################################################################
+
+list_source_files(${TARGET_NAME}
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+
+list_header_directories_to_include(${TARGET_NAME}
+  ${${TARGET_NAME}_HEADERS}
+  )
+
+## #############################################################################
+## add library
+## #############################################################################
+
+
+add_library(${TARGET_NAME} SHARED
+  ${${TARGET_NAME}_CFILES}
+  ${${TARGET_NAME}_QRC}
+  )
+
+
+## #############################################################################
+## include directorie.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PRIVATE ${${TARGET_NAME}_INCLUDE_DIRS}
+  )
+# PRIVATE beacause plugins are not supposed to be used somewhere else
+
+
+## #############################################################################
+## Link
+## #############################################################################
+
+target_link_libraries(${TARGET_NAME}
+  ITKCommon
+  ITKStatistics
+  Qt5::Core
+  dtkCore
+  dtkLog
+  medCore
+  medWidgets
+  )
+
+
+## #############################################################################
+## Install rules
+## #############################################################################
+
+set_plugin_install_rules(${TARGET_NAME})
+

--- a/src/plugins/process/bias_correction/medItkBiasCorrectionProcess.cpp
+++ b/src/plugins/process/bias_correction/medItkBiasCorrectionProcess.cpp
@@ -1,0 +1,399 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2014. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#include <medItkBiasCorrectionProcess.h>
+
+#include <dtkLog>
+
+#include <itkImage.h>
+//#include <itkBiasCorrectionFilter.h>
+#include <itkBinaryBallStructuringElement.h>
+#include <itkCommand.h>
+
+#include <medAbstractImageData.h>
+#include <medAbstractDataFactory.h>
+#include <medIntParameter.h>
+
+#include <itkN4BiasFieldCorrectionImageFilter.h>
+#include <itkExtractImageFilter.h>
+#include <itkConstantPadImageFilter.h>
+#include <itkOtsuThresholdImageFilter.h>
+#include <itkShrinkImageFilter.h>
+#include <itkTimeProbe.h>
+medItkBiasCorrectionProcess::medItkBiasCorrectionProcess(QObject *parent)
+    : medAbstractBiasCorrectionProcess(parent)
+
+{
+    m_filter = NULL;
+}
+
+medItkBiasCorrectionProcess::~medItkBiasCorrectionProcess()
+{
+
+}
+
+
+QString medItkBiasCorrectionProcess::caption() const
+{
+    return "Bias correction";
+}
+
+QString medItkBiasCorrectionProcess::description() const
+{
+    return "Use ITK N4BiasCorrectionFilter to compute a bias corrected image.";
+}
+medAbstractJob::medJobExitStatus medItkBiasCorrectionProcess::run()
+{
+    medAbstractJob::medJobExitStatus jobExitSatus = medAbstractJob::MED_JOB_EXIT_FAILURE;
+
+    if(this->input())
+    {
+        QString id =  this->input()->identifier();
+
+        if ( id == "itkDataImageChar3" )
+        {
+            jobExitSatus = this->_run<char, 3>();
+        }
+        else if ( id == "itkDataImageUChar3" )
+        {
+            jobExitSatus = this->_run<unsigned char, 3>();
+        }
+        else if ( id == "itkDataImageShort3" )
+        {
+            jobExitSatus = this->_run<short, 3>();
+        }
+        else if ( id == "itkDataImageUShort3" )
+        {
+            jobExitSatus = this->_run<unsigned short, 3>();
+        }
+        else if ( id == "itkDataImageInt3" )
+        {
+            jobExitSatus = this->_run<int, 3>();
+        }
+        else if ( id == "itkDataImageUInt3" )
+        {
+            jobExitSatus = this->_run<unsigned int, 3>();
+        }
+        else if ( id == "itkDataImageLong3" )
+        {
+            jobExitSatus = this->_run<long, 3>();
+        }
+        else if ( id== "itkDataImageULong3" )
+        {
+            jobExitSatus = this->_run<unsigned long, 3>();
+        }
+        else if ( id == "itkDataImageFloat3" )
+        {
+            jobExitSatus = this->_run<float, 3>();
+        }
+        else if ( id == "itkDataImageDouble3" )
+        {
+            jobExitSatus = this->_run<double, 3>();
+        }/*
+        else if ( id == "itkDataImageChar4" )
+        {
+            jobExitSatus = this->_run<char, 4>();
+        }
+        else if ( id == "itkDataImageUChar4" )
+        {
+            jobExitSatus = this->_run<unsigned char, 4>();
+        }
+        else if ( id == "itkDataImageShort4" )
+        {
+            jobExitSatus = this->_run<short, 4>();
+        }
+        else if ( id == "itkDataImageUShort4" )
+        {
+            jobExitSatus = this->_run<unsigned short, 4>();
+        }
+        else if ( id == "itkDataImageInt4" )
+        {
+            jobExitSatus = this->_run<int, 4>();
+        }
+        else if ( id == "itkDataImageUInt4" )
+        {
+            jobExitSatus = this->_run<unsigned int, 4>();
+        }
+        else if ( id == "itkDataImageLong4" )
+        {
+            jobExitSatus = this->_run<long, 4>();
+        }
+        else if ( id == "itkDataImageULong4" )
+        {
+            jobExitSatus = this->_run<unsigned long, 4>();
+        }
+        else if ( id == "itkDataImageFloat4" )
+        {
+            jobExitSatus = this->_run<float, 4>();
+        }
+        else if ( id == "itkDataImageDouble4" )
+        {
+            jobExitSatus = this->_run<double, 4>();
+        }*/
+    }
+    return jobExitSatus;
+}
+
+
+template <class inputType, unsigned int Dimension> medAbstractJob::medJobExitStatus medItkBiasCorrectionProcess::_run()
+{
+    N4BiasCorrectionCore();
+    return medAbstractJob::MED_JOB_EXIT_FAILURE;
+}
+
+void medItkBiasCorrectionProcess::cancel()
+{
+    if(this->isRunning() && m_filter.IsNotNull())
+    {
+        m_filter->AbortGenerateDataOn();
+    }
+}
+
+void medItkBiasCorrectionProcess::N4BiasCorrectionCore()
+{
+   typedef itk::Image<float, 3 > ImageType;
+   typedef itk::Image<unsigned char, 3> MaskImageType;
+   typedef itk::N4BiasFieldCorrectionImageFilter<ImageType, MaskImageType, ImageType> BiasFilter;
+   typedef itk::ConstantPadImageFilter<ImageType, ImageType> PadderType;
+   typedef itk::ConstantPadImageFilter<MaskImageType, MaskImageType> MaskPadderType;
+   typedef itk::ShrinkImageFilter<ImageType, ImageType> ShrinkerType;
+   typedef itk::ShrinkImageFilter<MaskImageType, MaskImageType> MaskShrinkerType;
+   typedef itk::BSplineControlPointImageFilter< BiasFilter::BiasFieldControlPointLatticeType, BiasFilter::ScalarImageType> BSplinerType;
+   typedef itk::ExpImageFilter<ImageType, ImageType> ExpFilterType;
+   typedef itk::DivideImageFilter<ImageType, ImageType, ImageType> DividerType;
+   typedef itk::ExtractImageFilter<ImageType, ImageType> CropperType;
+
+   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+   /////////////////////////////////////////////////  TODO TODO TODO ////////////////////////////////////////////////////////////////
+   /////////////////////////////////////////////////  TODO TODO TODO ////////////////////////////////////////////////////////////////
+   /////////////////////////////////////////////////  TODO TODO TODO ////////////////////////////////////////////////////////////////
+   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+   unsigned int uiThreadNb = 0;
+   unsigned int uiShrinkFactors = 0;
+   unsigned int uiSplineOrder = 0;
+   float fWienerFilterNoise;
+   float fbfFWHM;
+   float fConvergenceThreshold;
+   std::vector<unsigned int> oMaxNumbersIterationsVector;//TODO = extractMaxNumberOfIterationsVector(oArgIterationsString.getValue());
+   std::vector<float> oInitialMeshResolutionVect;//TODO = ConvertVector<float>(oArgInitialMeshResolutionString.getValue());
+   float fSplineDistance;//TODO = oArgSplineDistance.getValue();
+
+
+   /********************************************************************************/
+   /***************************** PREPARING STARTING *******************************/
+   /********************************************************************************/
+
+   /*** 0 ******************* Create filter and accessories ******************/
+   BiasFilter::Pointer filter = BiasFilter::New();
+   BiasFilter::ArrayType oNumberOfControlPointsArray;
+
+   /*** 1 ******************* Read input image *******************************/
+   ImageType::Pointer image = dynamic_cast<ImageType *>((itk::Object*)(this->input()->data()));
+
+   /*** 2 ******************* Creating Otsu mask *****************************/
+   //TODO std::cout << "Creating Otsu mask." << std::endl;
+   itk::TimeProbe timer;
+   timer.Start();
+   MaskImageType::Pointer maskImage = ITK_NULLPTR;
+   typedef itk::OtsuThresholdImageFilter<ImageType, MaskImageType> ThresholderType;
+   ThresholderType::Pointer otsu = ThresholderType::New();
+   otsu->SetInput(image);
+   otsu->SetNumberOfHistogramBins(200);
+   otsu->SetInsideValue(0);
+   otsu->SetOutsideValue(1);
+
+   otsu->SetNumberOfThreads(uiThreadNb);
+   otsu->Update();
+   maskImage = otsu->GetOutput();
+
+   /*** 3A *************** Set Maximum number of Iterations for the filter ***/
+   BiasFilter::VariableSizeArrayType itkTabMaximumIterations;
+   itkTabMaximumIterations.SetSize(oMaxNumbersIterationsVector.size());
+   for (int i = 0; i < oMaxNumbersIterationsVector.size(); ++i)
+   {
+      itkTabMaximumIterations[i] = oMaxNumbersIterationsVector[i];
+   }
+   filter->SetMaximumNumberOfIterations(itkTabMaximumIterations);
+
+   /*** 3B *************** Set Fitting Levels for the filter *****************/
+   BiasFilter::ArrayType oFittingLevelsTab;
+   oFittingLevelsTab.Fill(oMaxNumbersIterationsVector.size());
+   filter->SetNumberOfFittingLevels(oFittingLevelsTab);
+
+   /*** 4 ******************* Save image's index, size, origine **************/
+   ImageType::IndexType oImageIndex = image->GetLargestPossibleRegion().GetIndex();
+   ImageType::SizeType oImageSize = image->GetLargestPossibleRegion().GetSize();
+   ImageType::PointType newOrigin = image->GetOrigin();
+
+   if (fSplineDistance > 0)
+   {
+      /*** 5 ******************* Compute number of control points  **************/
+      itk::SizeValueType lowerBound[3];
+      itk::SizeValueType upperBound[3];
+
+      for (unsigned int i = 0; i < 3; i++)
+      {
+         float domain = static_cast<float>(image->GetLargestPossibleRegion().GetSize()[i] - 1) * image->GetSpacing()[i];
+         unsigned int numberOfSpans = static_cast<unsigned int>(std::ceil(domain / fSplineDistance));
+         unsigned long extraPadding = static_cast<unsigned long>((numberOfSpans * fSplineDistance - domain) / image->GetSpacing()[i] + 0.5);
+         lowerBound[i] = static_cast<unsigned long>(0.5 * extraPadding);
+         upperBound[i] = extraPadding - lowerBound[i];
+         newOrigin[i] -= (static_cast<float>(lowerBound[i]) * image->GetSpacing()[i]);
+         oNumberOfControlPointsArray[i] = numberOfSpans + filter->GetSplineOrder();
+      }
+
+      /*** 6 ******************* Padder  ****************************************/
+      PadderType::Pointer imagePadder = PadderType::New();
+      imagePadder->SetInput(image);
+      imagePadder->SetPadLowerBound(lowerBound);
+      imagePadder->SetPadUpperBound(upperBound);
+      imagePadder->SetConstant(0);
+      imagePadder->SetNumberOfThreads(uiThreadNb);
+      imagePadder->Update();
+
+      image = imagePadder->GetOutput();
+
+      /*** 7 ******************** Handle the mask image *************************/
+      MaskPadderType::Pointer maskPadder = MaskPadderType::New();
+      maskPadder->SetInput(maskImage);
+      maskPadder->SetPadLowerBound(lowerBound);
+      maskPadder->SetPadUpperBound(upperBound);
+      maskPadder->SetConstant(0);
+
+      maskPadder->SetNumberOfThreads(uiThreadNb);
+      maskPadder->Update();
+
+      maskImage = maskPadder->GetOutput();
+
+      /*** 8 ******************** SetNumber Of Control Points *******************/
+      filter->SetNumberOfControlPoints(oNumberOfControlPointsArray);
+   }
+   else if (oInitialMeshResolutionVect.size() == 3)
+   {
+      /*** 9 ******************** SetNumber Of Control Points alternative *******/
+      for (unsigned i = 0; i < 3; i++)
+      {
+         oNumberOfControlPointsArray[i] = static_cast<unsigned int>(oInitialMeshResolutionVect[i]) + filter->GetSplineOrder();
+      }
+      filter->SetNumberOfControlPoints(oNumberOfControlPointsArray);
+   }
+   else
+   {
+      std::cout << "No BSpline distance and Mesh Resolution is ignored because not 3 dimensions" << std::endl;
+   }
+
+   /*** 10 ******************* Shrinker image ********************************/
+   ShrinkerType::Pointer imageShrinker = ShrinkerType::New();
+   imageShrinker->SetInput(image);
+   imageShrinker->SetShrinkFactors(1);
+
+   /*** 11 ******************* Shrinker mask *********************************/
+   MaskShrinkerType::Pointer maskShrinker = MaskShrinkerType::New();
+   maskShrinker->SetInput(maskImage);
+   maskShrinker->SetShrinkFactors(1);
+
+   /*** 12 ******************* Shrink mask and image *************************/
+   imageShrinker->SetShrinkFactors(uiShrinkFactors);
+   maskShrinker->SetShrinkFactors(uiShrinkFactors);
+   imageShrinker->SetNumberOfThreads(uiThreadNb);
+   maskShrinker->SetNumberOfThreads(uiThreadNb);
+   imageShrinker->Update();
+   maskShrinker->Update();
+
+
+   /*** 13 ******************* Filter setings ********************************/
+   filter->SetSplineOrder(uiSplineOrder);
+   filter->SetWienerFilterNoise(fWienerFilterNoise);
+   filter->SetBiasFieldFullWidthAtHalfMaximum(fbfFWHM);
+   filter->SetConvergenceThreshold(fConvergenceThreshold);
+   filter->SetInput(imageShrinker->GetOutput());
+   filter->SetMaskImage(maskShrinker->GetOutput());
+
+   /*** 14 ******************* Apply filter **********************************/
+   itk::CStyleCommand::Pointer callback = itk::CStyleCommand::New();
+   callback->SetCallback(eventCallback);
+   filter->AddObserver(itk::ProgressEvent(), callback);
+   try
+   {
+      filter->SetNumberOfThreads(uiThreadNb);
+      filter->Update();
+   }
+   catch (itk::ExceptionObject & err)
+   {
+      std::cerr << "ExceptionObject caught !" << std::endl;
+      std::cerr << err << std::endl;
+      exit(EXIT_FAILURE);
+   }
+
+
+   /**
+   * Reconstruct the bias field at full image resolution.  Divide
+   * the original input image by the bias field to get the final
+   * corrected image.
+   */
+   BSplinerType::Pointer bspliner = BSplinerType::New();
+   bspliner->SetInput(filter->GetLogBiasFieldControlPointLattice());
+   bspliner->SetSplineOrder(filter->GetSplineOrder());
+   bspliner->SetSize(image->GetLargestPossibleRegion().GetSize());
+   bspliner->SetOrigin(newOrigin);
+   bspliner->SetDirection(image->GetDirection());
+   bspliner->SetSpacing(image->GetSpacing());
+   bspliner->SetNumberOfThreads(uiThreadNb);
+   bspliner->Update();
+
+   ImageType::Pointer logField = ImageType::New();
+   logField->SetOrigin(image->GetOrigin());
+   logField->SetSpacing(image->GetSpacing());
+   logField->SetRegions(image->GetLargestPossibleRegion());
+   logField->SetDirection(image->GetDirection());
+   logField->Allocate();
+
+   itk::ImageRegionIterator<BiasFilter::ScalarImageType> IB(bspliner->GetOutput(), bspliner->GetOutput()->GetLargestPossibleRegion());
+
+   itk::ImageRegionIterator<ImageType> IF(logField, logField->GetLargestPossibleRegion());
+
+   for (IB.GoToBegin(), IF.GoToBegin(); !IB.IsAtEnd(); ++IB, ++IF)
+   {
+      IF.Set(IB.Get()[0]);
+   }
+
+   ExpFilterType::Pointer expFilter = ExpFilterType::New();
+   expFilter->SetInput(logField);
+   expFilter->SetNumberOfThreads(uiThreadNb);
+   expFilter->Update();
+
+   DividerType::Pointer divider = DividerType::New();
+   divider->SetInput1(image);
+   divider->SetInput2(expFilter->GetOutput());
+   divider->SetNumberOfThreads(uiThreadNb);
+   divider->Update();
+
+   ImageType::RegionType inputRegion;
+   inputRegion.SetIndex(oImageIndex);
+   inputRegion.SetSize(oImageSize);
+
+   CropperType::Pointer cropper = CropperType::New();
+   cropper->SetInput(divider->GetOutput());
+   cropper->SetExtractionRegion(inputRegion);
+   cropper->SetDirectionCollapseToSubmatrix();
+   cropper->SetNumberOfThreads(uiThreadNb);
+   cropper->Update();
+
+   timer.Stop();
+   std::cout << "\nComputation time : " << timer.GetTotal() << std::endl;
+
+   /********************** Write output image *************************/
+   medAbstractImageData *out = qobject_cast<medAbstractImageData *>(medAbstractDataFactory::instance()->create(this->input()->identifier()));
+   out->setData(cropper->GetOutput());
+   this->setOutput(out);
+}

--- a/src/plugins/process/bias_correction/medItkBiasCorrectionProcess.cpp
+++ b/src/plugins/process/bias_correction/medItkBiasCorrectionProcess.cpp
@@ -350,12 +350,10 @@ medAbstractJob::medJobExitStatus medItkBiasCorrectionProcess::N4BiasCorrectionCo
    /*** 10 ******************* Shrinker image ********************************/
    ShrinkerType::Pointer imageShrinker = ShrinkerType::New();
    imageShrinker->SetInput(image);
-   imageShrinker->SetShrinkFactors(1);
 
    /*** 11 ******************* Shrinker mask *********************************/
    MaskShrinkerType::Pointer maskShrinker = MaskShrinkerType::New();
    maskShrinker->SetInput(maskImage);
-   maskShrinker->SetShrinkFactors(1);
 
    /*** 12 ******************* Shrink mask and image *************************/
    imageShrinker->SetShrinkFactors(uiShrinkFactors);
@@ -445,8 +443,8 @@ medAbstractJob::medJobExitStatus medItkBiasCorrectionProcess::N4BiasCorrectionCo
    cropper->SetNumberOfThreads(uiThreadNb);
    cropper->Update();
 
-   timer.Stop();
-   std::cout << "\nComputation time : " << timer.GetTotal() << std::endl;
+   //timer.Stop();
+   //std::cout << "\nComputation time : " << timer.GetTotal() << std::endl;
 
    /********************** Write output image *************************/
    medAbstractImageData *out = qobject_cast<medAbstractImageData *>(medAbstractDataFactory::instance()->create(this->input()->identifier()));

--- a/src/plugins/process/bias_correction/medItkBiasCorrectionProcess.cpp
+++ b/src/plugins/process/bias_correction/medItkBiasCorrectionProcess.cpp
@@ -44,20 +44,20 @@ medItkBiasCorrectionProcess::medItkBiasCorrectionProcess(QObject *parent): medAb
 
     m_poUIThreadNb = new medIntParameter("ThreadNb", this);
     m_poUIThreadNb->setCaption("Number of threads");
-    m_poUIThreadNb->setDescription("Set the number of computing treads, 0 for 1 thread per CPU");
-    m_poUIThreadNb->setRange(0, 128);
-    m_poUIThreadNb->setValue(0);
+    m_poUIThreadNb->setDescription("Set the number of computing treads");
+    m_poUIThreadNb->setRange(1, itk::MultiThreader::GetGlobalDefaultNumberOfThreads());
+    m_poUIThreadNb->setValue(itk::MultiThreader::GetGlobalDefaultNumberOfThreads());
 
     m_poUIShrinkFactors = new medIntParameter("Shrinkfactor", this);
     m_poUIShrinkFactors->setCaption("Shrink factor");
     m_poUIShrinkFactors->setDescription("Shrink factor");
-    m_poUIShrinkFactors->setRange(0, MAX_INT_POSITIVE);
+    m_poUIShrinkFactors->setRange(1, 10);
     m_poUIShrinkFactors->setValue(4);
 
     m_poUISplineOrder = new medIntParameter("BSplineOrder", this);
     m_poUISplineOrder->setCaption("BSpline Order");
     m_poUISplineOrder->setDescription("BSpline Order");
-    m_poUISplineOrder->setRange(0, MAX_INT_POSITIVE);
+    m_poUISplineOrder->setRange(1, 16);
     m_poUISplineOrder->setValue(3);
 
     m_poUIMaxNumbersIterationsVector1 = new medIntParameter("Iterations1st", this);
@@ -91,7 +91,7 @@ medItkBiasCorrectionProcess::medItkBiasCorrectionProcess(QObject *parent): medAb
     m_poFConvergenceThreshold = new medDoubleParameter("ConvergenceThreshold", this);
     m_poFConvergenceThreshold->setCaption("Convergence Threshold");
     m_poFConvergenceThreshold->setDescription("Convergence Threshold");
-    m_poFConvergenceThreshold->setRange(0.00000001, MAX_INT_POSITIVE);
+    m_poFConvergenceThreshold->setRange(0.00000001, 10);
     m_poFConvergenceThreshold->setValue(0.0001);
 
     m_poFSplineDistance = new medDoubleParameter("SplineDistance", this);

--- a/src/plugins/process/bias_correction/medItkBiasCorrectionProcess.h
+++ b/src/plugins/process/bias_correction/medItkBiasCorrectionProcess.h
@@ -45,12 +45,43 @@ public:
     virtual QString caption() const;
     virtual QString description() const;
 
+
+    medIntParameter* getUIThreadNb() { return m_poUIThreadNb; }
+    medIntParameter* getUIShrinkFactors() { return m_poUIShrinkFactors; }
+    medIntParameter* getUISplineOrder() { return m_poUISplineOrder; }
+    medIntParameter* getUIMaxNumbersIterationsVector1() { return m_poUIMaxNumbersIterationsVector1; }
+    medIntParameter* getUIMaxNumbersIterationsVector2() { return m_poUIMaxNumbersIterationsVector2; }
+    medIntParameter* getUIMaxNumbersIterationsVector3() { return m_poUIMaxNumbersIterationsVector3; }
+
+    medDoubleParameter* getFWienerFilterNoise() { return m_poFWienerFilterNoise; }
+    medDoubleParameter* getFbfFWHM() { return m_poFbfFWHM; }
+    medDoubleParameter* getFConvergenceThreshold() { return m_poFConvergenceThreshold; }
+    medDoubleParameter* getFSplineDistance() { return m_poFSplineDistance; }
+    medDoubleParameter* getFInitialMeshResolutionVect1() { return m_poFInitialMeshResolutionVect1; }
+    medDoubleParameter* getFInitialMeshResolutionVect2() { return m_poFInitialMeshResolutionVect2; }
+    medDoubleParameter* getFInitialMeshResolutionVect3() { return m_poFInitialMeshResolutionVect3; }
+
 private:
     template <class inputType, unsigned int Dimension> medAbstractJob::medJobExitStatus _run();
-    void N4BiasCorrectionCore();
+    medJobExitStatus N4BiasCorrectionCore();
 
 private:
     itk::SmartPointer<itk::ProcessObject> m_filter;
+
+    medIntParameter    *m_poUIThreadNb;
+    medIntParameter    *m_poUIShrinkFactors;
+    medIntParameter    *m_poUISplineOrder;
+    medIntParameter    *m_poUIMaxNumbersIterationsVector1;
+    medIntParameter    *m_poUIMaxNumbersIterationsVector2;
+    medIntParameter    *m_poUIMaxNumbersIterationsVector3;
+
+    medDoubleParameter *m_poFWienerFilterNoise;
+    medDoubleParameter *m_poFbfFWHM;
+    medDoubleParameter *m_poFConvergenceThreshold;
+    medDoubleParameter *m_poFSplineDistance;
+    medDoubleParameter *m_poFInitialMeshResolutionVect1;
+    medDoubleParameter *m_poFInitialMeshResolutionVect2;
+    medDoubleParameter *m_poFInitialMeshResolutionVect3;
 };
 
 inline medAbstractBiasCorrectionProcess* medItkBiasCorrectionProcessCreator()

--- a/src/plugins/process/bias_correction/medItkBiasCorrectionProcess.h
+++ b/src/plugins/process/bias_correction/medItkBiasCorrectionProcess.h
@@ -19,6 +19,7 @@
 #include <itkSmartPointer.h>
 
 #include <medIntParameter.h>
+#include <medStringParameter.h>
 
 #include <medItkBiasCorrectionProcessPluginExport.h>
 
@@ -49,9 +50,7 @@ public:
     medIntParameter* getUIThreadNb() { return m_poUIThreadNb; }
     medIntParameter* getUIShrinkFactors() { return m_poUIShrinkFactors; }
     medIntParameter* getUISplineOrder() { return m_poUISplineOrder; }
-    medIntParameter* getUIMaxNumbersIterationsVector1() { return m_poUIMaxNumbersIterationsVector1; }
-    medIntParameter* getUIMaxNumbersIterationsVector2() { return m_poUIMaxNumbersIterationsVector2; }
-    medIntParameter* getUIMaxNumbersIterationsVector3() { return m_poUIMaxNumbersIterationsVector3; }
+    medStringParameter* getSMaxIterations() { return m_poSMaxIterations; }
 
     medDoubleParameter* getFWienerFilterNoise() { return m_poFWienerFilterNoise; }
     medDoubleParameter* getFbfFWHM() { return m_poFbfFWHM; }
@@ -63,7 +62,7 @@ public:
 
 private:
     template <class inputType, unsigned int Dimension> medAbstractJob::medJobExitStatus _run();
-    medJobExitStatus N4BiasCorrectionCore();
+    template <class inputType, unsigned int Dimension> medAbstractJob::medJobExitStatus N4BiasCorrectionCore();
 
 private:
     itk::SmartPointer<itk::ProcessObject> m_filter;
@@ -71,9 +70,7 @@ private:
     medIntParameter    *m_poUIThreadNb;
     medIntParameter    *m_poUIShrinkFactors;
     medIntParameter    *m_poUISplineOrder;
-    medIntParameter    *m_poUIMaxNumbersIterationsVector1;
-    medIntParameter    *m_poUIMaxNumbersIterationsVector2;
-    medIntParameter    *m_poUIMaxNumbersIterationsVector3;
+    medStringParameter *m_poSMaxIterations;
 
     medDoubleParameter *m_poFWienerFilterNoise;
     medDoubleParameter *m_poFbfFWHM;

--- a/src/plugins/process/bias_correction/medItkBiasCorrectionProcess.h
+++ b/src/plugins/process/bias_correction/medItkBiasCorrectionProcess.h
@@ -1,0 +1,59 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2017. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#pragma once
+
+#include <medAbstractBiasCorrectionProcess.h>
+
+#include <itkProcessObject.h>
+#include <itkSmartPointer.h>
+
+#include <medIntParameter.h>
+
+#include <medItkBiasCorrectionProcessPluginExport.h>
+
+class medItkBiasCorrectionProcessPrivate;
+
+class MEDITKBIASCORRECTIONPROCESSPLUGIN_EXPORT medItkBiasCorrectionProcess: public medAbstractBiasCorrectionProcess
+{
+    Q_OBJECT
+public:
+    static void eventCallback(itk::Object *caller, const itk::EventObject& event, void *clientData)
+    {
+        medAbstractBiasCorrectionProcess * source = reinterpret_cast<medAbstractBiasCorrectionProcess *>(clientData);
+        itk::ProcessObject * processObject = (itk::ProcessObject*) caller;
+        source->progression()->setValue(processObject->GetProgress() * 100);
+    }
+
+
+    medItkBiasCorrectionProcess(QObject* parent = NULL);
+    ~medItkBiasCorrectionProcess();
+
+    virtual medAbstractJob::medJobExitStatus run();
+    virtual void cancel();
+
+    virtual QString caption() const;
+    virtual QString description() const;
+
+private:
+    template <class inputType, unsigned int Dimension> medAbstractJob::medJobExitStatus _run();
+    void N4BiasCorrectionCore();
+
+private:
+    itk::SmartPointer<itk::ProcessObject> m_filter;
+};
+
+inline medAbstractBiasCorrectionProcess* medItkBiasCorrectionProcessCreator()
+{
+    return new medItkBiasCorrectionProcess();
+}

--- a/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPlugin.cpp
+++ b/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPlugin.cpp
@@ -1,0 +1,35 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2017. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#include <medItkBiasCorrectionProcessPlugin.h>
+
+#include <medCore.h>
+#include <medWidgets.h>
+
+#include <medItkBiasCorrectionProcess.h>
+#include <medItkBiasCorrectionProcessPresenter.h>
+
+void medItkBiasCorrectionProcessPlugin::initialize(void)
+{
+    medCore::singleFilterOperation::biasCorrection::pluginFactory().record(medItkBiasCorrectionProcess::staticMetaObject.className(), medItkBiasCorrectionProcessCreator);
+
+    medWidgets::singleFilterOperation::biasCorrection::presenterFactory().record(medItkBiasCorrectionProcess::staticMetaObject.className(), medItkBiasCorrectionProcessPresenterCreator);
+}
+
+void medItkBiasCorrectionProcessPlugin::uninitialize(void)
+{
+
+}
+
+DTK_DEFINE_PLUGIN(medItkBiasCorrectionProcess)
+//DTK_DEFINE_PLUGIN(medItkBiasCorrectionProcessPresenter)

--- a/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPlugin.h
+++ b/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPlugin.h
@@ -1,0 +1,36 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2017. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#pragma once
+
+#include <medAbstractBiasCorrectionProcess.h>
+
+#include <medItkBiasCorrectionProcessPluginExport.h>
+
+#include <medAbstractSingleFilterOperationProcess.h>
+
+class MEDITKBIASCORRECTIONPROCESSPLUGIN_EXPORT medItkBiasCorrectionProcessPlugin : public medAbstractSingleFilterOperationProcessPlugin
+{
+    Q_OBJECT
+
+    Q_INTERFACES(medAbstractSingleFilterOperationProcessPlugin)
+    Q_PLUGIN_METADATA(IID "fr.inria.medItkBiasCorrectionProcessPlugin" FILE "medItkBiasCorrectionProcessPlugin.json")
+
+public:
+     medItkBiasCorrectionProcessPlugin() {}
+     virtual ~medItkBiasCorrectionProcessPlugin() {}
+
+public:
+    void initialize();
+    void uninitialize();
+};

--- a/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPlugin.json
+++ b/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPlugin.json
@@ -1,0 +1,6 @@
+{
+            "name" : "medItkBiasCorrectionProcessPlugin",
+         "concept" : "medAbstractBiasCorrectionProcess",
+         "version" : "0.0.1", 	
+    "dependencies" : []
+}

--- a/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPlugin.json
+++ b/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPlugin.json
@@ -1,6 +1,6 @@
 {
-            "name" : "medItkBiasCorrectionProcessPlugin",
-         "concept" : "medAbstractBiasCorrectionProcess",
-         "version" : "0.0.1", 	
+    "name" : "medItkBiasCorrectionProcessPlugin",
+    "concept" : "medAbstractSingleFilterOperationProcess",
+    "version" : "3.0.0",
     "dependencies" : []
 }

--- a/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPlugin.qrc
+++ b/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPlugin.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>medItkBiasCorrectionProcessPlugin.json</file>
+    </qresource>
+</RCC>

--- a/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPluginExport.h
+++ b/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPluginExport.h
@@ -1,0 +1,26 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2014. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#pragma once
+
+#include <QtGlobal>
+
+#if defined(medItkBiasCorrectionProcessPlugin_EXPORTS)
+#  define MEDITKBIASCORRECTIONPROCESSPLUGIN_EXPORT Q_DECL_EXPORT
+#else
+#  define MEDITKBIASCORRECTIONPROCESSPLUGIN_EXPORT Q_DECL_IMPORT
+#endif
+
+
+
+

--- a/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPresenter.cpp
+++ b/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPresenter.cpp
@@ -17,6 +17,7 @@
 
 #include <medIntParameterPresenter.h>
 #include <medDoubleParameterPresenter.h>
+#include <medStringParameterPresenter.h>
 
 #include <QLayout>
 #include <QWidget>
@@ -30,9 +31,7 @@ medItkBiasCorrectionProcessPresenter::medItkBiasCorrectionProcessPresenter(medIt
    m_poUIPresenterThreadNb = new medIntParameterPresenter(m_process->getUIThreadNb());
    m_poUIPresenterShrinkFactors = new medIntParameterPresenter(m_process->getUIShrinkFactors());
    m_poUIPresenterSplineOrder = new medIntParameterPresenter(m_process->getUISplineOrder());
-   m_poUIPresenterMaxNumbersIterationsVector1 = new medIntParameterPresenter(m_process->getUIMaxNumbersIterationsVector1());
-   m_poUIPresenterMaxNumbersIterationsVector2 = new medIntParameterPresenter(m_process->getUIMaxNumbersIterationsVector2());
-   m_poUIPresenterMaxNumbersIterationsVector3 = new medIntParameterPresenter(m_process->getUIMaxNumbersIterationsVector3());
+   m_poSPresenterMaxIterations = new medStringParameterPresenter(m_process->getSMaxIterations());
 
    m_poFPresenterWienerFilterNoise = new medDoubleParameterPresenter(m_process->getFWienerFilterNoise());
    m_poFPresenterbfFWHM = new medDoubleParameterPresenter(m_process->getFbfFWHM());
@@ -67,12 +66,11 @@ QWidget * medItkBiasCorrectionProcessPresenter::buildToolBoxWidget()
    poSplineOrderLayout->addWidget(m_poUIPresenterSplineOrder->buildWidget());
    poVLayout->addLayout(poSplineOrderLayout);
 
-   QLabel *poMaxNumbersIterationsLabel = new QLabel(m_poUIPresenterMaxNumbersIterationsVector1->parameter()->caption(), poResWidget);
+   QLabel *poMaxNumbersIterationsLabel = new QLabel(m_poSPresenterMaxIterations->parameter()->caption(), poResWidget);
    QHBoxLayout *poMaxNumbersIterationsLayout = new QHBoxLayout;
    poMaxNumbersIterationsLayout->addWidget(poMaxNumbersIterationsLabel);
-   poMaxNumbersIterationsLayout->addWidget(m_poUIPresenterMaxNumbersIterationsVector1->buildWidget());
-   poMaxNumbersIterationsLayout->addWidget(m_poUIPresenterMaxNumbersIterationsVector2->buildWidget());
-   poMaxNumbersIterationsLayout->addWidget(m_poUIPresenterMaxNumbersIterationsVector3->buildWidget());
+   poMaxNumbersIterationsLayout->addWidget(m_poSPresenterMaxIterations->buildWidget());
+
    poVLayout->addLayout(poMaxNumbersIterationsLayout);
    
 
@@ -101,7 +99,9 @@ QWidget * medItkBiasCorrectionProcessPresenter::buildToolBoxWidget()
    poVLayout->addLayout(poSplineDistanceLayout);
 
 
-   QLabel *poInitialMeshResolutionLabel = new QLabel(m_poFPresenterInitialMeshResolutionVect1->parameter()->caption(), poResWidget);
+   QLabel *poInitialMeshResolutionLabelX = new QLabel(m_poFPresenterInitialMeshResolutionVect1->parameter()->caption(), poResWidget);
+   QLabel *poInitialMeshResolutionLabelY = new QLabel(m_poFPresenterInitialMeshResolutionVect2->parameter()->caption(), poResWidget);
+   QLabel *poInitialMeshResolutionLabelZ = new QLabel(m_poFPresenterInitialMeshResolutionVect3->parameter()->caption(), poResWidget);
    QWidget *poWInitialMeshResolution1 = m_poFPresenterInitialMeshResolutionVect1->buildWidget();
    QWidget *poWInitialMeshResolution2 = m_poFPresenterInitialMeshResolutionVect2->buildWidget();
    QWidget *poWInitialMeshResolution3 = m_poFPresenterInitialMeshResolutionVect3->buildWidget();
@@ -109,25 +109,29 @@ QWidget * medItkBiasCorrectionProcessPresenter::buildToolBoxWidget()
    connect(m_poFPresenterSplineDistance->parameter(), &medDoubleParameter::valueChanged, [=](double pi_fVal)
    {
       bool bActive = pi_fVal != 0;
-      poInitialMeshResolutionLabel->setDisabled(bActive);
+      poInitialMeshResolutionLabelX->setDisabled(bActive);
+      poInitialMeshResolutionLabelY->setDisabled(bActive);
+      poInitialMeshResolutionLabelZ->setDisabled(bActive);
       poWInitialMeshResolution1->setDisabled(bActive);
       poWInitialMeshResolution2->setDisabled(bActive);
       poWInitialMeshResolution3->setDisabled(bActive);
    });
-   QHBoxLayout *poInitialMeshResolutionLayout = new QHBoxLayout;
-   poInitialMeshResolutionLayout->addWidget(poInitialMeshResolutionLabel);
-   poInitialMeshResolutionLayout->addWidget(poWInitialMeshResolution1);
-   poInitialMeshResolutionLayout->addWidget(poWInitialMeshResolution2);
-   poInitialMeshResolutionLayout->addWidget(poWInitialMeshResolution3);
-   /*poInitialMeshResolutionLayout->setSizeConstraint(QLayout::SetMaximumSize);
-   poInitialMeshResolutionLayout->setSizeConstraint(QLayout::SetMaximumSize);
-   poInitialMeshResolutionLayout->setSizeConstraint(QLayout::SetMaximumSize);
-   poInitialMeshResolutionLayout->setSizeConstraint(QLayout::SetMaximumSize);*/
-   poVLayout->addLayout(poInitialMeshResolutionLayout);
+
+   QHBoxLayout *poInitialMeshResolutionLayoutX = new QHBoxLayout;
+   poInitialMeshResolutionLayoutX->addWidget(poInitialMeshResolutionLabelX);
+   poInitialMeshResolutionLayoutX->addWidget(poWInitialMeshResolution1);
+   poVLayout->addLayout(poInitialMeshResolutionLayoutX);
+   QHBoxLayout *poInitialMeshResolutionLayoutY = new QHBoxLayout;
+   poInitialMeshResolutionLayoutY->addWidget(poInitialMeshResolutionLabelY);
+   poInitialMeshResolutionLayoutY->addWidget(poWInitialMeshResolution2);
+   poVLayout->addLayout(poInitialMeshResolutionLayoutY);
+   QHBoxLayout *poInitialMeshResolutionLayoutZ = new QHBoxLayout;
+   poInitialMeshResolutionLayoutZ->addWidget(poInitialMeshResolutionLabelZ);
+   poInitialMeshResolutionLayoutZ->addWidget(poWInitialMeshResolution3);
+   poVLayout->addLayout(poInitialMeshResolutionLayoutZ);
 
    poVLayout->addWidget(buildRunButton());
    poVLayout->addWidget(buildCancelButton());
-   //poVLayout->setSizeConstraint(QLayout::SetMinimumSize);// SetMinimumSize
 
    return poResWidget;
 }

--- a/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPresenter.cpp
+++ b/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPresenter.cpp
@@ -1,0 +1,133 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2017. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#pragma once
+
+#include <medItkBiasCorrectionProcessPresenter.h>
+
+#include <medIntParameterPresenter.h>
+#include <medDoubleParameterPresenter.h>
+
+#include <QLayout>
+#include <QWidget>
+#include <QLabel>
+#include <QPushButton>
+
+medItkBiasCorrectionProcessPresenter::medItkBiasCorrectionProcessPresenter(medItkBiasCorrectionProcess *parent) : medAbstractBiasCorrectionProcessPresenter(parent)
+{
+   m_process = parent;
+
+   m_poUIPresenterThreadNb = new medIntParameterPresenter(m_process->getUIThreadNb());
+   m_poUIPresenterShrinkFactors = new medIntParameterPresenter(m_process->getUIShrinkFactors());
+   m_poUIPresenterSplineOrder = new medIntParameterPresenter(m_process->getUISplineOrder());
+   m_poUIPresenterMaxNumbersIterationsVector1 = new medIntParameterPresenter(m_process->getUIMaxNumbersIterationsVector1());
+   m_poUIPresenterMaxNumbersIterationsVector2 = new medIntParameterPresenter(m_process->getUIMaxNumbersIterationsVector2());
+   m_poUIPresenterMaxNumbersIterationsVector3 = new medIntParameterPresenter(m_process->getUIMaxNumbersIterationsVector3());
+
+   m_poFPresenterWienerFilterNoise = new medDoubleParameterPresenter(m_process->getFWienerFilterNoise());
+   m_poFPresenterbfFWHM = new medDoubleParameterPresenter(m_process->getFbfFWHM());
+   m_poFPresenterConvergenceThreshold = new medDoubleParameterPresenter(m_process->getFConvergenceThreshold());
+   m_poFPresenterSplineDistance = new medDoubleParameterPresenter(m_process->getFSplineDistance());
+   m_poFPresenterInitialMeshResolutionVect1 = new medDoubleParameterPresenter(m_process->getFInitialMeshResolutionVect1());
+   m_poFPresenterInitialMeshResolutionVect2 = new medDoubleParameterPresenter(m_process->getFInitialMeshResolutionVect2());
+   m_poFPresenterInitialMeshResolutionVect3 = new medDoubleParameterPresenter(m_process->getFInitialMeshResolutionVect3());
+}
+
+QWidget * medItkBiasCorrectionProcessPresenter::buildToolBoxWidget()
+{
+   QWidget *poResWidget = new QWidget;
+   QVBoxLayout *poVLayout = new QVBoxLayout;
+   poResWidget->setLayout(poVLayout);
+
+   QLabel *poThredNbLabel = new QLabel(m_poUIPresenterThreadNb->parameter()->caption(), poResWidget);
+   QHBoxLayout *poThredNbLayout = new QHBoxLayout;
+   poThredNbLayout->addWidget(poThredNbLabel);
+   poThredNbLayout->addWidget(m_poUIPresenterThreadNb->buildWidget());
+   poVLayout->addLayout(poThredNbLayout);
+
+   QLabel *poShrinkFactorsLabel = new QLabel(m_poUIPresenterShrinkFactors->parameter()->caption(), poResWidget);
+   QHBoxLayout *poShrinkFactorsLayout = new QHBoxLayout;
+   poShrinkFactorsLayout->addWidget(poShrinkFactorsLabel);
+   poShrinkFactorsLayout->addWidget(m_poUIPresenterShrinkFactors->buildWidget());
+   poVLayout->addLayout(poShrinkFactorsLayout);
+
+   QLabel *poSplineOrderLabel = new QLabel(m_poUIPresenterSplineOrder->parameter()->caption(), poResWidget);
+   QHBoxLayout *poSplineOrderLayout = new QHBoxLayout;
+   poSplineOrderLayout->addWidget(poSplineOrderLabel);
+   poSplineOrderLayout->addWidget(m_poUIPresenterSplineOrder->buildWidget());
+   poVLayout->addLayout(poSplineOrderLayout);
+
+   QLabel *poMaxNumbersIterationsLabel = new QLabel(m_poUIPresenterMaxNumbersIterationsVector1->parameter()->caption(), poResWidget);
+   QHBoxLayout *poMaxNumbersIterationsLayout = new QHBoxLayout;
+   poMaxNumbersIterationsLayout->addWidget(poMaxNumbersIterationsLabel);
+   poMaxNumbersIterationsLayout->addWidget(m_poUIPresenterMaxNumbersIterationsVector1->buildWidget());
+   poMaxNumbersIterationsLayout->addWidget(m_poUIPresenterMaxNumbersIterationsVector2->buildWidget());
+   poMaxNumbersIterationsLayout->addWidget(m_poUIPresenterMaxNumbersIterationsVector3->buildWidget());
+   poVLayout->addLayout(poMaxNumbersIterationsLayout);
+   
+
+   QLabel *poWienerFilterNoiseLabel = new QLabel(m_poFPresenterWienerFilterNoise->parameter()->caption(), poResWidget);
+   QHBoxLayout *poWienerFilterNoiseLayout = new QHBoxLayout;
+   poWienerFilterNoiseLayout->addWidget(poWienerFilterNoiseLabel);
+   poWienerFilterNoiseLayout->addWidget(m_poFPresenterWienerFilterNoise->buildWidget());
+   poVLayout->addLayout(poWienerFilterNoiseLayout);
+
+   QLabel *pobfFWHMLabel = new QLabel(m_poFPresenterbfFWHM->parameter()->caption(), poResWidget);
+   QHBoxLayout *pobfFWHMLayout = new QHBoxLayout;
+   pobfFWHMLayout->addWidget(pobfFWHMLabel);
+   pobfFWHMLayout->addWidget(m_poFPresenterbfFWHM->buildWidget());
+   poVLayout->addLayout(pobfFWHMLayout);
+
+   QLabel *poConvergenceThresholdLabel = new QLabel(m_poFPresenterConvergenceThreshold->parameter()->caption(), poResWidget);
+   QHBoxLayout *poConvergenceThresholdLayout = new QHBoxLayout;
+   poConvergenceThresholdLayout->addWidget(poConvergenceThresholdLabel);
+   poConvergenceThresholdLayout->addWidget(m_poFPresenterConvergenceThreshold->buildWidget());
+   poVLayout->addLayout(poConvergenceThresholdLayout);
+
+   QLabel *poSplineDistanceLabel = new QLabel(m_poFPresenterSplineDistance->parameter()->caption(), poResWidget);
+   QHBoxLayout *poSplineDistanceLayout = new QHBoxLayout;
+   poSplineDistanceLayout->addWidget(poSplineDistanceLabel);
+   poSplineDistanceLayout->addWidget(m_poFPresenterSplineDistance->buildWidget());
+   poVLayout->addLayout(poSplineDistanceLayout);
+
+
+   QLabel *poInitialMeshResolutionLabel = new QLabel(m_poFPresenterInitialMeshResolutionVect1->parameter()->caption(), poResWidget);
+   QWidget *poWInitialMeshResolution1 = m_poFPresenterInitialMeshResolutionVect1->buildWidget();
+   QWidget *poWInitialMeshResolution2 = m_poFPresenterInitialMeshResolutionVect2->buildWidget();
+   QWidget *poWInitialMeshResolution3 = m_poFPresenterInitialMeshResolutionVect3->buildWidget();
+
+   connect(m_poFPresenterSplineDistance->parameter(), &medDoubleParameter::valueChanged, [=](double pi_fVal)
+   {
+      bool bActive = pi_fVal != 0;
+      poInitialMeshResolutionLabel->setDisabled(bActive);
+      poWInitialMeshResolution1->setDisabled(bActive);
+      poWInitialMeshResolution2->setDisabled(bActive);
+      poWInitialMeshResolution3->setDisabled(bActive);
+   });
+   QHBoxLayout *poInitialMeshResolutionLayout = new QHBoxLayout;
+   poInitialMeshResolutionLayout->addWidget(poInitialMeshResolutionLabel);
+   poInitialMeshResolutionLayout->addWidget(poWInitialMeshResolution1);
+   poInitialMeshResolutionLayout->addWidget(poWInitialMeshResolution2);
+   poInitialMeshResolutionLayout->addWidget(poWInitialMeshResolution3);
+   /*poInitialMeshResolutionLayout->setSizeConstraint(QLayout::SetMaximumSize);
+   poInitialMeshResolutionLayout->setSizeConstraint(QLayout::SetMaximumSize);
+   poInitialMeshResolutionLayout->setSizeConstraint(QLayout::SetMaximumSize);
+   poInitialMeshResolutionLayout->setSizeConstraint(QLayout::SetMaximumSize);*/
+   poVLayout->addLayout(poInitialMeshResolutionLayout);
+
+   poVLayout->addWidget(buildRunButton());
+   poVLayout->addWidget(buildCancelButton());
+   //poVLayout->setSizeConstraint(QLayout::SetMinimumSize);// SetMinimumSize
+
+   return poResWidget;
+}

--- a/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPresenter.h
+++ b/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPresenter.h
@@ -1,0 +1,33 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2017. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#pragma once
+
+#include <medAbstractBiasCorrectionProcessPresenter.h>
+#include <medItkBiasCorrectionProcess.h>
+#include <medProcessPresenterFactory.h>
+
+#include <medItkBiasCorrectionProcessPluginExport.h>
+
+class MEDITKBIASCORRECTIONPROCESSPLUGIN_EXPORT medItkBiasCorrectionProcessPresenter: public medAbstractBiasCorrectionProcessPresenter
+{
+    Q_OBJECT
+public:
+    medItkBiasCorrectionProcessPresenter(medItkBiasCorrectionProcess *parent) : medAbstractBiasCorrectionProcessPresenter(parent)
+    {m_process = parent;}
+    virtual medItkBiasCorrectionProcess* process() const {return m_process;}
+private:
+    medItkBiasCorrectionProcess *m_process;
+};
+
+MED_DECLARE_PROCESS_PRESENTER_CREATOR(medAbstractBiasCorrectionProcess, medItkBiasCorrectionProcess)

--- a/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPresenter.h
+++ b/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPresenter.h
@@ -21,6 +21,7 @@
 
 class medIntParameterPresenter;
 class medDoubleParameterPresenter;
+class medStringParameterPresenter;
 
 class MEDITKBIASCORRECTIONPROCESSPLUGIN_EXPORT medItkBiasCorrectionProcessPresenter: public medAbstractBiasCorrectionProcessPresenter
 {
@@ -35,16 +36,17 @@ private:
     medIntParameterPresenter    *m_poUIPresenterThreadNb;                     //Number of threads to run on (default: all cores)
     medIntParameterPresenter    *m_poUIPresenterShrinkFactors;                //Shrink factor, default=4
     medIntParameterPresenter    *m_poUIPresenterSplineOrder;                  //BSpline Order, default=3
-    medIntParameterPresenter    *m_poUIPresenterMaxNumbersIterationsVector1;  //B - Spline grid resolution
+    medStringParameterPresenter *m_poSPresenterMaxIterations;                 //Max iterations per round
+  /*medIntParameterPresenter    *m_poUIPresenterMaxNumbersIterationsVector1;  //B - Spline grid resolution
     medIntParameterPresenter    *m_poUIPresenterMaxNumbersIterationsVector2;  //B - Spline grid resolution
-    medIntParameterPresenter    *m_poUIPresenterMaxNumbersIterationsVector3;  //B - Spline grid resolution
+    medIntParameterPresenter    *m_poUIPresenterMaxNumbersIterationsVector3;  //B - Spline grid resolution*/
     medDoubleParameterPresenter *m_poFPresenterWienerFilterNoise;              //Wiener Filter Noise, default=0.01
     medDoubleParameterPresenter *m_poFPresenterbfFWHM;                         //Bias field Full Width at Half Maximum, default=0.15
     medDoubleParameterPresenter *m_poFPresenterConvergenceThreshold;           //Convergence Threshold, default=0.0001
     medDoubleParameterPresenter *m_poFPresenterSplineDistance;                 //B-Spline distance, default=0.0
-    medDoubleParameterPresenter *m_poFPresenterInitialMeshResolutionVect1;     //B - Spline grid resolution. Exist only if SplineDistance == 0. \ 
+    medDoubleParameterPresenter *m_poFPresenterInitialMeshResolutionVect1;     //B - Spline grid resolution. Exist only if SplineDistance == 0. | 
     medDoubleParameterPresenter *m_poFPresenterInitialMeshResolutionVect2;     //B - Spline grid resolution. Exist only if SplineDistance == 0. |--default=1x1x1
-    medDoubleParameterPresenter *m_poFPresenterInitialMeshResolutionVect3;     //B - Spline grid resolution. Exist only if SplineDistance == 0. / 
+    medDoubleParameterPresenter *m_poFPresenterInitialMeshResolutionVect3;     //B - Spline grid resolution. Exist only if SplineDistance == 0. | 
 
 };
 

--- a/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPresenter.h
+++ b/src/plugins/process/bias_correction/medItkBiasCorrectionProcessPresenter.h
@@ -19,15 +19,33 @@
 
 #include <medItkBiasCorrectionProcessPluginExport.h>
 
+class medIntParameterPresenter;
+class medDoubleParameterPresenter;
+
 class MEDITKBIASCORRECTIONPROCESSPLUGIN_EXPORT medItkBiasCorrectionProcessPresenter: public medAbstractBiasCorrectionProcessPresenter
 {
     Q_OBJECT
 public:
-    medItkBiasCorrectionProcessPresenter(medItkBiasCorrectionProcess *parent) : medAbstractBiasCorrectionProcessPresenter(parent)
-    {m_process = parent;}
+    medItkBiasCorrectionProcessPresenter(medItkBiasCorrectionProcess *parent);
+    virtual QWidget *buildToolBoxWidget();
     virtual medItkBiasCorrectionProcess* process() const {return m_process;}
+
 private:
     medItkBiasCorrectionProcess *m_process;
+    medIntParameterPresenter    *m_poUIPresenterThreadNb;                     //Number of threads to run on (default: all cores)
+    medIntParameterPresenter    *m_poUIPresenterShrinkFactors;                //Shrink factor, default=4
+    medIntParameterPresenter    *m_poUIPresenterSplineOrder;                  //BSpline Order, default=3
+    medIntParameterPresenter    *m_poUIPresenterMaxNumbersIterationsVector1;  //B - Spline grid resolution
+    medIntParameterPresenter    *m_poUIPresenterMaxNumbersIterationsVector2;  //B - Spline grid resolution
+    medIntParameterPresenter    *m_poUIPresenterMaxNumbersIterationsVector3;  //B - Spline grid resolution
+    medDoubleParameterPresenter *m_poFPresenterWienerFilterNoise;              //Wiener Filter Noise, default=0.01
+    medDoubleParameterPresenter *m_poFPresenterbfFWHM;                         //Bias field Full Width at Half Maximum, default=0.15
+    medDoubleParameterPresenter *m_poFPresenterConvergenceThreshold;           //Convergence Threshold, default=0.0001
+    medDoubleParameterPresenter *m_poFPresenterSplineDistance;                 //B-Spline distance, default=0.0
+    medDoubleParameterPresenter *m_poFPresenterInitialMeshResolutionVect1;     //B - Spline grid resolution. Exist only if SplineDistance == 0. \ 
+    medDoubleParameterPresenter *m_poFPresenterInitialMeshResolutionVect2;     //B - Spline grid resolution. Exist only if SplineDistance == 0. |--default=1x1x1
+    medDoubleParameterPresenter *m_poFPresenterInitialMeshResolutionVect3;     //B - Spline grid resolution. Exist only if SplineDistance == 0. / 
+
 };
 
 MED_DECLARE_PROCESS_PRESENTER_CREATOR(medAbstractBiasCorrectionProcess, medItkBiasCorrectionProcess)


### PR DESCRIPTION
BugCorrection #292
Two bugs are fix:
- Some view interaction glitches: for example drop the 4d image of the heart, then the heart mesh. If you interact with the view, it will change the window level of the first layer (image) even though the mesh is selected on the right. In addition if that view is linked to others (eg do a 4 view split after dropping the two data), then this window leveling is not synchronized with the others
- Drop the 4d heart image, switch to 3d mode, click on play in the navigator -> the image doesn't move. It does work in 2d but not 3d anymore...
Correction consists of:
-replace SetInputData by SetInputConnection;
-Create an individual windowLevel filter for x,y,z actors.