### PR TITLE
Resolve 2 crashing bugs from cli and open file

### DIFF
--- a/src/app/medInria/medMainWindow.cpp
+++ b/src/app/medInria/medMainWindow.cpp
@@ -383,22 +383,32 @@ void medMainWindow::open(const QString & path)
 {
     QEventLoop loop;
     QUuid uuid = medDataManager::instance()->importPath(path, false);
-    d->expectedUuids.append(uuid);
-    connect(medDataManager::instance(), SIGNAL(dataImported(medDataIndex,QUuid)),
-            this, SLOT(open_waitForImportedSignal(medDataIndex,QUuid)));
-    while( d->expectedUuids.contains(uuid)) {
-        loop.processEvents(QEventLoop::ExcludeUserInputEvents);
+    if (!uuid.isNull())
+    {
+        d->expectedUuids.append(uuid);
+        connect(medDataManager::instance(), SIGNAL(dataImported(medDataIndex,QUuid)), this, SLOT(open_waitForImportedSignal(medDataIndex,QUuid)));
+        while( d->expectedUuids.contains(uuid))
+        {
+            loop.processEvents(QEventLoop::ExcludeUserInputEvents);
+        }
+    }
+    else
+    {
+        QMessageBox msgBox;
+        msgBox.setText(path + " is not valid");
+        msgBox.exec();
     }
 }
 
 
 void medMainWindow::open_waitForImportedSignal(medDataIndex index, QUuid uuid)
 {
-    if(d->expectedUuids.contains(uuid)) {
+    if(d->expectedUuids.contains(uuid))
+    {
         d->expectedUuids.removeAll(uuid);
-        disconnect(medDataManager::instance(),SIGNAL(dataImported(medDataIndex,QUuid)),
-                   this,SLOT(open_waitForImportedSignal(medDataIndex,QUuid)));
-        if (index.isValid()) {
+        disconnect(medDataManager::instance(),SIGNAL(dataImported(medDataIndex,QUuid)), this,SLOT(open_waitForImportedSignal(medDataIndex,QUuid)));
+        if (index.isValid())
+        {
             this->showWorkspace(medVisualizationWorkspace::staticIdentifier());
             d->workspaceArea->currentWorkspace()->open(index);
         }

--- a/src/layers/legacy/medCoreLegacy/data/medAbstractData.cpp
+++ b/src/layers/legacy/medCoreLegacy/data/medAbstractData.cpp
@@ -225,21 +225,27 @@ void medAbstractData::generateThumbnail()
 
     dtkSmartPointer<medAbstractImageView> view = medViewFactory::instance()->createView<medAbstractImageView>("medVtkView");
 
-    if(offscreenCapable) {
+    if(offscreenCapable)
+    {
         view->setOffscreenRendering(true);
-    } else {
+    }
+    else
+    {
         // We need to get a handle to the main window, so we can A) find its position, and B) ensure it is drawn over the temporary window
         const QVariant property = QApplication::instance()->property("MainWindow");
         QObject* qObject = property.value<QObject*>();
-        QMainWindow* aMainWindow = dynamic_cast<QMainWindow*>(qObject);
-        QWidget * viewWidget = view->viewWidget();
+        if (qObject)
+        {
+            QMainWindow* aMainWindow = dynamic_cast<QMainWindow*>(qObject);
+            QWidget * viewWidget = view->viewWidget();
 
-        // Show our view in a seperate, temporary window
-        viewWidget->show();
-        // position the temporary window behind the main application
-        viewWidget->move(aMainWindow->geometry().x(), aMainWindow->geometry().y());
-        // and raise the main window above the temporary
-        aMainWindow->raise();
+            // Show our view in a seperate, temporary window
+            viewWidget->show();
+            // position the temporary window behind the main application
+            viewWidget->move(aMainWindow->geometry().x(), aMainWindow->geometry().y());
+            // and raise the main window above the temporary
+            aMainWindow->raise();
+        }
 
         // We need to wait for the window manager to finish animating before we can continue.
     #ifdef Q_OS_X11


### PR DESCRIPTION
Resolve issues: Command-line view infinite-loops with bad filepath #228
Resolve issues: "CRASHING BUG, when you open an image via the command line like "--view toto.nii.gz", on Windows and Linux not on OSX." of Rest of bug and bad behavior in release 3.0 of medInria #335 (this part is go into #413)

fix #228
fix #413