### PR TITLE
[music3] add a pop-up to validate exit

### DIFF
--- a/src/app/medInria/medMainWindow.cpp
+++ b/src/app/medInria/medMainWindow.cpp
@@ -730,18 +730,38 @@ void medMainWindow::hideShortcutAccess()
     this->activateWindow();
 }
 
-int medMainWindow::saveModified( void )
+int medMainWindow::saveModifiedAndOrValidateClosing()
 {
     QList<medDataIndex> indexes = medDatabaseNonPersistentController::instance()->availableItems();
 
     if(indexes.isEmpty())
-        return QDialog::Accepted;
+    {
+        // No data to save, pop-up window to validate the closing
 
-    medSaveModifiedDialog *saveDialog = new medSaveModifiedDialog(this);
-    saveDialog->show();
-    saveDialog->exec();
+        QMessageBox msgBox(this);
+        msgBox.setWindowTitle("Closing");
+        msgBox.setText("Do you really want to exit?");
+        msgBox.setStandardButtons(QMessageBox::Yes);
+        msgBox.addButton(QMessageBox::No);
+        msgBox.setDefaultButton(QMessageBox::No);
+        if(msgBox.exec() == QMessageBox::Yes)
+        {
+            return QDialog::Accepted;
+        }
+        else
+        {
+            return QDialog::Rejected;
+        }
+    }
+    else
+    {
+        // User is asked to save, cancel or exit without saving temporary data
 
-    return saveDialog->result();
+        medSaveModifiedDialog *saveDialog = new medSaveModifiedDialog(this);
+        saveDialog->show();
+        saveDialog->exec();
+        return saveDialog->result();
+    }
 }
 
 void medMainWindow::dragEnterEvent(QDragEnterEvent *event)
@@ -828,7 +848,7 @@ void medMainWindow::closeEvent(QCloseEvent *event)
         }
     }
 
-    if(this->saveModified() != QDialog::Accepted)
+    if(this->saveModifiedAndOrValidateClosing() != QDialog::Accepted)
     {
         event->ignore();
         return;

--- a/src/app/medInria/medMainWindow.h
+++ b/src/app/medInria/medMainWindow.h
@@ -113,7 +113,7 @@ private slots:
 protected:
     void closeEvent(QCloseEvent *event);
     void mousePressEvent(QMouseEvent * event);
-    int saveModified();
+    int saveModifiedAndOrValidateClosing();
     bool event(QEvent * e);
     void dragEnterEvent(QDragEnterEvent *event);
     void dragLeaveEvent(QDragLeaveEvent *event);


### PR DESCRIPTION
Commit: https://github.com/medInria/medInria-public/commit/77a42ed719e0bb8c67f159e2cad3d5eae7f53455

Original PR: https://github.com/Inria-Asclepios/medInria-public/pull/507

`If the user clicks on one of the exit buttons, a message dialog is displayed to validate the exit. If the database has temporary data, the classic medSaveModifiedDialog pop-up is displayed instead.`

:m: