### PR TITLE
[music3] generateThumbnail - remove pop-up at import in DB

### DIFF
--- a/src/layers/legacy/medCoreLegacy/data/medAbstractData.cpp
+++ b/src/layers/legacy/medCoreLegacy/data/medAbstractData.cpp
@@ -218,9 +218,11 @@ void medAbstractData::generateThumbnail()
     if ( ! gpu.vendor.toLower().contains("intel"))
         offscreenCapable = true;
 #elif defined(Q_OS_LINUX)
-    // only works on NVidia
-    if (gpu.vendor.toLower().contains("nvidia"))
+    if (gpu.vendor.toLower().contains("nvidia")
+            || gpu.vendor.toLower().contains("intel"))
+    {
         offscreenCapable = true;
+    }
 #endif
 
     dtkSmartPointer<medAbstractImageView> view = medViewFactory::instance()->createView<medAbstractImageView>("medVtkView");
@@ -234,19 +236,19 @@ void medAbstractData::generateThumbnail()
         // We need to get a handle to the main window, so we can A) find its position, and B) ensure it is drawn over the temporary window
         const QVariant property = QApplication::instance()->property("MainWindow");
         QObject* qObject = property.value<QObject*>();
+
         if (qObject)
         {
             QMainWindow* aMainWindow = dynamic_cast<QMainWindow*>(qObject);
             QWidget * viewWidget = view->viewWidget();
 
-            // Show our view in a seperate, temporary window
+            // Show our view in a separate, temporary window
             viewWidget->show();
             // position the temporary window behind the main application
             viewWidget->move(aMainWindow->geometry().x(), aMainWindow->geometry().y());
             // and raise the main window above the temporary
             aMainWindow->raise();
         }
-
         // We need to wait for the window manager to finish animating before we can continue.
     #ifdef Q_OS_X11
         qt_x11_wait_for_window_manager(viewWidget);


### PR DESCRIPTION
From this PR https://github.com/Inria-Asclepios/medInria-public/pull/569

The original problem in some Linux drivers seems to be removed since Ubuntu 18. It was there on Ubuntu 16 on X.org drivers, not nvidia. On Ubuntu, these driver names have changed, and always start with "Intel". 

The non-offscreenCapable algo in this medAbstractData::generateThumbnail creates a pop-up when you save a data in a toolbox for instance. So, using the offscreenCapable removes it.

:m:
