### PR TITLE
VR and vtk perf

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,11 @@ option(${PROJECT_NAME}_BUILD_DOCUMENTATION
   OFF
   )
 
+option(USE_OSPRay
+  "Build with OSPRay support"
+  OFF
+  )
+
 ## #############################################################################
 ## Find package
 ## #############################################################################

--- a/src/layers/legacy/medCoreLegacy/parameters/medTimeLineParameterL.cpp
+++ b/src/layers/legacy/medCoreLegacy/parameters/medTimeLineParameterL.cpp
@@ -104,7 +104,6 @@ medTimeLineParameterL::medTimeLineParameterL(QString name, QObject *parent):
     this->clear();
 
     connect(d->timeLine, SIGNAL(frameChanged(int)), this, SLOT(setFrame(int)));
-    //connect(d->timeLine, SIGNAL(frameChanged(int)), this, SLOT(increaseFrame(int)));
     connect(d->timeLine, SIGNAL(finished()), this, SLOT(reset()));
 
     connect(d->playParameter, SIGNAL(valueChanged(bool)), this, SLOT(play(bool)));

--- a/src/layers/legacy/medCoreLegacy/parameters/medTimeLineParameterL.cpp
+++ b/src/layers/legacy/medCoreLegacy/parameters/medTimeLineParameterL.cpp
@@ -104,6 +104,7 @@ medTimeLineParameterL::medTimeLineParameterL(QString name, QObject *parent):
     this->clear();
 
     connect(d->timeLine, SIGNAL(frameChanged(int)), this, SLOT(setFrame(int)));
+    //connect(d->timeLine, SIGNAL(frameChanged(int)), this, SLOT(increaseFrame(int)));
     connect(d->timeLine, SIGNAL(finished()), this, SLOT(reset()));
 
     connect(d->playParameter, SIGNAL(valueChanged(bool)), this, SLOT(play(bool)));
@@ -192,14 +193,9 @@ void medTimeLineParameterL::play(bool play)
 {
     d->playParameter->setValue(play);
 
-    if(d->timeLine->state() == QTimeLine::NotRunning && play)
+    if((d->timeLine->state() == QTimeLine::Paused || d->timeLine->state() == QTimeLine::NotRunning) && play)
     {
-        d->timeLine->start();
-        d->playParameter->setIcon (QPixmap(":/icons/pause.png"));
-        emit playing(play);
-    }
-    else if(d->timeLine->state() == QTimeLine::Paused && play)
-    {
+        d->timeLine->setCurrentTime(mapFrameToTime(d->currentFrame) * 1000);
         d->timeLine->resume();
         d->playParameter->setIcon (QPixmap(":/icons/pause.png"));
         emit playing(play);

--- a/src/layers/legacy/medVtkInria/CMakeLists.txt
+++ b/src/layers/legacy/medVtkInria/CMakeLists.txt
@@ -25,6 +25,14 @@ include(${ITK_USE_FILE})
 
 find_package(OpenGL REQUIRED)
 
+if (USE_OSPRay)
+  MESSAGE(AUTHOR_WARNING "use OSPRay *************************************************************")
+  add_definitions(-DMED_USE_OSPRAY_4_VR_BY_CPU)
+  set(VTK_OSPRAY_RENDERING_LIBRARY "vtkRenderingOSPRay")  
+ELSE()
+  set(VTK_OSPRAY_RENDERING_LIBRARY " ")  
+  MESSAGE(AUTHOR_WARNING "NO OSPRay *************************************************************")
+endif()
 
 ## #############################################################################
 ## List sources
@@ -163,7 +171,7 @@ target_link_libraries(${TARGET_NAME}
   vtkRenderingOpenGL2
   vtkRenderingVolumeOpenGL2
   vtkRenderingContextOpenGL2
-  vtkRenderingOSPRay
+  ${VTK_OSPRAY_RENDERING_LIBRARY}
   vtkInteractionWidgets
   vtkInteractionStyle
   vtkFiltersExtraction

--- a/src/layers/legacy/medVtkInria/CMakeLists.txt
+++ b/src/layers/legacy/medVtkInria/CMakeLists.txt
@@ -163,6 +163,7 @@ target_link_libraries(${TARGET_NAME}
   vtkRenderingOpenGL2
   vtkRenderingVolumeOpenGL2
   vtkRenderingContextOpenGL2
+  vtkRenderingOSPRay
   vtkInteractionWidgets
   vtkInteractionStyle
   vtkFiltersExtraction

--- a/src/layers/legacy/medVtkInria/CMakeLists.txt
+++ b/src/layers/legacy/medVtkInria/CMakeLists.txt
@@ -26,12 +26,10 @@ include(${ITK_USE_FILE})
 find_package(OpenGL REQUIRED)
 
 if (USE_OSPRay)
-  MESSAGE(AUTHOR_WARNING "use OSPRay *************************************************************")
   add_definitions(-DMED_USE_OSPRAY_4_VR_BY_CPU)
-  set(VTK_OSPRAY_RENDERING_LIBRARY "vtkRenderingOSPRay")  
+  set(VTK_OSPRAY_RENDERING_LIBRARY "vtkRenderingOSPRay")
 ELSE()
-  set(VTK_OSPRAY_RENDERING_LIBRARY " ")  
-  MESSAGE(AUTHOR_WARNING "NO OSPRay *************************************************************")
+  set(VTK_OSPRAY_RENDERING_LIBRARY "")
 endif()
 
 ## #############################################################################

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -211,11 +211,13 @@ void vtkImageView3D::SetVolumeMapperToRayCast()
   this->VolumeMapper->SetRequestedRenderMode(vtkSmartVolumeMapper::RayCastRenderMode );
 }
 
+#ifdef MED_USE_OSPRAY_4_VR_BY_CPU
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetVolumeMapperToOSPRayRenderMode()
 {
   this->VolumeMapper->SetRequestedRenderMode(vtkSmartVolumeMapper::OSPRayRenderMode);
 }
+#endif // MED_USE_OSPRAY_4_VR_BY_CPU
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetVolumeMapperToGPU()

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -200,38 +200,33 @@ vtkMTimeType vtkImageView3D::GetMTime()
 
 
 //----------------------------------------------------------------------------
-void vtkImageView3D::SetVolumeMapperTo3DTexture()
+/*void vtkImageView3D::SetVolumeMapperTo3DTexture()
 {
-  this->VolumeMapper->SetRequestedRenderMode(
-                                             vtkSmartVolumeMapper::TextureRenderMode );
-}
+  this->VolumeMapper->SetRequestedRenderMode(vtkSmartVolumeMapper::TextureRenderMode );
+}*/
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetVolumeMapperToRayCast()
 {
-  this->VolumeMapper->SetRequestedRenderMode(
-                                             vtkSmartVolumeMapper::RayCastRenderMode );
+  this->VolumeMapper->SetRequestedRenderMode(vtkSmartVolumeMapper::RayCastRenderMode );
 }
 
 //----------------------------------------------------------------------------
-void vtkImageView3D::SetVolumeMapperToRayCastAndTexture()
+void vtkImageView3D::SetVolumeMapperToOSPRayRenderMode()
 {
-  this->VolumeMapper->SetRequestedRenderMode(
-                                             vtkSmartVolumeMapper::RayCastAndTextureRenderMode );
+  this->VolumeMapper->SetRequestedRenderMode(vtkSmartVolumeMapper::OSPRayRenderMode);
 }
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetVolumeMapperToGPU()
 {
-  this->VolumeMapper->SetRequestedRenderMode(
-                                             vtkSmartVolumeMapper::GPURenderMode );
+  this->VolumeMapper->SetRequestedRenderMode(vtkSmartVolumeMapper::GPURenderMode );
 }
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetVolumeMapperToDefault()
 {
-  this->VolumeMapper->SetRequestedRenderMode(
-                                             vtkSmartVolumeMapper::DefaultRenderMode );
+  this->VolumeMapper->SetRequestedRenderMode(vtkSmartVolumeMapper::DefaultRenderMode );
 }
 
 //----------------------------------------------------------------------------
@@ -455,16 +450,22 @@ void vtkImageView3D::InstallInteractor()
 //----------------------------------------------------------------------------
 void vtkImageView3D::UnInstallInteractor()
 {
-  this->BoxWidget->SetInteractor (NULL);
-  this->PlaneWidget->SetInteractor (NULL);
-  this->Marker->SetInteractor (NULL);
+    this->BoxWidget->SetInteractor (NULL);
+    this->PlaneWidget->SetInteractor (NULL);
+    this->Marker->SetInteractor (NULL);
 
-  if (this->Interactor)
-  {
-    this->Interactor->SetRenderWindow (NULL);
-    this->Interactor->SetInteractorStyle (NULL);
-  }
-  this->IsInteractorInstalled = 0;
+    if (this->Interactor)
+    {
+        auto poRenderer = this->Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer();
+        while (poRenderer)
+        {
+            this->RenderWindow->RemoveRenderer(poRenderer);
+            poRenderer = this->Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer();
+        }
+        this->Interactor->SetRenderWindow (NULL);
+        this->Interactor->SetInteractorStyle (NULL);
+    }
+    this->IsInteractorInstalled = 0;
 }
 
 //----------------------------------------------------------------------------

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -198,13 +198,6 @@ vtkMTimeType vtkImageView3D::GetMTime()
   return mTime;
 }
 
-
-//----------------------------------------------------------------------------
-/*void vtkImageView3D::SetVolumeMapperTo3DTexture()
-{
-  this->VolumeMapper->SetRequestedRenderMode(vtkSmartVolumeMapper::TextureRenderMode );
-}*/
-
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetVolumeMapperToRayCast()
 {

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
@@ -84,9 +84,10 @@ public:
 
     virtual medVtkImageInfo* GetMedVtkImageInfo(int layer = 0) const;
 
-    //virtual void SetVolumeMapperTo3DTexture();
     virtual void SetVolumeMapperToRayCast();
+#ifdef MED_USE_OSPRAY_4_VR_BY_CPU
     virtual void SetVolumeMapperToOSPRayRenderMode();
+#endif //MED_USE_OSPRAY_4_VR_BY_CPU
     virtual void SetVolumeMapperToGPU();
     virtual void SetVolumeMapperToDefault();
 

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
@@ -84,9 +84,9 @@ public:
 
     virtual medVtkImageInfo* GetMedVtkImageInfo(int layer = 0) const;
 
-    virtual void SetVolumeMapperTo3DTexture();
+    //virtual void SetVolumeMapperTo3DTexture();
     virtual void SetVolumeMapperToRayCast();
-    virtual void SetVolumeMapperToRayCastAndTexture();
+    virtual void SetVolumeMapperToOSPRayRenderMode();
     virtual void SetVolumeMapperToGPU();
     virtual void SetVolumeMapperToDefault();
 

--- a/src/plugins/legacy/itkDataImage/CMakeLists.txt
+++ b/src/plugins/legacy/itkDataImage/CMakeLists.txt
@@ -37,6 +37,10 @@ if (ITK_USE_SYSTEM_GDCM)
   add_definitions(-DITK_USE_SYSTEM_GDCM)
 endif()
 
+if (USE_OSPRay)
+  add_definitions(-DMED_USE_OSPRAY_4_VR_BY_CPU)
+endif()
+
 find_package(DCMTK REQUIRED NO_MODULE)
 
 find_package(VTK REQUIRED)

--- a/src/plugins/legacy/itkDataImage/navigators/medVtkViewItkDataImageNavigator.cpp
+++ b/src/plugins/legacy/itkDataImage/navigators/medVtkViewItkDataImageNavigator.cpp
@@ -77,9 +77,8 @@ medVtkViewItkDataImageNavigator::medVtkViewItkDataImageNavigator(medAbstractView
 
     d->renderer3DParameter = new medStringListParameterL("Renderer", this);
     d->renderer3DParameter->addItem("GPU");
-    d->renderer3DParameter->addItem("Ray Cast / Texture");
+    d->renderer3DParameter->addItem("OSPRay / CPU");
     d->renderer3DParameter->addItem("Ray Cast");
-    d->renderer3DParameter->addItem("Texture");
     d->renderer3DParameter->addItem("Default");
     connect(d->renderer3DParameter, SIGNAL(valueChanged(QString)), this, SLOT(setRenderer(QString)));
 
@@ -225,8 +224,8 @@ void medVtkViewItkDataImageNavigator::setRenderer(QString renderer)
     if ( renderer=="GPU" )
         d->view3d->SetVolumeMapperToGPU();
 
-    else if ( renderer=="Ray Cast / Texture" )
-        d->view3d->SetVolumeMapperToRayCastAndTexture();
+    else if ( renderer=="OSPRay / CPU" )
+        d->view3d->SetVolumeMapperToOSPRayRenderMode();
 
     else if ( renderer=="Ray Cast" )
         d->view3d->SetVolumeMapperToRayCast();

--- a/src/plugins/legacy/itkDataImage/navigators/medVtkViewItkDataImageNavigator.cpp
+++ b/src/plugins/legacy/itkDataImage/navigators/medVtkViewItkDataImageNavigator.cpp
@@ -77,7 +77,9 @@ medVtkViewItkDataImageNavigator::medVtkViewItkDataImageNavigator(medAbstractView
 
     d->renderer3DParameter = new medStringListParameterL("Renderer", this);
     d->renderer3DParameter->addItem("GPU");
+#ifdef MED_USE_OSPRAY_4_VR_BY_CPU
     d->renderer3DParameter->addItem("OSPRay / CPU");
+#endif //MED_USE_OSPRAY_4_VR_BY_CPU
     d->renderer3DParameter->addItem("Ray Cast");
     d->renderer3DParameter->addItem("Default");
     connect(d->renderer3DParameter, SIGNAL(valueChanged(QString)), this, SLOT(setRenderer(QString)));
@@ -223,10 +225,10 @@ void medVtkViewItkDataImageNavigator::setRenderer(QString renderer)
 {
     if ( renderer=="GPU" )
         d->view3d->SetVolumeMapperToGPU();
-
+#ifdef MED_USE_OSPRAY_4_VR_BY_CPU
     else if ( renderer=="OSPRay / CPU" )
         d->view3d->SetVolumeMapperToOSPRayRenderMode();
-
+#endif
     else if ( renderer=="Ray Cast" )
         d->view3d->SetVolumeMapperToRayCast();
 

--- a/src/plugins/legacy/medVtkView/medVtkView.cpp
+++ b/src/plugins/legacy/medVtkView/medVtkView.cpp
@@ -92,7 +92,7 @@ medVtkView::medVtkView(QObject* parent): medAbstractImageView(parent),
     d->renWin->SetStereoTypeToCrystalEyes();
     d->renWin->SetAlphaBitPlanes(1);
     d->renWin->SetMultiSamples(0);
-            // needed for imersive room
+            // needed for immersive room
     if (qApp->arguments().contains("--stereo"))
         d->renWin->SetStereoRender(1);
 

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -44,10 +44,10 @@ find_package(Boost REQUIRED)
 #   * otherwise use download and compile locally the package as an external 
 #     module.
 
-option(USE_DTKIMAGING
-  "Use DTK imaging layer" OFF
-  )
-
+option(USE_DTKIMAGING "Use DTK imaging layer" OFF )
+  
+option(USE_OSPRay "Use OSPRay for CPU VR" OFF )
+  
 list(APPEND external_projects
   VTK 
   ITK 
@@ -67,6 +67,11 @@ else()
   list(APPEND external_projects
       medInria
       )
+endif()
+
+if (USE_OSPRay)
+  SET(ospray_DIR CACHE PATH "The directory containing a CMAKE configuration file for OSPRay")
+  SET(OSPRAY_INSTALL_DIR CACHE PATH "Install location of OSPRay")
 endif()
 
 ## #############################################################################

--- a/superbuild/projects_modules/VTK.cmake
+++ b/superbuild/projects_modules/VTK.cmake
@@ -39,7 +39,7 @@ if (NOT USE_SYSTEM_${ep})
 ## #############################################################################
 
 set(git_url git://vtk.org/VTK.git)
-set(git_tag v8.0.0)
+set(git_tag v8.1.0.rc1)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project
@@ -66,12 +66,16 @@ set(cmake_args
   -DVTK_RENDERING_BACKEND=OpenGL2
   -DVTK_Group_Qt=ON
   -DModule_vtkGUISupportQtOpenGL=ON
-  -DModule_vtkRenderingOSPRay=ON
+  -DModule_vtkRenderingOSPRay:BOOL=${USE_OSPRay}
   -DVTK_QT_VERSION=5
   -DQt5_DIR=${Qt5_DIR}
   )
 
-
+if(USE_OSPRay)
+  list(APPEND cmake_args
+  -Dospray_DIR=${ospray_DIR}
+  -DOSPRAY_INSTALL_DIR=${OSPRAY_INSTALL_DIR})
+endif()
 ## #############################################################################
 ## Add external-project
 ## #############################################################################
@@ -97,4 +101,5 @@ set(${ep}_DIR ${binary_dir} PARENT_SCOPE)
 
 endif() #NOT USE_SYSTEM_ep
 
-endfunction()
+endfunction(VTK_project)
+

--- a/superbuild/projects_modules/VTK.cmake
+++ b/superbuild/projects_modules/VTK.cmake
@@ -66,6 +66,7 @@ set(cmake_args
   -DVTK_RENDERING_BACKEND=OpenGL2
   -DVTK_Group_Qt=ON
   -DModule_vtkGUISupportQtOpenGL=ON
+  -DModule_vtkRenderingOSPRay=ON
   -DVTK_QT_VERSION=5
   -DQt5_DIR=${Qt5_DIR}
   )

--- a/superbuild/projects_modules/medInria.cmake
+++ b/superbuild/projects_modules/medInria.cmake
@@ -72,6 +72,7 @@ set(cmake_args
   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS_${ep}}
   -DUSE_DTKIMAGING:BOOL=${USE_DTKIMAGING}
+  -DUSE_OSPRay:BOOL=${USE_OSPRay}
   -DDCMTK_DIR=${DCMTK_DIR}
   -Ddtk_DIR=${dtk_DIR}
   -DITK_DIR=${ITK_DIR}
@@ -135,27 +136,4 @@ set(${ep}_SOURCE_DIR ${source_dir} PARENT_SCOPE)
 
 endif() #NOT USE_SYSTEM_ep
 
-endfunction()     
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+endfunction()


### PR DESCRIPTION
Correction of 4 bugs from #292 :
 - Once you've seen your data in VR, changing the orientation is quite slow, slicing is very slow. It's also happened to me since I am using VTK7 in MUSIC.
 - Remove deprecated VTK VR modes
 - Add new VTK VR modes if they are available
 - In 4D volume, in visualization mode, when time is set manually, if you press 'play' button, it start playing at the first 3D volume.
BECAREFULL !!! Create a dependency on OSPRay external library.
