### PR TITLE
[music3] medUtilities empty variable crash solved

### DIFF
--- a/src/layers/legacy/medUtilities/medUtilities.cpp
+++ b/src/layers/legacy/medUtilities/medUtilities.cpp
@@ -151,7 +151,7 @@ void medUtilities::switchTo3D(medAbstractView *view, Mode3DType mode3D)
         medAbstractImageView* imageView = qobject_cast<medAbstractImageView*>(view);
         imageView->setOrientation(medImageView::VIEW_ORIENTATION_3D);
 
-        medStringListParameterL * mode3DParam = 0, *renderer3DParam = 0;
+        medStringListParameterL *mode3DParam = nullptr, *renderer3DParam = nullptr;
 
         foreach (medAbstractNavigator* navigator, view->navigators())
         {
@@ -196,7 +196,7 @@ void medUtilities::switchTo3D(medAbstractView *view, Mode3DType mode3D)
 
             if(renderer3DParam)
             {
-                renderer3DParam->setValue("Ray Cast");
+                renderer3DParam->setValue("Default");
             }
         }
     }

--- a/src/layers/legacy/medUtilities/medUtilities.cpp
+++ b/src/layers/legacy/medUtilities/medUtilities.cpp
@@ -176,23 +176,29 @@ void medUtilities::switchTo3D(medAbstractView *view, Mode3DType mode3D)
             }
         }
 
-        switch(mode3D)
+        if(mode3DParam)
         {
-        case VR:
-            mode3DParam->setValue("VR");
-            break;
-        case MIP_MAXIMUM:
-            mode3DParam->setValue("MIP - Maximum");
-            break;
-        case MIP_MINIMUM:
-            mode3DParam->setValue("MIP - Minimum");
-            break;
-        case MSR:
-            mode3DParam->setValue("MSR");
-            break;
-        }
+            switch(mode3D)
+            {
+                case VR:
+                    mode3DParam->setValue("VR");
+                    break;
+                case MIP_MAXIMUM:
+                    mode3DParam->setValue("MIP - Maximum");
+                    break;
+                case MIP_MINIMUM:
+                    mode3DParam->setValue("MIP - Minimum");
+                    break;
+                case MSR:
+                    mode3DParam->setValue("MSR");
+                    break;
+            }
 
-        renderer3DParam->setValue("Ray Cast");
+            if(renderer3DParam)
+            {
+                renderer3DParam->setValue("Ray Cast");
+            }
+        }
     }
 }
 


### PR DESCRIPTION
From PR https://github.com/Inria-Asclepios/medInria-public/pull/582

> crash when call to to switchTo3D
> mode3DParam and renderer3DParam could not have not been initialized.

:m: