### PR TITLE
Fixes for MUSIC plugins

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -163,7 +163,17 @@ endif()
 # Setup Configuration files
 ################################################################################
 
-set_lib_properties_variables(medCoreLegacy medLog medRegistration medCore medImageIO medVtkInria medWidgets)
+set_lib_properties_variables(
+    medCoreLegacy
+    medLog
+    medRegistration
+    medCore
+    medImageIO
+    medVtkInria
+    medWidgets
+    medUtilities
+    medVtkDataMeshBase
+    )
 
 if(EXISTS ${CMAKE_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in)
   configure_file( ## Build tree configure file

--- a/src/cmake/medInriaConfig.cmake.in
+++ b/src/cmake/medInriaConfig.cmake.in
@@ -41,5 +41,13 @@ add_library(medWidgets UNKNOWN IMPORTED)
 find_library(medWidgets_LIBRARY NAMES medWidgets PATHS @medWidgets_LIBRARY_DIR@ @medWidgets_LIBRARY_DIR@/@CMAKE_BUILD_TYPE@)
 set_target_properties(medWidgets PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "@medWidgets_INCLUDE_DIRS@" IMPORTED_LOCATION ${medWidgets_LIBRARY})
 
+add_library(medUtilities UNKNOWN IMPORTED)
+find_library(medUtilities_LIBRARY NAMES medUtilities PATHS @medUtilities_LIBRARY_DIR@ @medUtilities_LIBRARY_DIR@/@CMAKE_BUILD_TYPE@)
+set_target_properties(medUtilities PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "@medUtilities_INCLUDE_DIRS@" IMPORTED_LOCATION ${medUtilities_LIBRARY})
+
+add_library(medVtkDataMeshBase UNKNOWN IMPORTED)
+find_library(medVtkDataMeshBase_LIBRARY NAMES medVtkDataMeshBase PATHS @medVtkDataMeshBase_LIBRARY_DIR@ @medVtkDataMeshBase_LIBRARY_DIR@/@CMAKE_BUILD_TYPE@)
+set_target_properties(medVtkDataMeshBase PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "@medVtkDataMeshBase_INCLUDE_DIRS@" IMPORTED_LOCATION ${medVtkDataMeshBase_LIBRARY})
+
 set(medInria_CMAKE_DIR @medInria_CMAKE_DIR@)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${medInria_CMAKE_DIR}")

--- a/src/layers/legacy/medVtkDataMeshBase/CMakeLists.txt
+++ b/src/layers/legacy/medVtkDataMeshBase/CMakeLists.txt
@@ -61,6 +61,7 @@ target_include_directories(${TARGET_NAME}
 
 target_link_libraries(${TARGET_NAME}
   ${QT_LIBRARIES}
+  ${ITK_LIBRARIES}
   medCore
   medLog
   medVtkInria


### PR DESCRIPTION
Some changes required for the MUSIC plugins:

- Provide include path variables for medUtilities and medVtkDataMeshBase
- Add medUtilities and medVtkDataMeshBase to the config file
- Link ITK libs for medVtkDataMeshBase