### PR TITLE
[Diffusion] toolboxes were too large

### DIFF
--- a/src/app/medInria/areas/workspaces/diffusion/medDiffusionWorkspace.cpp
+++ b/src/app/medInria/areas/workspaces/diffusion/medDiffusionWorkspace.cpp
@@ -39,7 +39,7 @@ public:
 
 medDiffusionWorkspace::medDiffusionWorkspace(QWidget *parent) : medAbstractWorkspaceLegacy(parent), d(new medDiffusionWorkspacePrivate)
 {
-    d->diffusionContainer = 0;
+    d->diffusionContainer = nullptr;
 
     // -- Bundling toolbox --
     d->fiberBundlingToolBox = medToolBoxFactory::instance()->createToolBox("medFiberBundlingToolBox", parent);
@@ -82,7 +82,7 @@ medDiffusionWorkspace::medDiffusionWorkspace(QWidget *parent) : medAbstractWorks
 medDiffusionWorkspace::~medDiffusionWorkspace()
 {
     delete d;
-    d = NULL;
+    d = nullptr;
 }
 
 void medDiffusionWorkspace::setupTabbedViewContainer()
@@ -201,7 +201,7 @@ void medDiffusionWorkspace::addToolBoxInput(medAbstractData *data)
     if (medData->Dimension() == 4)
         d->diffusionEstimationToolBox->addInputImage(medData);
 
-    if (dynamic_cast<medAbstractDiffusionModelImageData*>(medData) != 0)
+    if (dynamic_cast<medAbstractDiffusionModelImageData*>(medData) != nullptr)
     {
         d->diffusionScalarMapsToolBox->addInputImage(medData);
         d->diffusionTractographyToolBox->addInputImage(medData);

--- a/src/layers/medCore/process/diffusion_processes/medDiffusionModelEstimationMetaProcess.cpp
+++ b/src/layers/medCore/process/diffusion_processes/medDiffusionModelEstimationMetaProcess.cpp
@@ -36,12 +36,12 @@ public:
 medDiffusionModelEstimationMetaProcess::medDiffusionModelEstimationMetaProcess(QObject *parent)
     : medAbstractProcess(parent), d(new medDiffusionModelEstimationMetaProcessPrivate)
 {
-    d->input = 0;
-    d->output = 0;
+    d->input = nullptr;
+    d->output = nullptr;
 
-    d->dwiMaskCalculator = 0;
+    d->dwiMaskCalculator = nullptr;
     d->dwiMaskApplyer = medCore::maskImage::pluginFactory().create("medItkMaskImageProcess");
-    d->modelEstimator = 0;
+    d->modelEstimator = nullptr;
 }
 
 medDiffusionModelEstimationMetaProcess::~medDiffusionModelEstimationMetaProcess()

--- a/src/layers/medWidgets/process/diffusion_processes/medDiffusionModelEstimationMetaProcessPresenter.cpp
+++ b/src/layers/medWidgets/process/diffusion_processes/medDiffusionModelEstimationMetaProcessPresenter.cpp
@@ -60,10 +60,10 @@ medDiffusionModelEstimationMetaProcessPresenter::medDiffusionModelEstimationMeta
             this, &medDiffusionModelEstimationMetaProcessPresenter::_importOutput,
             Qt::QueuedConnection);
 
-    d->modelEstimationPresenter = 0;
-    d->dwiMaskCalculatorPresenter = 0;
-    d->dwiMaskCalculatorWidget = 0;
-    d->modelEstimationWidget = 0;
+    d->modelEstimationPresenter = nullptr;
+    d->dwiMaskCalculatorPresenter = nullptr;
+    d->dwiMaskCalculatorWidget = nullptr;
+    d->modelEstimationWidget = nullptr;
 }
 
 medDiffusionModelEstimationMetaProcessPresenter::~medDiffusionModelEstimationMetaProcessPresenter()
@@ -81,7 +81,7 @@ QWidget *medDiffusionModelEstimationMetaProcessPresenter::buildToolBoxWidget()
     QVBoxLayout *tbLayout = new QVBoxLayout;
     tbWidget->setLayout(tbLayout);
 
-    QLabel *dwiMaskingLabel = new QLabel(tr("DWI masking algorithm:"));
+    QLabel *dwiMaskingLabel = new QLabel(tr("DWI masking"));
     QHBoxLayout *dwiMaskingComboLayout = new QHBoxLayout;
     dwiMaskingComboLayout->addWidget(dwiMaskingLabel);
     d->dwiMaskingComboBox = new QComboBox;
@@ -103,7 +103,7 @@ QWidget *medDiffusionModelEstimationMetaProcessPresenter::buildToolBoxWidget()
     tbLayout->addWidget(d->dwiMaskCalculatorWidget);
     d->dwiMaskCalculatorWidget->hide();
 
-    QLabel *modelEstimationLabel = new QLabel(tr("Estimation algorithm:"));
+    QLabel *modelEstimationLabel = new QLabel(tr("Estimation"));
     QHBoxLayout *modelEstimationComboLayout = new QHBoxLayout;
     modelEstimationComboLayout->addWidget(modelEstimationLabel);
     d->modelEstimationComboBox = new QComboBox;

--- a/src/layers/medWidgets/toolboxes/medDiffusionSelectorToolBox.cpp
+++ b/src/layers/medWidgets/toolboxes/medDiffusionSelectorToolBox.cpp
@@ -52,11 +52,11 @@ public:
 
 medDiffusionSelectorToolBox::medDiffusionSelectorToolBox(QWidget *parent, SelectorType type) : medToolBox(parent), d(new medDiffusionSelectorToolBoxPrivate)
 {
-    d->currentProcess = 0;
-    d->currentProcessPresenter = 0;
-    d->currentToolBox = 0;
-    d->processOutput = 0;
-    d->methodCombo = 0;
+    d->currentProcess = nullptr;
+    d->currentProcessPresenter = nullptr;
+    d->currentToolBox = nullptr;
+    d->processOutput = nullptr;
+    d->methodCombo = nullptr;
     d->selectorType = type;
 
     // /////////////////////////////////////////////////////////////////
@@ -75,7 +75,7 @@ medDiffusionSelectorToolBox::medDiffusionSelectorToolBox(QWidget *parent, Select
     d->mainLayout = new QVBoxLayout(mainPage);
     QHBoxLayout *inputLayout = new QHBoxLayout;
     QLabel *inputDescriptionLabel = new QLabel(mainPage);
-    inputDescriptionLabel->setText(tr("Input image:"));
+    inputDescriptionLabel->setText(tr("Input image"));
     inputLayout->addWidget(inputDescriptionLabel);
 
     d->chooseInput = new QComboBox(mainPage);
@@ -105,7 +105,7 @@ medDiffusionSelectorToolBox::medDiffusionSelectorToolBox(QWidget *parent, Select
         }
 
         case ScalarMaps:
-            labelTitle = tr("Scalar maps:");
+            labelTitle = tr("Scalar maps");
             foreach(QString pluginKey, medCore::diffusionScalarMaps::pluginFactory().keys())
             {
                 medAbstractProcess *process = medCore::diffusionScalarMaps::pluginFactory().create(pluginKey);
@@ -115,7 +115,7 @@ medDiffusionSelectorToolBox::medDiffusionSelectorToolBox(QWidget *parent, Select
 
         case Tractography:
         default:
-            labelTitle = tr("Tractography algorithm:");
+            labelTitle = tr("Tractography algorithm");
             foreach(QString pluginKey, medCore::tractography::pluginFactory().keys())
             {
                 medAbstractProcess *process = medCore::tractography::pluginFactory().create(pluginKey);
@@ -144,7 +144,7 @@ medDiffusionSelectorToolBox::medDiffusionSelectorToolBox(QWidget *parent, Select
 medDiffusionSelectorToolBox::~medDiffusionSelectorToolBox(void)
 {
     delete d;
-    d = NULL;
+    d = nullptr;
 }
 
 void medDiffusionSelectorToolBox::chooseProcess(int id)
@@ -159,7 +159,7 @@ void medDiffusionSelectorToolBox::chooseProcess(int id)
     {
         case Estimation:
         {
-            dtkWarn() << "Should not be here anymore: processes for estimation are handled inside the meta process";
+            qWarning() << "Should not be here anymore: processes for estimation are handled inside the meta process";
             break;
         }
 
@@ -206,7 +206,7 @@ void medDiffusionSelectorToolBox::chooseProcess(int id)
     {
         d->currentToolBox->hide();
         d->mainLayout->removeWidget ( d->currentToolBox );
-        d->currentToolBox = 0;
+        d->currentToolBox = nullptr;
     }
 
     d->currentToolBox = d->currentProcessPresenter->buildToolBoxWidget();
@@ -216,7 +216,7 @@ void medDiffusionSelectorToolBox::chooseProcess(int id)
 medAbstractData *medDiffusionSelectorToolBox::processOutput()
 {
     if (!d->currentProcess)
-        return 0;
+        return nullptr;
 
     switch(d->selectorType)
     {

--- a/src/layers/medWidgets/toolboxes/medDiffusionSelectorToolBox.h
+++ b/src/layers/medWidgets/toolboxes/medDiffusionSelectorToolBox.h
@@ -36,7 +36,7 @@ public:
         Tractography
     };
 
-     medDiffusionSelectorToolBox(QWidget *parent = 0, SelectorType type = Estimation);
+     medDiffusionSelectorToolBox(QWidget *parent = nullptr, SelectorType type = Estimation);
     ~medDiffusionSelectorToolBox();
 
     void addInputImage(medAbstractImageData *data);


### PR DESCRIPTION
The toolboxes opened when the Diffusion workspace is open were too large. It should fit in the minimum size of the column.

:m: