### PR TITLE
Improvements and small corrections

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medDataManager.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDataManager.cpp
@@ -13,7 +13,7 @@
 
 #include <medDataManager.h>
 
-#include <dtkLog>
+#include <QDebug>
 
 #include <medAbstractDataFactory.h>
 #include <medDatabaseController.h>
@@ -98,9 +98,10 @@ medAbstractData* medDataManager::retrieveData(const medDataIndex& index)
     // If nothing in the tracker, we'll get a null weak pointer, thus a null shared pointer
     medAbstractData *dataObjRef = d->loadedDataObjectTracker.value(index);
 
-    if(dataObjRef) {
+    if(dataObjRef)
+    {
         // we found an existing instance of that object
-        dtkDebug()<<"medDataManager we found an existing instance of that object" <<dataObjRef->count();
+        qDebug()<<"medDataManager we found an existing instance of that object" <<dataObjRef->count();
         return dataObjRef;
     }
 
@@ -248,7 +249,7 @@ QList<medDataIndex> medDataManager::moveStudy(const medDataIndex& indexStudy, co
     }
 
     if(dbc->dataSourceId() != toPatient.dataSourceId()) {
-        dtkWarn() << "medDataManager: Moving data accross controllers is not supported.";
+        dtkWarn() << "medDataManager: Moving data across controllers is not supported.";
     } else {
         newIndexList = dbc->moveStudy(indexStudy,toPatient);
     }
@@ -268,7 +269,7 @@ medDataIndex medDataManager::moveSerie(const medDataIndex& indexSerie, const med
     medDataIndex newIndex;
 
     if(dbc->dataSourceId() != toStudy.dataSourceId()) {
-        dtkWarn() << "medDataManager: Moving data accross controllers is not supported.";
+        dtkWarn() << "medDataManager: Moving data across controllers is not supported.";
     } else {
         newIndex = dbc->moveSerie(indexSerie,toStudy);
     }
@@ -300,7 +301,7 @@ void medDataManager::garbageCollect()
     Q_D(medDataManager);
     QMutexLocker locker(&(d->mutex));
 
-    // garbage collect datas that are only referenced by the manager
+    // garbage collect data that are only referenced by the manager
     QMutableHashIterator <medDataIndex, dtkSmartPointer<medAbstractData> > it(d->loadedDataObjectTracker);
     while(it.hasNext()) {
         it.next();

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
@@ -8,17 +8,15 @@ vtkStandardNewMacro(vtkImage2DDisplay);
 
 vtkImage2DDisplay::vtkImage2DDisplay()
 {
-    //this->m_bInputSeted = false;
-    this->Input = 0;
+    this->InputProducer     = 0;
     this->ImageActor        = vtkImageActor::New();
     this->WindowLevel       = vtkImageMapToColors::New();
     this->WindowLevel->SetOutputFormatToRGBA();
-    this->ColorWindow = 1e-3 * VTK_DOUBLE_MAX;
-    this->ColorLevel  = 0;
-    this->ColorTransferFunction = NULL;
+    this->ColorWindow       = 1e-3 * VTK_DOUBLE_MAX;
+    this->ColorLevel        = 0;
+    this->ColorTransferFunction   = NULL;
     this->OpacityTransferFunction = NULL;
-    this->UseLookupTable = false;
-    //this->m_sVtkImageInfo = { 0 };
+    this->UseLookupTable    = false;
 }
 
 vtkImage2DDisplay::~vtkImage2DDisplay()
@@ -29,12 +27,14 @@ void vtkImage2DDisplay::SetInput(vtkAlgorithmOutput *pi_poVtkAlgoPort)
 {
     if (pi_poVtkAlgoPort)
     {
-        if (pi_poVtkAlgoPort->GetProducer() && pi_poVtkAlgoPort->GetProducer()->IsA("vtkImageAlgorithm")/* && pi_poVtkAlgoPort->GetProducer()->IsTypeOf("vtkImageAlgorithm")*/)
+        if (pi_poVtkAlgoPort->GetProducer() && pi_poVtkAlgoPort->GetProducer()->IsA("vtkImageAlgorithm"))
         {
             vtkAlgorithmOutput *poVtkAlgoPortTmp = pi_poVtkAlgoPort;
             vtkImageAlgorithm *poVtkImgAlgoTmp = static_cast<vtkImageAlgorithm*>(pi_poVtkAlgoPort->GetProducer());
             vtkImageData *poVtkImgTmp = poVtkImgAlgoTmp->GetOutput();
-
+            
+            InputProducer = poVtkImgAlgoTmp;
+            
             m_sVtkImageInfo.SetSpacing(poVtkImgTmp->GetSpacing());
             m_sVtkImageInfo.SetOrigin(poVtkImgTmp->GetOrigin());
             m_sVtkImageInfo.SetScalarRange(poVtkImgTmp->GetScalarRange());
@@ -48,10 +48,8 @@ void vtkImage2DDisplay::SetInput(vtkAlgorithmOutput *pi_poVtkAlgoPort)
             {
                 this->WindowLevel->SetInputConnection(poVtkAlgoPortTmp);
                 poVtkAlgoPortTmp = this->WindowLevel->GetOutputPort();
-                //poVtkImgTmp = this->WindowLevel->GetOutput();
             }
             this->ImageActor->GetMapper()->SetInputConnection(poVtkAlgoPortTmp);
-            //this->ImageActor->GetProperty()->SetInterpolationTypeToCubic();
         }
         else
         {

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
@@ -1,5 +1,6 @@
 #include "vtkImage2DDisplay.h"
 #include <vtkImageMapper3D.h>
+#include <vtkImageProperty.h>
 #include <vtkImageAlgorithm.h>
 #include <vtkAlgorithmOutput.h>
 
@@ -50,6 +51,7 @@ void vtkImage2DDisplay::SetInput(vtkAlgorithmOutput *pi_poVtkAlgoPort)
                 //poVtkImgTmp = this->WindowLevel->GetOutput();
             }
             this->ImageActor->GetMapper()->SetInputConnection(poVtkAlgoPortTmp);
+            //this->ImageActor->GetProperty()->SetInterpolationTypeToCubic();
         }
         else
         {

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.h
@@ -22,8 +22,10 @@ public:
 
   virtual vtkImageActor* GetImageActor() { return this->ImageActor; }
 
-  virtual vtkImageMapToColors* GetWindowLevel() const
-  { return this->WindowLevel; }
+  virtual vtkImageMapToColors* GetWindowLevel() const { return this->WindowLevel; }
+
+  virtual vtkImageAlgorithm* GetInputProducer() const { return this->InputProducer; }
+
   vtkSetMacro(ColorWindow, double);
   vtkGetMacro(ColorWindow,double);
   vtkSetMacro(ColorLevel, double);
@@ -46,7 +48,7 @@ protected:
 
 private:
   vtkSmartPointer<vtkImageMapToColors>        WindowLevel;
-  vtkSmartPointer<vtkImageData>               Input;
+  vtkSmartPointer<vtkImageAlgorithm>          InputProducer;
   vtkSmartPointer<vtkImageActor>              ImageActor;
   double                                      ColorWindow;
   double                                      ColorLevel;

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.h
@@ -16,7 +16,6 @@ public:
   vtkTypeMacro (vtkImage2DDisplay, vtkObject);
 
   virtual void SetInput(vtkAlgorithmOutput*  pi_poVtkAlgoPort);
-  //virtual vtkImageData* GetInput() { return this->Input; }
 
   virtual vtkLookupTable * GetLookupTable() const;
 

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
@@ -1090,7 +1090,7 @@ double vtkImageView::GetValueAtPosition(double worldcoordinates[3], int componen
 
     int indices[3];
     this->GetImageCoordinatesFromWorldCoordinates (worldcoordinates, indices);
-    this->Get2DDisplayMapperInputAlgorithum()->UpdateInformation();
+    this->Get2DDisplayMapperInputAlgorithm()->UpdateInformation();
     vtkImageData* inputImage = poAlgoTmp->GetOutput();
 
     int* w_extent = this->GetMedVtkImageInfo()->extent;
@@ -1114,7 +1114,7 @@ double vtkImageView::GetValueAtPosition(double worldcoordinates[3], int componen
          (indices[2] > extent[5]) )
     {
 
-        int* u_extent = this->Get2DDisplayMapperInputAlgorithum(layer)->GetUpdateExtent ();
+        int* u_extent = this->Get2DDisplayMapperInputAlgorithm(layer)->GetUpdateExtent ();
         if ( (indices[0] < u_extent[0]) ||
              (indices[0] > u_extent[1]) ||
              (indices[1] < u_extent[2]) ||
@@ -1123,13 +1123,13 @@ double vtkImageView::GetValueAtPosition(double worldcoordinates[3], int componen
              (indices[2] > u_extent[5]) )
         {
             int pointExtent [6] = { indices [0], indices [0], indices [1], indices [1], indices [2], indices [2] };
-            this->Get2DDisplayMapperInputAlgorithum(layer)->UpdateExtent(pointExtent);
-            this->Get2DDisplayMapperInputAlgorithum(layer)->Update();
+            this->Get2DDisplayMapperInputAlgorithm(layer)->UpdateExtent(pointExtent);
+            this->Get2DDisplayMapperInputAlgorithm(layer)->Update();
 
         } 
         else
         {
-            this->Get2DDisplayMapperInputAlgorithum(layer)->Update ();
+            this->Get2DDisplayMapperInputAlgorithm(layer)->Update ();
             int* new_extent = this->GetMedVtkImageInfo()->extent;
             if ( (indices[0] < new_extent[0]) ||
                  (indices[0] > new_extent[1]) ||
@@ -1146,7 +1146,7 @@ double vtkImageView::GetValueAtPosition(double worldcoordinates[3], int componen
     else
     {
         // Need to be sure that the input is up to date. Otherwise we may be requesting bad data.
-        this->Get2DDisplayMapperInputAlgorithum(layer)->Update();
+        this->Get2DDisplayMapperInputAlgorithm(layer)->Update();
     }
 
     return inputImage->GetScalarComponentAsDouble(indices[0], indices[1], indices[2], component);
@@ -1270,7 +1270,7 @@ double vtkImageView::GetZoom()
 {
     if (!this->GetMedVtkImageInfo() || !this->GetMedVtkImageInfo()->initialized)
         return 1.0;
-    if (!this->Get2DDisplayMapperInputAlgorithum() || !this->Get2DDisplayMapperInputAlgorithum()->GetOutputInformation(0))
+    if (!this->Get2DDisplayMapperInputAlgorithm() || !this->Get2DDisplayMapperInputAlgorithm()->GetOutputInformation(0))
         return 1.0;
 
     vtkCamera *cam = this->GetRenderer() ? this->GetRenderer()->GetActiveCamera() : NULL;
@@ -1652,13 +1652,13 @@ void vtkImageView::GetInputBoundsInWorldCoordinates ( double * bounds )
 }
 
 //----------------------------------------------------------------------------
-vtkAlgorithm* vtkImageView::Get2DDisplayMapperInputAlgorithum() const
+vtkAlgorithm* vtkImageView::Get2DDisplayMapperInputAlgorithm() const
 {
     int layer = this->GetCurrentLayer();
-    return this->Get2DDisplayMapperInputAlgorithum(layer);
+    return this->Get2DDisplayMapperInputAlgorithm(layer);
 }
 
-vtkAlgorithm* vtkImageView::Get2DDisplayMapperInputAlgorithum (int layer) const
+vtkAlgorithm* vtkImageView::Get2DDisplayMapperInputAlgorithm (int layer) const
 {
     return this->WindowLevel->GetInputAlgorithm();
 }

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
@@ -1081,7 +1081,9 @@ double vtkImageView::GetValueAtPosition(double worldcoordinates[3], int componen
 //----------------------------------------------------------------------------
 double vtkImageView::GetValueAtPosition(double worldcoordinates[3], int component, int layer )
 {
-    if (!this->GetMedVtkImageInfo(layer) || !this->GetMedVtkImageInfo(layer)->initialized)
+    vtkImageAlgorithm* poAlgoTmp = dynamic_cast<vtkImageAlgorithm*>(this->GetInputAlgorithm(layer));
+
+    if (!poAlgoTmp || !(poAlgoTmp = dynamic_cast<vtkImageAlgorithm*>(poAlgoTmp->GetInputAlgorithm())) || !this->GetMedVtkImageInfo(layer) || !this->GetMedVtkImageInfo(layer)->initialized)
     {
         return 0.0;
     }
@@ -1089,6 +1091,7 @@ double vtkImageView::GetValueAtPosition(double worldcoordinates[3], int componen
     int indices[3];
     this->GetImageCoordinatesFromWorldCoordinates (worldcoordinates, indices);
     this->GetInputAlgorithm()->UpdateInformation();
+    vtkImageData* input = poAlgoTmp->GetOutput();
 
     int* w_extent = this->GetMedVtkImageInfo()->extent;
     if ((indices[0] < w_extent[0]) ||
@@ -1147,7 +1150,7 @@ double vtkImageView::GetValueAtPosition(double worldcoordinates[3], int componen
         this->GetInputAlgorithm(layer)->Update();
     }
 
-    return m_poInternalImageFromInput->GetScalarComponentAsDouble(indices[0], indices[1], indices[2], component);//FloTODO
+    return input->GetScalarComponentAsDouble(indices[0], indices[1], indices[2], component);
 
 }
 
@@ -1661,6 +1664,10 @@ vtkAlgorithm* vtkImageView::GetInputAlgorithm (int layer) const
     return this->WindowLevel->GetInputAlgorithm();
 }
 
+vtkAlgorithm* vtkImageView::GetInputAlgorithm2(int layer) const
+{
+    return this->WindowLevel->GetInputAlgorithm();
+}
 
 //----------------------------------------------------------------------------
 void vtkImageView::PrintSelf(ostream& os, vtkIndent indent)

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.h
@@ -478,7 +478,8 @@ public:
     vtkGetMacro(IsInteractorInstalled, int);
 
     virtual vtkAlgorithm* GetInputAlgorithm () const;
-    virtual vtkAlgorithm* GetInputAlgorithm (int layer) const;
+    virtual vtkAlgorithm* GetInputAlgorithm(int layer) const;
+    virtual vtkAlgorithm* GetInputAlgorithm2(int layer) const;
 
 protected:
     vtkImageView();

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.h
@@ -477,8 +477,8 @@ public:
 
     vtkGetMacro(IsInteractorInstalled, int);
 
-    virtual vtkAlgorithm* Get2DDisplayMapperInputAlgorithum () const;
-    virtual vtkAlgorithm* Get2DDisplayMapperInputAlgorithum(int layer) const;
+    virtual vtkAlgorithm* Get2DDisplayMapperInputAlgorithm () const;
+    virtual vtkAlgorithm* Get2DDisplayMapperInputAlgorithm(int layer) const;
     virtual vtkImageAlgorithm* GetInputAlgorithm(int layer) const;
 
 protected:

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.h
@@ -477,9 +477,9 @@ public:
 
     vtkGetMacro(IsInteractorInstalled, int);
 
-    virtual vtkAlgorithm* GetInputAlgorithm () const;
-    virtual vtkAlgorithm* GetInputAlgorithm(int layer) const;
-    virtual vtkAlgorithm* GetInputAlgorithm2(int layer) const;
+    virtual vtkAlgorithm* Get2DDisplayMapperInputAlgorithum () const;
+    virtual vtkAlgorithm* Get2DDisplayMapperInputAlgorithum(int layer) const;
+    virtual vtkImageAlgorithm* GetInputAlgorithm(int layer) const;
 
 protected:
     vtkImageView();

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
@@ -280,8 +280,8 @@ void vtkImageView2D::GetSliceRange(int &min, int &max) const
 {
   if (this->GetMedVtkImageInfo()->initialized)
   {
-      this->Get2DDisplayMapperInputAlgorithum()->UpdateInformation();
-      int* w_ext = this->Get2DDisplayMapperInputAlgorithum()->GetOutputInformation(0)->Get(vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT());
+      this->Get2DDisplayMapperInputAlgorithm()->UpdateInformation();
+      int* w_ext = this->Get2DDisplayMapperInputAlgorithm()->GetOutputInformation(0)->Get(vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT());
       min = w_ext[this->SliceOrientation * 2];
       max = w_ext[this->SliceOrientation * 2 + 1];
   }
@@ -2315,7 +2315,7 @@ vtkImageMapToColors * vtkImageView2D::GetWindowLevel( int layer/*=0*/ ) const
     else return NULL;
 }
 
-vtkAlgorithm* vtkImageView2D::Get2DDisplayMapperInputAlgorithum (int layer) const
+vtkAlgorithm* vtkImageView2D::Get2DDisplayMapperInputAlgorithm (int layer) const
 {
     return this->GetWindowLevel(layer);
 }

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
@@ -280,8 +280,8 @@ void vtkImageView2D::GetSliceRange(int &min, int &max) const
 {
   if (this->GetMedVtkImageInfo()->initialized)
   {
-      this->GetInputAlgorithm()->UpdateInformation();
-      int* w_ext = this->GetInputAlgorithm()->GetOutputInformation(0)->Get(vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT());
+      this->Get2DDisplayMapperInputAlgorithum()->UpdateInformation();
+      int* w_ext = this->Get2DDisplayMapperInputAlgorithum()->GetOutputInformation(0)->Get(vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT());
       min = w_ext[this->SliceOrientation * 2];
       max = w_ext[this->SliceOrientation * 2 + 1];
   }
@@ -2315,9 +2315,20 @@ vtkImageMapToColors * vtkImageView2D::GetWindowLevel( int layer/*=0*/ ) const
     else return NULL;
 }
 
-vtkAlgorithm* vtkImageView2D::GetInputAlgorithm (int layer) const
+vtkAlgorithm* vtkImageView2D::Get2DDisplayMapperInputAlgorithum (int layer) const
 {
     return this->GetWindowLevel(layer);
+}
+
+vtkImageAlgorithm* vtkImageView2D::GetInputAlgorithm(int layer) const
+{
+    vtkImageAlgorithm *poRes = nullptr;
+    
+    vtkImage2DDisplay * imageDisplay = this->GetImage2DDisplayForLayer(layer);
+    if (imageDisplay)
+        poRes = imageDisplay->GetInputProducer();
+
+    return poRes;
 }
 
 ////----------------------------------------------------------------------------

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.h
@@ -258,8 +258,8 @@ public:
 
     virtual vtkImageMapToColors *GetWindowLevel(int layer=0) const;
 
-    using vtkImageView::Get2DDisplayMapperInputAlgorithum;
-    virtual vtkAlgorithm* Get2DDisplayMapperInputAlgorithum(int layer) const;
+    using vtkImageView::Get2DDisplayMapperInputAlgorithm;
+    virtual vtkAlgorithm* Get2DDisplayMapperInputAlgorithm(int layer) const;
     virtual vtkImageAlgorithm* GetInputAlgorithm(int layer) const;
 
     //BTX

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.h
@@ -258,8 +258,9 @@ public:
 
     virtual vtkImageMapToColors *GetWindowLevel(int layer=0) const;
 
-    using vtkImageView::GetInputAlgorithm;
-    virtual vtkAlgorithm* GetInputAlgorithm (int layer) const;
+    using vtkImageView::Get2DDisplayMapperInputAlgorithum;
+    virtual vtkAlgorithm* Get2DDisplayMapperInputAlgorithum(int layer) const;
+    virtual vtkImageAlgorithm* GetInputAlgorithm(int layer) const;
 
     //BTX
     /**


### PR DESCRIPTION
- Correction of crashing bug when medInria closing after a set in first fibers and after over the fibers a volume. The bug is due to dtklog.
- Correction  issuses #318 "The pixel value in a layered view of medinria is always linked to the first layer. Even if the second layer of a view is selected."