### PR TITLE
Workspaces improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+*.bak
 *.swp
 *.user
 *.orig

--- a/src/app/medInria/medDiffusionWorkspace.cpp
+++ b/src/app/medInria/medDiffusionWorkspace.cpp
@@ -90,7 +90,7 @@ void medDiffusionWorkspace::setupTabbedViewContainer()
     //the stack has been instantiated in constructor
     if ( ! this->tabbedViewContainers()->count())
     {
-        d->diffusionContainer = this->tabbedViewContainers()->addContainerInTab(this->name());
+        d->diffusionContainer = this->tabbedViewContainers()->addContainerInTabNamed(this->name());
 
         d->diffusionContainer->setClosingMode(medViewContainer::CLOSE_CONTAINER);
         d->diffusionContainer->setUserSplittable(false);
@@ -99,6 +99,7 @@ void medDiffusionWorkspace::setupTabbedViewContainer()
         connect (d->diffusionContainer,SIGNAL(viewContentChanged()), this, SLOT(updateToolBoxesInputs()));
         connect(this->tabbedViewContainers(),SIGNAL(containersSelectedChanged()),this,SLOT(changeCurrentContainer()));
     }
+    this->tabbedViewContainers()->setKeepLeastOne(true);
 }
 
 void medDiffusionWorkspace::getEstimationOutput(medAbstractJob::medJobExitStatus status)

--- a/src/app/medInria/medFilteringWorkspace.cpp
+++ b/src/app/medInria/medFilteringWorkspace.cpp
@@ -405,7 +405,7 @@ medFilteringWorkspace::medFilteringWorkspace(QWidget *parent): medAbstractWorksp
     QPushButton *poCreateFilterButton = new QPushButton("Create filter");
     poDummyWidget4MarginOfCreateButton->setLayout(poDummyCreatButtonLayout);
     poDummyCreatButtonLayout->addWidget(poCreateFilterButton);
-    connect(poCreateFilterButton, SIGNAL(clicked()), this, SLOT(createFilterEnv()));
+    connect(poCreateFilterButton, SIGNAL(clicked()), this, SLOT(createFilterEnvironment()));
 
     d->workspaceToolBox = new medToolBox;
     d->workspaceToolBox->setTitle("Process controller");
@@ -842,7 +842,11 @@ void medFilteringWorkspace::setProcessSelection(int index)
     d->iProcessSelection = index;
 }
 
-void medFilteringWorkspace::createFilterEnv()
+/**
+* @brief  This function creates environment for a filter.
+* @detail Creates environment for a filter like new tab, ProcessPresenter, toolbox with title and process.
+*/
+void medFilteringWorkspace::createFilterEnvironment()
 {
     medAbstractProcess *poProcess = nullptr;
     medAbstractProcessPresenter *poPresenter = nullptr;

--- a/src/app/medInria/medFilteringWorkspace.cpp
+++ b/src/app/medInria/medFilteringWorkspace.cpp
@@ -31,8 +31,9 @@
 #include <QDebug>
 
 // Yikes, this is ugly but necessary
-struct SingleFiltersGathering
+class SingleFiltersGathering
 {
+public:
     // fun times
     medAbstractGaussianFilterProcessPluginFactory* gaussianFactory;
     medAbstractMedianFilterProcessPluginFactory* medianFactory;
@@ -147,8 +148,9 @@ struct SingleFiltersGathering
     }
 };
 
-struct MorphomathGathering
+class MorphomathGathering
 {
+public:
     // fun times
     medAbstractErodeImageProcessPluginFactory* erodeFactory;
     medAbstractDilateImageProcessPluginFactory* dilateFactory;
@@ -213,8 +215,9 @@ struct MorphomathGathering
     }
 };
 
-struct ArithmeticGathering
+class ArithmeticGathering
 {
+public:
     // Image arithmetic stuff
     medAbstractAddFilterProcessPluginFactory* addFactory;
     medAbstractSubtractFilterProcessPluginFactory* subtractFactory;
@@ -339,17 +342,25 @@ struct ArithmeticGathering
     }
 };
 
+struct  stProcessAndToolBox
+{
+    medAbstractProcess *process;
+    medAbstractProcessPresenter *presenter;
+    QWidget *toolBox;
+};
+
 class medFilteringWorkspacePrivate
 {
 public:
-    medAbstractProcess *process;
-    medAbstractProcessPresenter *presenter;
+    int iProcessSelection;
 
     QComboBox *processTypeComboBox;
     QComboBox *processSelectorComboBox;
 
     medToolBox *workspaceToolBox;
-    QWidget *currentProcessToolBox;
+    medToolBox *FiltersParamToolBox;
+    int iCurrentTab;
+    std::vector<stProcessAndToolBox> oProcessTab;
 
     std::vector <SingleFiltersGathering> singleFiltersVector;
     std::vector <MorphomathGathering> morphoMathsVector;
@@ -358,9 +369,12 @@ public:
 
 medFilteringWorkspace::medFilteringWorkspace(QWidget *parent): medAbstractWorkspaceLegacy (parent), d(new medFilteringWorkspacePrivate)
 {
+    d->iProcessSelection = 0;
+    d->processTypeComboBox = nullptr;
+    d->processSelectorComboBox = nullptr;
+    d->workspaceToolBox = nullptr;
+    d->iCurrentTab = -1;
 
-    d->presenter = NULL;
-    d->process = NULL;
 
     QWidget *processTypeWidget = new QWidget;
     QLabel *processTypeLabel = new QLabel("Process Type", processTypeWidget);
@@ -374,8 +388,7 @@ medFilteringWorkspace::medFilteringWorkspace(QWidget *parent): medAbstractWorksp
     d->processTypeComboBox->addItem("Image arithmetic");
     processTypeWidget->setLayout(processTypeLayout);
 
-    connect(d->processTypeComboBox,SIGNAL(currentIndexChanged(int)),
-            this,SLOT(setProcessType(int)));
+    connect(d->processTypeComboBox,SIGNAL(currentIndexChanged(int)),this,SLOT(setProcessType(int)));
 
     QWidget *processWidget = new QWidget;
     QLabel *processLabel = new QLabel("Process", processWidget);
@@ -385,14 +398,29 @@ medFilteringWorkspace::medFilteringWorkspace(QWidget *parent): medAbstractWorksp
     processLayout->addWidget(d->processSelectorComboBox);
     processWidget->setLayout(processLayout);
 
-    connect(d->processSelectorComboBox, SIGNAL(currentIndexChanged(int)),
-            this,SLOT(setProcessSelection(int)));
+    connect(d->processSelectorComboBox, SIGNAL(currentIndexChanged(int)),this,SLOT(setProcessSelection(int)));
+
+    QWidget *poDummyWidget4MarginOfCreateButton = new QWidget();
+    QGridLayout *poDummyCreatButtonLayout = new QGridLayout();
+    QPushButton *poCreateFilterButton = new QPushButton("Create filter");
+    poDummyWidget4MarginOfCreateButton->setLayout(poDummyCreatButtonLayout);
+    poDummyCreatButtonLayout->addWidget(poCreateFilterButton);
+    connect(poCreateFilterButton, SIGNAL(clicked()), this, SLOT(createFilterEnv()));
 
     d->workspaceToolBox = new medToolBox;
     d->workspaceToolBox->setTitle("Process controller");
     d->workspaceToolBox->addWidget(processTypeWidget);
     d->workspaceToolBox->addWidget(processWidget);
+    d->workspaceToolBox->addWidget(poDummyWidget4MarginOfCreateButton);
     this->addToolBox(d->workspaceToolBox);
+
+    d->FiltersParamToolBox = new medToolBox;
+    d->FiltersParamToolBox->setTitle("Parameters of filter");
+    this->addToolBox(d->FiltersParamToolBox);
+
+    connect(tabbedViewContainers(), SIGNAL(currentChanged(int)), this, SLOT(setCurrentTab(int)));
+    connect(tabbedViewContainers(), SIGNAL(tabCloseRequested(int)), this, SLOT(closingTab(int)));
+    
 }
 
 medFilteringWorkspace::~medFilteringWorkspace()
@@ -811,6 +839,15 @@ void medFilteringWorkspace::setProcessType(int index)
 
 void medFilteringWorkspace::setProcessSelection(int index)
 {
+    d->iProcessSelection = index;
+}
+
+void medFilteringWorkspace::createFilterEnv()
+{
+    medAbstractProcess *poProcess = nullptr;
+    medAbstractProcessPresenter *poPresenter = nullptr;
+    int index = d->iProcessSelection;
+
     if (index == 0)
         return;
 
@@ -825,8 +862,8 @@ void medFilteringWorkspace::setProcessSelection(int index)
             {
                 if (d->morphoMathsVector[i].pluginKey == pluginKey)
                 {
-                    d->process = d->morphoMathsVector[i].getProcess();
-                    d->presenter = d->morphoMathsVector[i].getPresenter();
+                    poProcess = d->morphoMathsVector[i].getProcess();
+                    poPresenter = d->morphoMathsVector[i].getPresenter();
                     break;
                 }
             }
@@ -840,8 +877,8 @@ void medFilteringWorkspace::setProcessSelection(int index)
             {
                 if (d->singleFiltersVector[i].pluginKey == pluginKey)
                 {
-                    d->process = d->singleFiltersVector[i].getProcess();
-                    d->presenter = d->singleFiltersVector[i].getPresenter();
+                    poProcess = d->singleFiltersVector[i].getProcess();
+                    poPresenter = d->singleFiltersVector[i].getPresenter();
                     break;
                 }
             }
@@ -856,8 +893,8 @@ void medFilteringWorkspace::setProcessSelection(int index)
             {
                 if (d->arithmeticsVector[i].pluginKey == pluginKey)
                 {
-                    d->process = d->arithmeticsVector[i].getProcess();
-                    d->presenter = d->arithmeticsVector[i].getPresenter();
+                    poProcess = d->arithmeticsVector[i].getProcess();
+                    poPresenter = d->arithmeticsVector[i].getPresenter();
                     break;
                 }
             }
@@ -866,15 +903,49 @@ void medFilteringWorkspace::setProcessSelection(int index)
         }
     }
 
-    d->workspaceToolBox->removeWidget(d->currentProcessToolBox);
-    d->currentProcessToolBox = d->presenter->buildToolBoxWidget();
-    d->workspaceToolBox->addWidget(d->currentProcessToolBox);
-    d->workspaceToolBox->setTitle(d->process->caption());
+    QWidget *poToolBoxWidget = poPresenter->buildToolBoxWidget();
+
+    d->oProcessTab.push_back({ poProcess, poPresenter, poToolBoxWidget });
+    if (d->iCurrentTab >= 0 && d->iCurrentTab < d->oProcessTab.size())
+    {
+        d->oProcessTab[d->iCurrentTab].toolBox->hide();
+    }
+    d->FiltersParamToolBox->setTitle(QString("Parameters of ") + poProcess->caption());
+    d->FiltersParamToolBox->addWidget(poToolBoxWidget);
+
+    d->iCurrentTab = d->oProcessTab.size()-1;
 
     if (this->tabbedViewContainers()->currentWidget() == 0)
-        this->tabbedViewContainers()->setSplitter(this->tabbedViewContainers()->currentIndex(), d->presenter->buildViewContainerSplitter());
+        this->tabbedViewContainers()->setSplitter(this->tabbedViewContainers()->currentIndex(), poPresenter->buildViewContainerSplitter());
     else
-        this->tabbedViewContainers()->setSplitter(this->tabbedViewContainers()->count(), d->presenter->buildViewContainerSplitter());
+        this->tabbedViewContainers()->setSplitter(this->tabbedViewContainers()->count(), poPresenter->buildViewContainerSplitter());
+}
+
+void medFilteringWorkspace::setCurrentTab(int index)
+{
+    if ( (index >= 0) && (d->iCurrentTab >= 0) && d->oProcessTab.size() && (d->iCurrentTab != index))
+    {
+        stProcessAndToolBox stTmp = d->oProcessTab[index];
+        d->FiltersParamToolBox->setTitle(QString("Parameters of ") + stTmp.process->caption());
+        if (d->iCurrentTab < d->oProcessTab.size())
+            d->oProcessTab[d->iCurrentTab].toolBox->hide();
+        stTmp.toolBox->show();
+        d->iCurrentTab = index;
+    }
+}
+
+void medFilteringWorkspace::closingTab(int index)
+{
+    stProcessAndToolBox &stTmp = d->oProcessTab[index];
+    d->FiltersParamToolBox->removeWidget(stTmp.toolBox);
+    d->iCurrentTab = d->oProcessTab.size();
+    delete stTmp.presenter;
+    delete stTmp.process;
+    delete stTmp.toolBox;
+    stTmp.presenter = nullptr;
+    stTmp.process   = nullptr;
+    stTmp.toolBox   = nullptr;
+    d->oProcessTab.erase((d->oProcessTab.begin()) + index);
 }
 
 bool medFilteringWorkspace::isUsable()

--- a/src/app/medInria/medFilteringWorkspace.h
+++ b/src/app/medInria/medFilteringWorkspace.h
@@ -43,7 +43,7 @@ public:
 public slots:
     void setProcessType(int index);
     void setProcessSelection(int index);
-    void createFilterEnv(/*int index*/);
+    void createFilterEnvironment();
     void setCurrentTab(int index);
     void closingTab(int index);
 

--- a/src/app/medInria/medFilteringWorkspace.h
+++ b/src/app/medInria/medFilteringWorkspace.h
@@ -24,9 +24,7 @@ class medFilteringWorkspacePrivate;
 class medFilteringWorkspace : public medAbstractWorkspaceLegacy
 {
     Q_OBJECT
-    MED_WORKSPACE_INTERFACE("Filtering",
-                            "Workspace to apply filters to images.",
-                            "Methodology")
+    MED_WORKSPACE_INTERFACE("Filtering", "Workspace to apply filters to images.", "Methodology")
 public:
     medFilteringWorkspace(QWidget *parent = 0);
     ~medFilteringWorkspace();
@@ -45,6 +43,9 @@ public:
 public slots:
     void setProcessType(int index);
     void setProcessSelection(int index);
+    void createFilterEnv(/*int index*/);
+    void setCurrentTab(int index);
+    void closingTab(int index);
 
 private:
     medFilteringWorkspacePrivate *d;

--- a/src/app/medInria/medRegistrationWorkspace.cpp
+++ b/src/app/medInria/medRegistrationWorkspace.cpp
@@ -83,7 +83,7 @@ void medRegistrationWorkspace::setupTabbedViewContainer()
     //the stack has been instantiated in constructor
     if (!this->tabbedViewContainers()->count())
     {
-        d->fixedContainer = this->tabbedViewContainers()->addContainerInTab(tr("Compare"));
+        d->fixedContainer = this->tabbedViewContainers()->addContainerInTabNamed(tr("Compare"));
         QLabel *fixedLabel = new QLabel(tr("FIXED"));
         fixedLabel->setAlignment(Qt::AlignCenter);
         d->fixedContainer->setDefaultWidget(fixedLabel);
@@ -100,7 +100,7 @@ void medRegistrationWorkspace::setupTabbedViewContainer()
         d->movingContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
 
 
-        d->fuseContainer = this->tabbedViewContainers()->addContainerInTab(tr("Fuse"));
+        d->fuseContainer = this->tabbedViewContainers()->addContainerInTabNamed(tr("Fuse"));
         QLabel *fuseLabel = new QLabel(tr("FUSE"));
         fuseLabel->setAlignment(Qt::AlignCenter);
         d->fuseContainer->setDefaultWidget(fuseLabel);

--- a/src/app/medInria/medSegmentationWorkspace.cpp
+++ b/src/app/medInria/medSegmentationWorkspace.cpp
@@ -79,9 +79,10 @@ medAbstractWorkspaceLegacy(parent), d(new medSegmentationWorkspacePrivate)
 void medSegmentationWorkspace::setupTabbedViewContainer()
 {
     if (!tabbedViewContainers()->count()) {
-        this->tabbedViewContainers()->addContainerInTab(this->name());
+        this->tabbedViewContainers()->addContainerInTabNamed(this->name());
     }
     this->tabbedViewContainers()->unlockTabs();
+    this->tabbedViewContainers()->setKeepLeastOne(true);
 }
 
 medSegmentationWorkspace::~medSegmentationWorkspace(void)

--- a/src/app/medInria/medVisualizationWorkspace.cpp
+++ b/src/app/medInria/medVisualizationWorkspace.cpp
@@ -4,7 +4,7 @@
 
  Copyright (c) INRIA 2013 - 2014. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.
@@ -20,13 +20,8 @@
 #include <medViewParameterGroupL.h>
 #include <medLayerParameterGroupL.h>
 
-class medVisualizationWorkspacePrivate
-{
-public:
 
-};
-
-medVisualizationWorkspace::medVisualizationWorkspace(QWidget *parent) : medAbstractWorkspaceLegacy(parent), d(new medVisualizationWorkspacePrivate)
+medVisualizationWorkspace::medVisualizationWorkspace(QWidget *parent) : medAbstractWorkspaceLegacy(parent)
 {
     medViewParameterGroupL *viewGroup1 = new medViewParameterGroupL("View Group 1", this, this->identifier());
     viewGroup1->setLinkAllParameters(true);
@@ -38,18 +33,20 @@ medVisualizationWorkspace::medVisualizationWorkspace(QWidget *parent) : medAbstr
 
 void medVisualizationWorkspace::setupTabbedViewContainer()
 {
-    if (!tabbedViewContainers()->count()) {
-        this->tabbedViewContainers()->addContainerInTab(this->name());
+    if (!tabbedViewContainers()->count())
+    {
+        this->tabbedViewContainers()->addContainerInTabNamed(this->name());
     }
     this->tabbedViewContainers()->unlockTabs();
+    this->tabbedViewContainers()->setKeepLeastOne(true);
 }
 
 medVisualizationWorkspace::~medVisualizationWorkspace(void)
 {
-    delete d;
-    d = NULL;
 }
 
-bool medVisualizationWorkspace::isUsable(){
+bool medVisualizationWorkspace::isUsable()
+{
     return true; // for the time being, no test is defined.
 }
+

--- a/src/app/medInria/medVisualizationWorkspace.h
+++ b/src/app/medInria/medVisualizationWorkspace.h
@@ -1,3 +1,4 @@
+#pragma once
 /*=========================================================================
 
  medInria
@@ -11,14 +12,9 @@
 
 =========================================================================*/
 
-#pragma once
-
 #include <QtCore>
 
 #include <medAbstractWorkspaceLegacy.h>
-
-
-class medVisualizationWorkspacePrivate;
 
 class medVisualizationWorkspace : public medAbstractWorkspaceLegacy
 {
@@ -33,9 +29,6 @@ public:
     virtual void setupTabbedViewContainer();
 
     static bool isUsable();
-
-private:
-    medVisualizationWorkspacePrivate *d;
 };
 
 

--- a/src/layers/legacy/medCoreLegacy/gui/medAbstractWorkspaceLegacy.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/medAbstractWorkspaceLegacy.cpp
@@ -78,7 +78,7 @@ medAbstractWorkspaceLegacy::medAbstractWorkspaceLegacy(QWidget *parent) : QObjec
 {
     d->parent = parent;
 
-    d->selectionToolBox = new medToolBox;
+    d->selectionToolBox = new medToolBox(parent);
     d->selectionToolBox->setTitle("Selection");
     d->selectionToolBox->header()->hide();
     d->selectionToolBox->hide();
@@ -134,11 +134,13 @@ medAbstractWorkspaceLegacy::~medAbstractWorkspaceLegacy(void)
 void medAbstractWorkspaceLegacy::addToolBox(medToolBox *toolbox)
 {
     d->toolBoxes.append(toolbox);
+    d->selectionToolBox->addWidget(toolbox);
 }
 
 void medAbstractWorkspaceLegacy::removeToolBox(medToolBox *toolbox)
 {
     d->toolBoxes.removeOne(toolbox);
+    d->selectionToolBox->removeWidget(toolbox);
 }
 
 QList<medToolBox*> medAbstractWorkspaceLegacy::toolBoxes() const

--- a/src/layers/legacy/medCoreLegacy/gui/medAbstractWorkspaceLegacy.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/medAbstractWorkspaceLegacy.cpp
@@ -193,7 +193,7 @@ void medAbstractWorkspaceLegacy::clearWorkspaceToolBoxes()
 void medAbstractWorkspaceLegacy::addNewTab()
 {
     QString tabName = QString("%1 %2").arg(this->name()).arg(d->viewContainerStack->count());
-    d->viewContainerStack->addContainerInTab(tabName);
+    d->viewContainerStack->addContainerInTabNamed(tabName);
 }
 
 void medAbstractWorkspaceLegacy::updateNavigatorsToolBox()

--- a/src/layers/legacy/medCoreLegacy/gui/medAbstractWorkspaceLegacy.h
+++ b/src/layers/legacy/medCoreLegacy/gui/medAbstractWorkspaceLegacy.h
@@ -52,7 +52,7 @@ class MEDCORELEGACY_EXPORT medAbstractWorkspaceLegacy : public QObject
 public:
 
     medAbstractWorkspaceLegacy(QWidget *parent=0);
-    ~medAbstractWorkspaceLegacy();
+    virtual ~medAbstractWorkspaceLegacy();
 
     virtual QString identifier() const = 0;
     virtual QString name() const = 0;

--- a/src/layers/legacy/medCoreLegacy/gui/medRootContainer.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/medRootContainer.cpp
@@ -14,7 +14,7 @@ medRootContainer::medRootContainer(medTabbedViewContainers* parent) : m_poParent
 medRootContainer::~medRootContainer()
 {
 #ifdef _DEBUG
-    std::cout << "~medRootContainer\n";
+    std::cout << "~medRootContainer" << std::endl;
 #endif // _DEBUG
 }
 

--- a/src/layers/legacy/medCoreLegacy/gui/medRootContainer.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/medRootContainer.cpp
@@ -1,0 +1,38 @@
+#include "medRootContainer.h"
+#ifdef _DEBUG
+    #include <iostream>
+#endif // _DEBUG
+
+medRootContainer::medRootContainer(medTabbedViewContainers* parent) : m_poParent(parent)
+{
+    m_poSplitter = nullptr;
+    setContentsMargins(0, 0, 0, 0);
+    m_oInternalLayout.setContentsMargins(0, 0, 0, 0);
+    setLayout(&m_oInternalLayout);
+}
+
+medRootContainer::~medRootContainer()
+{
+#ifdef _DEBUG
+    std::cout << "~medRootContainer\n";
+#endif // _DEBUG
+}
+
+void medRootContainer::replaceSplitter(medViewContainerSplitter *pi_poSplitter)
+{
+    if (m_poSplitter)
+    {
+        m_oInternalLayout.removeWidget(m_poSplitter);
+        m_poSplitter->setParent(nullptr);
+        m_poSplitter->disconnect(m_poParent);
+    }
+
+    m_poSplitter = pi_poSplitter;    
+
+    if (m_poSplitter)
+    {
+        connect(m_poSplitter, SIGNAL(destroyed()), m_poParent, SLOT(closeCurrentTab()));
+        m_oInternalLayout.addWidget(m_poSplitter);
+        m_poSplitter->setParent(this);
+    }
+}

--- a/src/layers/legacy/medCoreLegacy/gui/medRootContainer.h
+++ b/src/layers/legacy/medCoreLegacy/gui/medRootContainer.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <QGridLayout>
+#include <medViewContainerSplitter.h>
+#include <medTabbedViewContainers.h>
+
+class medRootContainer : public QWidget
+{
+    Q_OBJECT
+private:
+    medViewContainerSplitter *m_poSplitter;
+    QGridLayout m_oInternalLayout;
+    medTabbedViewContainers *m_poParent;
+
+public:
+    medRootContainer(medTabbedViewContainers* parent);
+    virtual ~medRootContainer();
+
+    void replaceSplitter(medViewContainerSplitter *pi_poSplitter);
+    inline medViewContainerSplitter * getSplitter() const { return m_poSplitter; }
+};
+

--- a/src/layers/legacy/medCoreLegacy/gui/medTabbedViewContainers.h
+++ b/src/layers/legacy/medCoreLegacy/gui/medTabbedViewContainers.h
@@ -59,9 +59,6 @@ public slots:
 protected:
 
 private slots :
-    // Not sure of the name - RDE
-    //void resetTabState();
-    //void closeCurrentTab();
     void tabBarDoubleClickedHandler(int  index);
 
     void addContainerToSelection(QUuid container);

--- a/src/layers/legacy/medCoreLegacy/gui/medTabbedViewContainers.h
+++ b/src/layers/legacy/medCoreLegacy/gui/medTabbedViewContainers.h
@@ -1,3 +1,4 @@
+#pragma once
 /*=========================================================================
 
  medInria
@@ -10,8 +11,6 @@
   PURPOSE.
 
 =========================================================================*/
-
-#pragma once
 
 #include <QtGui>
 #include <QUuid>
@@ -28,9 +27,8 @@ class medAbstractWorkspaceLegacy;
 class medTabbedViewContainersPrivate;
 
 /**
- * @brief A QStackedWidget that contains medViewContainers.
+ * @brief A QTabWidget that contains medViewContainers.
  * There is one such stack per medViewWorkspace.
- *
 */
 class MEDCORELEGACY_EXPORT medTabbedViewContainers : public QTabWidget
 {
@@ -43,39 +41,40 @@ public:
     void lockTabs();
     void unlockTabs();
     void hideTabBar();
-    QList<QUuid> containersSelected();
     void adjustContainersSize();
+    QList<QUuid> containersSelected();
     QList<medAbstractView*> viewsInTab(int index = 0);
     QList<medViewContainer*> containersInTab(int index = 0);
-
-    medAbstractWorkspaceLegacy * owningWorkspace() const;
-
-public slots:
-    medViewContainer* addContainerInTab();
-    medViewContainer* addContainerInTab(const QString &name);
-    medViewContainer* insertContainerInTab(int index, const QString &name);
+    void setKeepLeastOne(bool pi_bVal);
     // TODO mutualize all of this
     void setSplitter(int index, medViewContainerSplitter* splitter);
 
+public slots:
+    medViewContainer* addContainerInTabUnNamed();
+    medViewContainer* addContainerInTabNamed(const QString &name);
+    medViewContainer* insertNewTab(int index, const QString &name);
     void closeCurrentTab();
     void closeTab(int index);
 
 protected:
 
+private slots :
+    // Not sure of the name - RDE
+    //void resetTabState();
+    //void closeCurrentTab();
+    void tabBarDoubleClickedHandler(int  index);
 
-private slots:
-    void disconnectTabFromSplitter(int index);
-    void repopulateCurrentTab();
     void addContainerToSelection(QUuid container);
     void removeContainerFromSelection(QUuid container);
-    void connectContainer(QUuid container);
     void buildTemporaryPool();
+
+    void disconnectTabFromSplitter(int index);
+    void connectContainer(QUuid container);
     void connectContainerSelectedForCurrentTab();
     void minimizeOtherContainers(QUuid containerMaximized, bool maximized);
-    void minimizeSplitterContainers(QUuid containerMaximized, bool maximized,
-                                                             medViewContainerSplitter *splitter);
-    // Not sure of the name - RDE
-    void resetTabState();
+
+private:
+    void minimizeSplitterContainers(QUuid containerMaximized, bool maximized, medViewContainerSplitter *splitter);
 
 signals:
     void containersSelectedChanged();
@@ -83,5 +82,3 @@ signals:
 private:
     medTabbedViewContainersPrivate *d;
 };
-
-

--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medToolBox.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medToolBox.cpp
@@ -66,7 +66,6 @@ medToolBox::medToolBox(QWidget *parent) : QWidget(parent), d(new medToolBoxPriva
 medToolBox::~medToolBox(void)
 {
     delete d;
-
     d = NULL;
 }
 

--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medToolBoxBody.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medToolBoxBody.cpp
@@ -35,7 +35,6 @@ medToolBoxBody::medToolBoxBody(QWidget *parent) : QFrame(parent), d(new medToolB
 medToolBoxBody::~medToolBoxBody(void)
 {
     delete d;
-
     d = NULL;
 }
 
@@ -46,20 +45,18 @@ void medToolBoxBody::addWidget(QWidget *widget)
 
     d->widgets.append(widget);
 
-    if (d->layoutOrientation == Qt::Vertical) {
+    if (d->layoutOrientation == Qt::Vertical)
+    {
         d->layout->setRowStretch (d->layout->count(), 0);
-        d->layout->addWidget(widget, d->layout->count(),
-                             0, Qt::AlignTop);
+        d->layout->addWidget(widget, d->layout->count(), 0, Qt::AlignTop);
         d->layout->setRowStretch (d->layout->count(), 1);
     }
-    else {
+    else
+    {
         d->layout->setColumnStretch (d->layout->count(), 0);
-        d->layout->addWidget(widget, 0,
-                             d->layout->count(), Qt::AlignTop);
+        d->layout->addWidget(widget, 0, d->layout->count(), Qt::AlignTop);
         d->layout->setColumnStretch (d->layout->count(), 1);
     }
-
-    widget->setParent(this);
 }
 
 void medToolBoxBody::removeWidget(QWidget *widget)
@@ -104,7 +101,8 @@ void medToolBoxBody::setOrientation(Qt::Orientation orientation)
     this->clear();
 
 
-    foreach(QWidget * wid, d->widgets ) {
+    foreach(QWidget * wid, d->widgets )
+    {
       //addToolBox also sets the orientation of the toolboxes
       addWidget (wid);
       wid->show();

--- a/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.cpp
@@ -90,8 +90,7 @@ public:
 };
 
 
-medViewContainer::medViewContainer(medViewContainerSplitter *parent): QFrame(parent),
-    d(new medViewContainerPrivate)
+medViewContainer::medViewContainer(medViewContainerSplitter *parent): QFrame(parent), d(new medViewContainerPrivate)
 {
     d->parent = parent;
 
@@ -147,10 +146,7 @@ medViewContainer::medViewContainer(medViewContainerSplitter *parent): QFrame(par
     d->maximizedAction->setToolTip("Toggle maximized / unmaximized");
     d->maximizedAction->setCheckable(true);
     QIcon maximizedIcon(":/icons/maximize.svg");
-    maximizedIcon.addFile(":/icons/un_maximize.svg",
-                        QSize(16,16),
-                        QIcon::Normal,
-                        QIcon::On);
+    maximizedIcon.addFile(":/icons/un_maximize.svg", QSize(16,16), QIcon::Normal, QIcon::On);
 
     d->maximizedAction->setIcon(maximizedIcon);
     d->maximizedAction->setIconVisibleInMenu(true);
@@ -231,17 +227,16 @@ medViewContainer::medViewContainer(medViewContainerSplitter *parent): QFrame(par
 medViewContainer::~medViewContainer()
 {
     removeInternView();
-
-    // Trick to 'inform' a parented splitter
-    // "you're not my dad anymore!"
-    // There is no  'takeItem()' or 'removeWidget()' or wathever methode to remove a widget from a QSplitter.
-    // this is used to remove the ownership of the container, If the parent splitter end up with no child it will be deleted.
-    // see medViewContainerSplitter::~medViewContainerSplitter() and medViewContainerSplitter::checkIfStillDeserveToLive()
-
-    this->setParent(NULL);
-
     medViewContainerManager::instance()->unregisterContainer(this);
+
     delete d;
+    d = nullptr;
+}
+
+void medViewContainer::checkIfStillDeserveToLiveContainer()
+{
+    this->setParent(NULL);    
+    this->close();
 }
 
 void medViewContainer::popupMenu()
@@ -368,16 +363,16 @@ void medViewContainer::setClosingMode(medViewContainer::ClosingMode mode)
     case medViewContainer::CLOSE_CONTAINER:
         d->closeContainerButton->show();
         d->closeContainerButton->disconnect(this, SLOT(removeView()));
-        connect(d->closeContainerButton, SIGNAL(clicked()), this, SLOT(close()));
+        connect(d->closeContainerButton, SIGNAL(clicked()), this, SLOT(checkIfStillDeserveToLiveContainer()));
         break;
     case medViewContainer::CLOSE_VIEW:
         d->closeContainerButton->show();
-        d->closeContainerButton->disconnect(this, SLOT(close()));
+        d->closeContainerButton->disconnect(this, SLOT(checkIfStillDeserveToLiveContainer()));
         connect(d->closeContainerButton, SIGNAL(clicked()), this, SLOT(removeView()));
         break;
     case medViewContainer::CLOSE_BUTTON_HIDDEN:
         d->closeContainerButton->hide();
-        d->closeContainerButton->disconnect(this, SLOT(close()));
+        d->closeContainerButton->disconnect(this, SLOT(checkIfStillDeserveToLiveContainer()));
         connect(d->closeContainerButton, SIGNAL(clicked()), this, SLOT(removeView()));
         break;
     }

--- a/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.h
+++ b/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.h
@@ -1,3 +1,4 @@
+#pragma once
 /*=========================================================================
 
  medInria
@@ -10,8 +11,6 @@
   PURPOSE.
 
 =========================================================================*/
-
-#pragma once
 
 #include <QFrame>
 
@@ -92,6 +91,8 @@ public slots:
     void unHighlight();
 
     void splitContainer(unsigned int numY, unsigned int numX);
+
+    void checkIfStillDeserveToLiveContainer();
 
 signals:
     void maximized(QUuid uuid, bool maximized);

--- a/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainerSplitter.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainerSplitter.cpp
@@ -34,7 +34,7 @@ medViewContainerSplitter::medViewContainerSplitter(QWidget *parent)
 medViewContainerSplitter::~medViewContainerSplitter()
 {
 #ifdef _DEBUG
-    std::cout << "~medViewContainerSplitter\n";
+    std::cout << "~medViewContainerSplitter" << std::endl;
 #endif // _DEBUG
 }
 

--- a/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainerSplitter.h
+++ b/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainerSplitter.h
@@ -1,3 +1,4 @@
+#pragma once
 /*=========================================================================
 
  medInria
@@ -11,7 +12,6 @@
 
 =========================================================================*/
 
-#pragma once
 
 #include <QSplitter>
 
@@ -34,36 +34,22 @@ public:
 public slots:
     void addViewContainer(medViewContainer* container);
     void insertViewContainer(int index, medViewContainer* container);
-    medViewContainer* split(Qt::AlignmentFlag alignement = Qt::AlignRight);
+
     medViewContainer* splitVertically(medViewContainer *sender);
     medViewContainer* splitHorizontally(medViewContainer *sender);
+    medViewContainer* split(Qt::AlignmentFlag alignement = Qt::AlignRight);
     medViewContainer* split(medViewContainer *sender, Qt::AlignmentFlag alignement = Qt::AlignRight);
     void split(medDataIndex index, Qt::AlignmentFlag alignement = Qt::AlignRight);
 
 signals:
     void newContainer(QUuid);
-    void containerRemoved();
-
-    /**
-     * @brief aboutTobedestroyed
-     * It is emited right from the start of the destructor. It is used by the medTabbedViewContainer
-     * to repopulate the current tab when the last container is removed. We can't use the destroyed
-     * signal because it is emited too late.
-     * We want it to be emited before the splitter get unparented, otherwise the tab is already remooved.
-     */
-    void aboutTobedestroyed();
 
 private slots:
     medViewContainer* splitVertically();
     medViewContainer* splitHorizontally();
-
-    void checkIfStillDeserveToLive();
+    void checkIfStillDeserveToLiveSpliter();
 
 private:
     void recomputeSizes(int requestIndex, int newIndex, int newSize);
-
-    void insertNestedSplitter(int index,
-                           medViewContainer *oldContainer,
-                           medViewContainer *newContainer,
-                           bool inverseOrderInSplitter = false);
+    void insertNestedSplitter(int index, medViewContainer *oldContainer, medViewContainer *newContainer, bool inverseOrderInSplitter = false);
 };

--- a/src/layers/legacy/medCoreLegacy/medPluginManager.cpp
+++ b/src/layers/legacy/medCoreLegacy/medPluginManager.cpp
@@ -149,7 +149,6 @@ medPluginManager::medPluginManager(void) : dtkPluginManager(), d(new medPluginMa
 medPluginManager::~medPluginManager(void)
 {
     delete d;
-
     d = NULL;
 }
 

--- a/src/layers/medCore/job/medJobManager.cpp
+++ b/src/layers/medCore/job/medJobManager.cpp
@@ -49,8 +49,7 @@ medJobManager::~medJobManager()
     // just in case some unparented job are still living.
     for(medAbstractJob* job : d->jobs)
     {
-        dtkDebug() << "Orphan job still living at the end of the app detected:"
-                 << job->caption() << job;
+        job->cancel();
         job->deleteLater();
     }
 }
@@ -68,12 +67,6 @@ void medJobManager::unregisterJob(medAbstractJob *job)
 QList<medAbstractJob *> medJobManager::jobs() const
 {
     return d->jobs;
-}
-
-void medJobManager::cancelAll()
-{
-    for(medAbstractJob *job : d->jobs)
-        job->cancel();
 }
 
 void medJobManager::startJobInThread(medAbstractJob *job)

--- a/src/layers/medCore/job/medJobManager.h
+++ b/src/layers/medCore/job/medJobManager.h
@@ -39,8 +39,6 @@ public:
     void unregisterJob(medAbstractJob *job);
     QList<medAbstractJob *> jobs() const;
 
-    void cancelAll();
-
 public:
      void startJobInThread(medAbstractJob* job);
 


### PR DESCRIPTION
 - "Generic, filtering and diffusion workspaces probably do something wrong when loading plugin processes or handling them: when quitting the app after using one plugin in those workspaces, there is a crash" by mikejbuckingham
 - "Sometimes a crash happens when quitting medinria related to views and tabbed views deletion. Replicating this will do it : open medinria, load a first layer with an image, then add a mesh on top of it. Now close the app and the crash happens" by ocommowi

Improve multi-tabs into filtering workspace. 
   - split toolBoxe of creation of new filter and parameter of it in 2 different.
   - Improve robustness of toolBoxes placing and displaying.