### PR TITLE
External project plugins

### DIFF
--- a/packaging/apple/ApplePackScript.cmake.in
+++ b/packaging/apple/ApplePackScript.cmake.in
@@ -1,2 +1,2 @@
 execute_process(COMMAND rm -f @PROJECT_BINARY_DIR@/medInria-@@PROJECT_NAME@_VERSION@.dmg)
-execute_process(COMMAND @PROJECT_BINARY_DIR@/packaging/apple/mac_packager.sh @medInria_BINARY_DIR@/bin/plugins @medInria_BINARY_DIR@/bin/plugins_legacy @PRIVATE_PLUGINS_DIRS@ @PRIVATE_PLUGINS_LEGACY_DIRS@)
+execute_process(COMMAND @PROJECT_BINARY_DIR@/packaging/apple/mac_packager.sh @medInria_BINARY_DIR@/bin/plugins @medInria_BINARY_DIR@/bin/plugins_legacy @PRIVATE_PLUGINS_DIRS@ @PRIVATE_PLUGINS_LEGACY_DIRS@ @EXTERNAL_PROJECT_PLUGINS_LEGACY_DIRS@)

--- a/packaging/linux/LinuxPackaging.cmake
+++ b/packaging/linux/LinuxPackaging.cmake
@@ -99,6 +99,10 @@ foreach(dir ${PRIVATE_PLUGINS_LEGACY_DIRS})
     set(CPACK_INSTALL_CMAKE_PROJECTS ${CPACK_INSTALL_CMAKE_PROJECTS} ${dir} ${dir} ALL "/bin")
 endforeach()
 
+foreach(dir ${EXTERNAL_PROJECT_PLUGINS_LEGACY_DIRS})
+    set(CPACK_INSTALL_CMAKE_PROJECTS ${CPACK_INSTALL_CMAKE_PROJECTS} ${dir} ${dir} ALL "/bin")
+endforeach()
+
 install(CODE "include(${CURRENT_BIN_DIR}/PostArchiveCleanupScript.cmake)")
 
 # force the medinria-superproject install target to run last so we can use it

--- a/packaging/unix/Launchers.cmake
+++ b/packaging/unix/Launchers.cmake
@@ -24,7 +24,11 @@ endforeach()
 
 foreach (dir ${PRIVATE_PLUGINS_LEGACY_DIRS})
 	set(DEV_PLUGINS_LEGACY_DIRS "${DEV_PLUGINS_LEGACY_DIRS}:${dir}/bin/plugins_legacy")
-endforeach() 
+endforeach()
+
+foreach (dir ${EXTERNAL_PROJECT_PLUGINS_LEGACY_DIRS})
+        set(DEV_PLUGINS_LEGACY_DIRS "${DEV_PLUGINS_LEGACY_DIRS}:${dir}/bin/plugins_legacy")
+endforeach()
 
 ExternalProject_Get_Property(medInria binary_dir)
 

--- a/packaging/windows/WindowsLaunchers.cmake
+++ b/packaging/windows/WindowsLaunchers.cmake
@@ -15,11 +15,15 @@ set(CURRENT_SRC_DIR ${CMAKE_SOURCE_DIR}/packaging/windows)
 
 foreach (dir ${PRIVATE_PLUGINS_DIRS})
     set(DEV_PLUGINS_DIRS "${DEV_PLUGINS_DIRS}:${dir}/plugins/%1")
-endforeach() 
+endforeach()
 
 foreach (dir ${PRIVATE_PLUGINS_LEGACY_DIRS})
     set(DEV_PLUGINS_LEGACY_DIRS "${DEV_PLUGINS_LEGACY_DIRS}:${dir}/plugins_legacy/%1")
 endforeach() 
+
+foreach (dir ${EXTERNAL_PROJECT_PLUGINS_LEGACY_DIRS})
+    set(DEV_PLUGINS_LEGACY_DIRS "${DEV_PLUGINS_LEGACY_DIRS}:${dir}/plugins_legacy/%1")
+endforeach()
 
 set(WIN_TYPE x86)
 if (CMAKE_GENERATOR MATCHES "Win64")

--- a/packaging/windows/WindowsPackaging.cmake
+++ b/packaging/windows/WindowsPackaging.cmake
@@ -85,6 +85,16 @@ if (NOT PRIVATE_PLUGINS_LEGACY_DIRS STREQUAL "")
     endforeach()
 endif()
 
+if (NOT EXTERNAL_PROJECT_PLUGINS_LEGACY_DIRS STREQUAL "")
+    foreach(pluginpath ${EXTERNAL_PROJECT_PLUGINS_LEGACY_DIRS})
+        file(TO_CMAKE_PATH ${pluginpath} pluginpath)
+# Add an extra slash, otherwise we copy the folder, not its content
+        set(pluginpath "${pluginpath}/")
+        message("Adding ${pluginpath} to the external project plugins dirs...")
+        install(DIRECTORY ${pluginpath} DESTINATION plugins_legacy COMPONENT Runtime FILES_MATCHING PATTERN "*${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    endforeach()
+endif()
+
 #${CMAKE_CFG_INTDIR}
 set(APP "\${CMAKE_INSTALL_PREFIX}/bin/medInria.exe")
 set(QT_BINARY_DIR "${Qt5_DIR}/../../../bin")

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -54,7 +54,7 @@ list(APPEND external_projects
   TTK 
   DCMTK 
   QtDCM 
-  dtk 
+  dtk
   )
 
 if (USE_DTKIMAGING)
@@ -138,6 +138,8 @@ set(CMAKE_MODULE_PATH
 
 set(PRIVATE_PLUGINS_DIRS "" CACHE PATH "Folders containing private plugins, separated by ';'")
 set(PRIVATE_PLUGINS_LEGACY_DIRS "" CACHE PATH "Folders containing legacy private plugins, separated by ';'")
+
+set(EXTERNAL_PROJECT_PLUGINS_LEGACY_DIRS "")
 
 ## #############################################################################
 ## Add Targets


### PR DESCRIPTION
In MUSIC 2 we have various private plugin repositories, and setting up a working MUSIC development environment is impractical. Each private set of plugins must be cloned separately, and each has its own superproject which needs to be configured with the path to the medInria superproject, and inversely the medInria superproject needs to be configured with the path of the private plugins to load them.
It is much simpler to remove the plugin superprojects and set them up as external projects, so that medInria handles their configuration automatically. I did this successfully with the main MUSIC plugins repo, and it requires the addition of a cmake variable `EXTERNAL_PROJECT_PLUGINS_LEGACY_DIRS` that allows external project configuration files to add the path of their plugins.

_(The inclusion of MUSIC as an external project will be done on our fork of medInria)_