### PR TITLE
[music3] remove Wno-inconsistent-missing-override warning

### DIFF
--- a/superbuild/projects_modules/QtDCM.cmake
+++ b/superbuild/projects_modules/QtDCM.cmake
@@ -49,8 +49,12 @@ set(git_tag master)
 
 # set compilation flags
 if (UNIX)
-  set(${ep}_c_flags "${${ep}_c_flags} -Wall -Wno-inconsistent-missing-override")
-  set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wall -Wno-inconsistent-missing-override")
+  set(${ep}_c_flags "${${ep}_c_flags} -Wall")
+  set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wall")
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wno-inconsistent-missing-override")
 endif()
 
 set(cmake_args

--- a/superbuild/projects_modules/RPI.cmake
+++ b/superbuild/projects_modules/RPI.cmake
@@ -49,8 +49,12 @@ set(git_tag master)
 
 # set compilation flags
 if (UNIX)
-  set(${ep}_c_flags "${${ep}_c_flags} -Wall -Wno-inconsistent-missing-override")
-  set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wall -Wno-inconsistent-missing-override")
+  set(${ep}_c_flags "${${ep}_c_flags} -Wall")
+  set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wall")
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wno-inconsistent-missing-override")
 endif()
 
 set(cmake_args

--- a/superbuild/projects_modules/TTK.cmake
+++ b/superbuild/projects_modules/TTK.cmake
@@ -49,8 +49,12 @@ set(git_tag master)
 
 # set compilation flags
 if (UNIX)
-  set(${ep}_c_flags "${${ep}_c_flags} -Wall -Wno-inconsistent-missing-override")
-  set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wall -Wno-inconsistent-missing-override")
+  set(${ep}_c_flags "${${ep}_c_flags} -Wall")
+  set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wall")
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wno-inconsistent-missing-override")
 endif()
 
 set(cmake_args

--- a/superbuild/projects_modules/dtk.cmake
+++ b/superbuild/projects_modules/dtk.cmake
@@ -50,8 +50,12 @@ set(git_tag 1.7.1)
 
 # set compilation flags
  if (UNIX)
-  set(${ep}_c_flags "${${ep}_c_flags} -Wall -Wno-inconsistent-missing-override")
-  set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wall -Wno-inconsistent-missing-override")
+  set(${ep}_c_flags "${${ep}_c_flags} -Wall")
+  set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wall")
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wno-inconsistent-missing-override")
 endif()
 
 set(cmake_args

--- a/superbuild/projects_modules/dtkImaging.cmake
+++ b/superbuild/projects_modules/dtkImaging.cmake
@@ -50,8 +50,12 @@ set(git_tag master)
 
 # set compilation flags
  if (UNIX)
-  set(${ep}_c_flags "${${ep}_c_flags} -Wall -Wno-inconsistent-missing-override")
-  set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wall -Wno-inconsistent-missing-override")
+  set(${ep}_c_flags "${${ep}_c_flags} -Wall")
+  set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wall")
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wno-inconsistent-missing-override")
 endif()
 
 set(cmake_args

--- a/superbuild/projects_modules/medInria.cmake
+++ b/superbuild/projects_modules/medInria.cmake
@@ -53,8 +53,12 @@ if (NOT USE_SYSTEM_${ep})
 
 # set compilation flags
 if (UNIX)
-  set(${ep}_c_flags "${${ep}_c_flags} -Wall -Wno-inconsistent-missing-override")
-  set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wall -Wno-inconsistent-missing-override")
+  set(${ep}_c_flags "${${ep}_c_flags} -Wall")
+  set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wall")
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(${ep}_cxx_flags "${${ep}_cxx_flags} -Wno-inconsistent-missing-override")
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX)


### PR DESCRIPTION
(From https://github.com/Inria-Asclepios/medinria-superproject/pull/64)

This PR removes the `-Wno-inconsistent-missing-override` warning on Linux.

:m: