### PR TITLE
[music3] change the background color - kept in screenshots

### DIFF
--- a/src/app/medInria/medMainWindow.cpp
+++ b/src/app/medInria/medMainWindow.cpp
@@ -451,12 +451,14 @@ void medMainWindow::captureScreenshot()
         QString fileName = QFileDialog::getSaveFileName(this,
                                                         tr("Save screenshot as"),
                                                         QString(QDir::home().absolutePath() + "/screen.png"),
-                                                        "Image files (*.png *.jpeg *jpg);;All files (*.*)",
+                                                        "Image files (*.png *.jpeg *.jpg);;All files (*.*)",
                                                         0);
 
         QByteArray format = fileName.right(fileName.lastIndexOf('.')).toUpper().toLatin1();
         if ( ! QImageWriter::supportedImageFormats().contains(format) )
+        {
             format = "PNG";
+        }
 
         QImage image = screenshot.toImage();
         image.save(fileName, format.constData());

--- a/src/app/medInria/medMainWindow.cpp
+++ b/src/app/medInria/medMainWindow.cpp
@@ -445,21 +445,22 @@ void medMainWindow::toggleFullScreen()
 void medMainWindow::captureScreenshot()
 {
     QPixmap screenshot = d->workspaceArea->grabScreenshot();
-    QString fileName = QFileDialog::getSaveFileName(this, tr("Save screenshot as"),
-                                                    QDir::home().absolutePath(),
-                                                    QString(), 0, QFileDialog::HideNameFilterDetails);
 
-    QByteArray format = fileName.right(fileName.lastIndexOf('.')).toUpper().toLatin1();
-    if ( ! QImageWriter::supportedImageFormats().contains(format) )
-        format = "PNG";
+    if (!screenshot.isNull())
+    {
+        QString fileName = QFileDialog::getSaveFileName(this,
+                                                        tr("Save screenshot as"),
+                                                        QString(QDir::home().absolutePath() + "/screen.png"),
+                                                        "Image files (*.png *.jpeg *jpg);;All files (*.*)",
+                                                        0);
 
-    QImage transparentImage = screenshot.toImage();
-    QImage outImage(transparentImage.size(), QImage::Format_RGB32);
-    outImage.fill(QColor(Qt::black).rgb());
+        QByteArray format = fileName.right(fileName.lastIndexOf('.')).toUpper().toLatin1();
+        if ( ! QImageWriter::supportedImageFormats().contains(format) )
+            format = "PNG";
 
-    QPainter painter(&outImage);
-    painter.drawImage(0,0,transparentImage);
-    outImage.save(fileName, format.constData());
+        QImage image = screenshot.toImage();
+        image.save(fileName, format.constData());
+    }
 }
 
 void medMainWindow::showFullScreen()

--- a/src/plugins/legacy/vtkDataMesh/navigators/vtkDataMeshNavigator.cpp
+++ b/src/plugins/legacy/vtkDataMesh/navigators/vtkDataMeshNavigator.cpp
@@ -18,11 +18,11 @@
 #include <vtkRenderWindow.h>
 #include <vtkRenderer.h>
 
-#include <medVtkViewBackend.h>
-
-#include <medViewFactory.h>
 #include <medAbstractImageView.h>
 #include <medBoolParameterL.h>
+#include <medStringListParameterL.h>
+#include <medViewFactory.h>
+#include <medVtkViewBackend.h>
 
 #include <QLabel>
 
@@ -44,7 +44,7 @@ public:
     QList <medAbstractParameterL*> parameters;
 
     medBoolParameterL *depthPeelingParameter;
-
+    medStringListParameterL *colorBackgroundParam;
 };
 
 
@@ -64,10 +64,27 @@ vtkDataMeshNavigator::vtkDataMeshNavigator(medAbstractView* parent):
     d->view2d = backend->view2D;
     d->view3d = backend->view3D;
 
+    // Depth Peeling
     d->depthPeelingParameter = new medBoolParameterL("DepthPeeling", this);
     connect(d->depthPeelingParameter, SIGNAL(valueChanged(bool)), this, SLOT(enableDepthPeeling(bool)));
 
     d->parameters.append(d->depthPeelingParameter);
+
+    // Background
+    QStringList colors = createColorList();
+
+    d->colorBackgroundParam = new medStringListParameterL("Background Color", this);
+
+    foreach(QString color, colors)
+    {
+        d->colorBackgroundParam->addItem(color, medStringListParameterL::createIconFromColor(color));
+    }
+
+    connect(d->colorBackgroundParam, SIGNAL(valueChanged(QString)), this, SLOT(setBackgroundColor(QString)));
+
+    d->colorBackgroundParam->setValue("#000000");
+
+    d->parameters.append(d->colorBackgroundParam);
 }
 
 vtkDataMeshNavigator::~vtkDataMeshNavigator()
@@ -144,6 +161,52 @@ void vtkDataMeshNavigator::enableDepthPeeling(bool enabled)
     d->imageView->render();
 }
 
+QStringList vtkDataMeshNavigator::createColorList()
+{
+    QStringList colors;
+    colors << "#FFFFFF";
+    colors << "#808080";
+    colors << "#800000";
+    colors << "#804040";
+    colors << "#FF8080";
+    colors << "#FF0000";
+    colors << "#FFFF80";
+    colors << "#FFFF00";
+    colors << "#FF8040";
+    colors << "#FF8000";
+    colors << "#80FF80";
+    colors << "#80FF00";
+    colors << "#00FF00";
+    colors << "#80FFFF";
+    colors << "#00FFFF";
+    colors << "#004080";
+    colors << "#0000FF";
+    colors << "#0080FF";
+    colors << "#0080C0";
+    colors << "#000000";
+    return colors;
+}
+
+void vtkDataMeshNavigator::setBackgroundColor(QColor color)
+{
+    if( !color.isValid() )
+    {
+        color.setRgb(0, 0, 0);
+    }
+
+    double r,g,b;
+    color.getRgbF(&r, &g, &b);
+
+    d->view3d->SetBackground(r, g, b);
+
+    d->imageView->render();
+}
+
+void vtkDataMeshNavigator::setBackgroundColor(const QString &color)
+{
+    d->colorBackgroundParam->setValue(color);
+    setBackgroundColor(QColor(color));
+}
 
 /*=========================================================================
 
@@ -156,6 +219,9 @@ QWidget *  vtkDataMeshNavigator::buildToolBoxWidget()
 {
     QWidget *toolBoxWidget = new QWidget;
     QFormLayout *layout = new QFormLayout(toolBoxWidget);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setLabelAlignment(Qt::AlignLeft);
+
     foreach(medAbstractParameterL *parameter, d->parameters)
         layout->addRow(parameter->getLabel(), parameter->getWidget());
     return toolBoxWidget;

--- a/src/plugins/legacy/vtkDataMesh/navigators/vtkDataMeshNavigator.h
+++ b/src/plugins/legacy/vtkDataMesh/navigators/vtkDataMeshNavigator.h
@@ -43,10 +43,16 @@ public slots:
     void updateWidgets();
 
     void enableDepthPeeling(bool);
+    void setBackgroundColor(const QString &color);
+
+protected slots:
+    void setBackgroundColor(QColor color);
 
 protected:
     virtual QWidget * buildToolBoxWidget();
     virtual QWidget * buildToolBarWidget();
+
+    QStringList createColorList();
 
 private:
     vtkDataMeshNavigatorPrivate *d;


### PR DESCRIPTION
From https://github.com/Inria-Asclepios/medInria-public/pull/348

The user can change the background color of a mesh from a list of color. The color background is kept when the user export screenshots of the view(s). There is a default name and filter for the screenshots.

:m: