### PR TITLE
- Remove issues #386 and enhance startup capability for VS2017  

### DIFF
--- a/packaging/windows/WindowsLaunchers.cmake
+++ b/packaging/windows/WindowsLaunchers.cmake
@@ -30,7 +30,7 @@ if (CMAKE_GENERATOR MATCHES "Win64")
     set(WIN_TYPE x64)
 endif()
 
-set(VS_TYPE "VS140COMNTOOLS")
+set(VS_TYPE "VS141COMNTOOLS")
 
 configure_file(${CURRENT_SRC_DIR}/medInria.bat.in     medInria.bat     @ONLY)
 configure_file(${CURRENT_SRC_DIR}/medInria-dev.bat.in medInria-dev.bat @ONLY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,8 +135,6 @@ if(NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
   add_definitions(-DQT_NO_DEBUG)
 endif()
 
-add_definitions(-DITK_LEGACY_REMOVE)
-
 ## #############################################################################
 ## Windows specificity
 ## #############################################################################
@@ -158,6 +156,7 @@ if(${PROJECT_NAME}_BUILD_DOCUMENTATION)
   add_subdirectory(doc)
 endif()
 
+set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT medInria)
 
 ################################################################################
 # Setup Configuration files

--- a/superbuild/projects_modules/medInria.cmake
+++ b/superbuild/projects_modules/medInria.cmake
@@ -138,6 +138,29 @@ set(${ep}_DIR ${binary_dir} PARENT_SCOPE)
 
 ExternalProject_Get_Property(${ep} source_dir)
 set(${ep}_SOURCE_DIR ${source_dir} PARENT_SCOPE)
+  
+  
+if (WIN32)
+  file(TO_NATIVE_PATH ${ITK_DIR}                 ITK_BIN_BASE)
+  file(TO_NATIVE_PATH ${VTK_DIR}                 VTK_BIN_BASE)
+  file(TO_NATIVE_PATH ${dtk_DIR}                 DTK_BIN_BASE)
+  file(TO_NATIVE_PATH ${_qt5Core_install_prefix} QT5_BIN_BASE)
+  file(TO_NATIVE_PATH ${medInria_BINARY_DIR}     MED_BIN_BASE)
+  
+  set(CONFIG_MODE $<$<CONFIG:debug>:Debug>$<$<CONFIG:release>:Release>$<$<CONFIG:MinSizeRel>:MinSizeRel>$<$<CONFIG:RelWithDebugInfo>:RelWithDebugInfo>)
+  
+  set(MED_BIN_BASE ${MED_BIN_BASE}\\bin\\${CONFIG_MODE})  
+  
+  add_custom_command(TARGET ${ep}
+          POST_BUILD
+          COMMAND for %%I in (${ITK_BIN_BASE}\\bin\\${CONFIG_MODE}\\*.dll) do del /S ${MED_BIN_BASE}\\%%~nxI & mklink /H ${MED_BIN_BASE}\\%%~nxI %%~fI
+          COMMAND for %%I in (${VTK_BIN_BASE}\\bin\\${CONFIG_MODE}\\*.dll) do del /S ${MED_BIN_BASE}\\%%~nxI & mklink /H ${MED_BIN_BASE}\\%%~nxI %%~fI
+          COMMAND for %%I in (${DTK_BIN_BASE}\\bin\\${CONFIG_MODE}\\*.dll) do del /S ${MED_BIN_BASE}\\%%~nxI & mklink /H ${MED_BIN_BASE}\\%%~nxI %%~fI
+          COMMAND for %%I in (${QT5_BIN_BASE}\\bin\\*.dll)                 do del /S ${MED_BIN_BASE}\\%%~nxI & mklink /H ${MED_BIN_BASE}\\%%~nxI %%~fI
+  		)
+endif()
+
+
 
 endif() #NOT USE_SYSTEM_ep
 


### PR DESCRIPTION
- Remove issues #386 warning ITK_LEGACY_REMOVE
- On VisualStudio make medInria as startup project into medInria Solution
- On VisualStudio for medInria superbuil solution make a post build event for medInria project to hardlink DLLs dependencies.