### PR TITLE
[music3] workspace Reformat, Crop tlbx and Reslice tlbx

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/medTabbedViewContainers.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/medTabbedViewContainers.cpp
@@ -79,9 +79,8 @@ medTabbedViewContainers::medTabbedViewContainers(medAbstractWorkspaceLegacy* own
 medTabbedViewContainers::~medTabbedViewContainers(void)
 {
     delete d;
-    d = NULL;
+    d = nullptr;
 }
-
 
 void medTabbedViewContainers::lockTabs()
 {

--- a/src/layers/legacy/medUtilities/mscTransform.h
+++ b/src/layers/legacy/medUtilities/mscTransform.h
@@ -1,3 +1,10 @@
+#include <vtkMatrix4x4.h>
+#include <vtkMatrixToLinearTransform.h>
+#include <vtkMetaDataSet.h>
+#include <vtkPointSet.h>
+#include <vtkSmartPointer.h>
+#include <vtkTransformFilter.h>
+
 #pragma once
 
 class medAbstractData;
@@ -248,7 +255,7 @@ void applyTransform(vtkMetaDataSet& mesh, const vtkMatrix4x4& transform)
     matrixToTransform->SetInput(transformCopy);
 
     vtkSmartPointer<vtkTransformFilter> transformFilter = vtkSmartPointer<vtkTransformFilter>::New();
-    transformFilter->SetInput(mesh.GetDataSet());
+    transformFilter->SetInputData(mesh.GetDataSet());
     transformFilter->SetTransform(matrixToTransform);
     transformFilter->Update();
 

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -57,6 +57,7 @@ set(PLUGIN_LIST
   legacy/mscAlgorithmPaint                                               ON
   legacy/variationalSegmentation                                         ON
   legacy/voiCutter                                                       ON
+  legacy/reformat                                                        ON
   process/arithmetic_operation                                           ON
   process/bias_correction                                                ON
   process/dwi_basic_thresholding                                         ON

--- a/src/plugins/legacy/medVtkView/medVtkView.cpp
+++ b/src/plugins/legacy/medVtkView/medVtkView.cpp
@@ -133,7 +133,7 @@ medVtkView::medVtkView(QObject* parent): medAbstractImageView(parent),
     d->viewWidget->setEnableHiDPI(true);
     d->viewWidget->SetRenderWindow(d->renWin);
 
-    // Event filter used to know if the view is selecetd or not
+    // Event filter used to know if the view is selected or not
     d->viewWidget->installEventFilter(this);
     d->viewWidget->setFocusPolicy(Qt::ClickFocus );
     d->viewWidget->setCursor(QCursor(Qt::CrossCursor));

--- a/src/plugins/legacy/reformat/CMakeLists.txt
+++ b/src/plugins/legacy/reformat/CMakeLists.txt
@@ -34,7 +34,7 @@ include_directories(${dtk_INCLUDE_DIRS})
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-find_package(VTK REQUIRED)
+find_package(VTK REQUIRED COMPONENTS vtkGUISupportQt vtkInteractionWidgets vtkInteractionImage)
 include(${VTK_USE_FILE})
 
 ## #############################################################################
@@ -73,10 +73,13 @@ add_library(${TARGET_NAME} SHARED
 target_link_libraries(${TARGET_NAME}
   ${QT_LIBRARIES}
   ITKCommon
+  ITKTransform
   medCore
   medVtkInria
   medUtilities
   vtkInteractionImage
+  vtkGUISupportQt
+  vtkGUISupportQtOpenGL
   )
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/src/plugins/legacy/reformat/CMakeLists.txt
+++ b/src/plugins/legacy/reformat/CMakeLists.txt
@@ -75,8 +75,8 @@ target_link_libraries(${TARGET_NAME}
   ITKCommon
   medCore
   medVtkInria
-  QVTK
   medUtilities
+  vtkInteractionImage
   )
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/src/plugins/legacy/reformat/CMakeLists.txt
+++ b/src/plugins/legacy/reformat/CMakeLists.txt
@@ -1,0 +1,88 @@
+################################################################################
+#
+# medInria
+#
+# Copyright (c) INRIA 2013 - 2019. All rights reserved.
+# See LICENSE.txt for details.
+# 
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.
+#
+################################################################################
+
+set(TARGET_NAME reformatPlugin)
+
+## #############################################################################
+## Setup version numbering
+## #############################################################################
+
+set(${TARGET_NAME}_VERSION ${MEDINRIA_VERSION})
+
+string(TOUPPER ${TARGET_NAME} TARGET_NAME_UP)
+add_definitions(-D${TARGET_NAME_UP}_VERSION="${${TARGET_NAME}_VERSION}")
+
+set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
+
+## #############################################################################
+## Resolve dependencies
+## #############################################################################
+
+find_package(dtk REQUIRED)
+include_directories(${dtk_INCLUDE_DIRS})
+
+find_package(ITK REQUIRED)
+include(${ITK_USE_FILE})
+
+find_package(VTK REQUIRED)
+include(${VTK_USE_FILE})
+
+## #############################################################################
+## List Sources
+## #############################################################################
+
+list_source_files(${TARGET_NAME}
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+
+## #############################################################################
+## include directories
+## #############################################################################
+
+list_header_directories_to_include(${TARGET_NAME}
+  ${${TARGET_NAME}_HEADERS}
+  )
+
+include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
+  ${MEDINRIA_INCLUDE_DIRS}
+  )
+
+## #############################################################################
+## add library
+## #############################################################################
+
+add_library(${TARGET_NAME} SHARED
+  ${${TARGET_NAME}_CFILES}
+  ${${TARGET_NAME}_QRC}
+  )
+
+## #############################################################################
+## Link
+## #############################################################################
+
+target_link_libraries(${TARGET_NAME}
+  ${QT_LIBRARIES}
+  ITKCommon
+  medCore
+  medVtkInria
+  QVTK
+  medUtilities
+  )
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+## #############################################################################
+## Install rules
+## #############################################################################
+
+set_plugin_install_rules_legacy(${TARGET_NAME})

--- a/src/plugins/legacy/reformat/medCropToolBox.cpp
+++ b/src/plugins/legacy/reformat/medCropToolBox.cpp
@@ -58,17 +58,17 @@ public:
     void updateBorderWidgetIfVisible();
     void updateCurrentOrientation();
     void updateBoxWidgetFromBorderWidget();
-    void adjustBoxCornersToAnnulPlaceFactor(double* maxBoxCorner, double* minBoxCorner);
+    void adjustBoxCornersToAnnulPlaceFactor(double *maxBoxCorner, double *minBoxCorner);
     void updateBorderWidgetFromBoxWidget();
-    void setBorderFromWorldPoints(double* worldPoint1, double* worldPoint2);
-    void getMinAndMaxBoxCorners(double* minCorner, double* maxCorner);
-    void worldToNormalizedViewport(double* worldPoint, double* viewportPoint);
-    void normalizedViewportToWorld(double* viewportPoint, double* worldPoint);
-    void applyOrientationMatrix(double* worldPointIn, double* WorldPointOut);
-    void applyInverseOrientationMatrix(double* worldPointIn, double* worldPointOut);
+    void setBorderFromWorldPoints(double *worldPoint1, double *worldPoint2);
+    void getMinAndMaxBoxCorners(double *minCorner, double *maxCorner);
+    void worldToNormalizedViewport(double *worldPoint, double *viewportPoint);
+    void normalizedViewportToWorld(double *viewportPoint, double *worldPoint);
+    void applyOrientationMatrix(double *worldPointIn, double *WorldPointOut);
+    void applyInverseOrientationMatrix(double *worldPointIn, double *worldPointOut);
     void generateOutput();
-    template <typename ImageType> int extractCroppedImage(medAbstractData* input, int* minIndices, int* maxIndices, medAbstractData** output);
-    void replaceViewWithOutputData(medAbstractWorkspaceLegacy& workspace);
+    template <typename ImageType> int extractCroppedImage(medAbstractData *input, int *minIndices, int *maxIndices, medAbstractData **output);
+    void replaceViewWithOutputData(medAbstractWorkspaceLegacy &workspace);
     void importOutput();
 };
 
@@ -98,7 +98,6 @@ public:
             }
         }
     }
-
 };
 
 bool medCropToolBox::registered()
@@ -114,18 +113,27 @@ medCropToolBox::medCropToolBox(QWidget* parent)
     d->borderWidget->SelectableOff();
     static_cast<vtkBorderRepresentation*>(d->borderWidget->GetRepresentation())->GetBorderProperty()->SetColor(0,1,0);
 
-    d->applyButton = new QPushButton(applyButtonName, this);
-    d->applyButton->setObjectName(applyButtonName);
-
-    d->saveButton = new QPushButton(saveButtonName, this);
-    d->saveButton->setObjectName(saveButtonName);
-
-    QWidget* cropToolBoxBody = new QWidget(this);
-    QVBoxLayout* cropToolBoxLayout = new QVBoxLayout(cropToolBoxBody);
+    QWidget *cropToolBoxBody = new QWidget(this);
+    QVBoxLayout *cropToolBoxLayout = new QVBoxLayout(cropToolBoxBody);
     cropToolBoxBody->setLayout(cropToolBoxLayout);
     addWidget(cropToolBoxBody);
+
+    QLabel* help = new QLabel("Drop a data in the view, adapt the cropping box:\n"
+                             "you can resize the box and change the data orientation.\n"
+                             "Then, apply the transformation and save the result.");
+    help->setStyleSheet("font: italic");
+    help->setWordWrap(true);
+    cropToolBoxLayout->addWidget(help);
+
+    d->applyButton = new QPushButton(applyButtonName, this);
+    d->applyButton->setToolTip("Apply the crop to the data and display the result");
+    d->applyButton->setObjectName(applyButtonName);
     cropToolBoxLayout->addWidget(d->applyButton);
     connect(d->applyButton, SIGNAL(clicked()), this, SLOT(applyCrop()));
+
+    d->saveButton = new QPushButton(saveButtonName, this);
+    d->saveButton->setToolTip("Save the current cropped data in the database");
+    d->saveButton->setObjectName(saveButtonName);
     cropToolBoxLayout->addWidget(d->saveButton);
     connect(d->saveButton, SIGNAL(clicked()), this, SLOT(saveCrop()));
 
@@ -169,7 +177,7 @@ void medCropToolBox::handleCameraMoveEvent()
 void medCropToolBox::updateView()
 {
     medViewContainer *currentContainer = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainer();
-    medAbstractView *viewNotLayered = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainerView();
+    medAbstractView *viewNotLayered    = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainerView();
     medAbstractLayeredView *view = qobject_cast<medAbstractLayeredView*>(viewNotLayered);
 
     if (view)
@@ -307,7 +315,7 @@ void medCropToolBoxPrivate::updateBoxWidgetFromBorderWidget()
     view3D->GetBoxWidget()->PlaceWidget(minBoxCorner[0], maxBoxCorner[0], minBoxCorner[1], maxBoxCorner[1], minBoxCorner[2], maxBoxCorner[2]);
 }
 
-void medCropToolBoxPrivate::adjustBoxCornersToAnnulPlaceFactor(double* maxBoxCorner, double* minBoxCorner)
+void medCropToolBoxPrivate::adjustBoxCornersToAnnulPlaceFactor(double *maxBoxCorner, double *minBoxCorner)
 {
     double center[3];
     double placeFactor = view3D->GetBoxWidget()->GetPlaceFactor();
@@ -329,7 +337,7 @@ void medCropToolBoxPrivate::updateBorderWidgetFromBoxWidget()
     borderWidget->GetBorderRepresentation()->Modified();
 }
 
-void medCropToolBoxPrivate::setBorderFromWorldPoints(double* worldPoint1, double* worldPoint2)
+void medCropToolBoxPrivate::setBorderFromWorldPoints(double *worldPoint1, double *worldPoint2)
 {
     double orientatedWorldPoint1[3], orientatedWorldPoint2[3], viewportPoint1[3], viewportPoint2[3];
 
@@ -351,9 +359,9 @@ void medCropToolBoxPrivate::setBorderFromWorldPoints(double* worldPoint1, double
     borderWidget->GetBorderRepresentation()->SetPosition2(viewportPoint2[0] - viewportPoint1[0], viewportPoint2[1] - viewportPoint1[1]);
 }
 
-void medCropToolBoxPrivate::getMinAndMaxBoxCorners(double* minCorner, double* maxCorner)
+void medCropToolBoxPrivate::getMinAndMaxBoxCorners(double *minCorner, double *maxCorner)
 {
-    vtkPolyData* polyData = vtkPolyData::New();
+    vtkPolyData *polyData = vtkPolyData::New();
     view3D->GetBoxWidget()->GetPolyData(polyData);
     polyData->GetPoint(0, minCorner);
     polyData->GetPoint(6, maxCorner);
@@ -368,7 +376,7 @@ void medCropToolBoxPrivate::getMinAndMaxBoxCorners(double* minCorner, double* ma
     }
 }
 
-void medCropToolBoxPrivate::worldToNormalizedViewport(double* worldPoint, double* viewportPoint)
+void medCropToolBoxPrivate::worldToNormalizedViewport(double *worldPoint, double *viewportPoint)
 {
     vtkRenderer *renderer = borderWidget->GetCurrentRenderer();
 
@@ -377,13 +385,13 @@ void medCropToolBoxPrivate::worldToNormalizedViewport(double* worldPoint, double
         renderer->SetWorldPoint(worldPoint);
         renderer->WorldToDisplay();
         renderer->GetDisplayPoint(viewportPoint);
-        renderer->DisplayToNormalizedDisplay(viewportPoint[0], viewportPoint[1]);
-        renderer->NormalizedDisplayToViewport(viewportPoint[0], viewportPoint[1]);
+        renderer->DisplayToNormalizedDisplay  (viewportPoint[0], viewportPoint[1]);
+        renderer->NormalizedDisplayToViewport (viewportPoint[0], viewportPoint[1]);
         renderer->ViewportToNormalizedViewport(viewportPoint[0], viewportPoint[1]);
     }
 }
 
-void medCropToolBoxPrivate::normalizedViewportToWorld(double* viewportPoint, double* worldPoint)
+void medCropToolBoxPrivate::normalizedViewportToWorld(double *viewportPoint, double *worldPoint)
 {
     vtkRenderer *renderer = borderWidget->GetCurrentRenderer();
     double homogeneousVector[4];
@@ -392,8 +400,8 @@ void medCropToolBoxPrivate::normalizedViewportToWorld(double* viewportPoint, dou
     {
         std::copy(viewportPoint, viewportPoint + 3, homogeneousVector);
         renderer->NormalizedViewportToViewport(homogeneousVector[0], homogeneousVector[1]);
-        renderer->ViewportToNormalizedDisplay(homogeneousVector[0], homogeneousVector[1]);
-        renderer->NormalizedDisplayToDisplay(homogeneousVector[0], homogeneousVector[1]);
+        renderer->ViewportToNormalizedDisplay (homogeneousVector[0], homogeneousVector[1]);
+        renderer->NormalizedDisplayToDisplay  (homogeneousVector[0], homogeneousVector[1]);
         renderer->SetDisplayPoint(homogeneousVector);
         renderer->DisplayToWorld();
         renderer->GetWorldPoint(homogeneousVector);
@@ -401,7 +409,7 @@ void medCropToolBoxPrivate::normalizedViewportToWorld(double* viewportPoint, dou
     }
 }
 
-void medCropToolBoxPrivate::applyOrientationMatrix(double* worldPointIn, double* worldPointOut)
+void medCropToolBoxPrivate::applyOrientationMatrix(double *worldPointIn, double *worldPointOut)
 {
     double homogeneousVector[4];
 
@@ -411,7 +419,7 @@ void medCropToolBoxPrivate::applyOrientationMatrix(double* worldPointIn, double*
     std::copy(homogeneousVector, homogeneousVector + 3, worldPointOut);
 }
 
-void medCropToolBoxPrivate::applyInverseOrientationMatrix(double* worldPointIn, double* worldPointOut)
+void medCropToolBoxPrivate::applyInverseOrientationMatrix(double *worldPointIn, double *worldPointOut)
 {
     double homogeneousVector[4];
 
@@ -436,17 +444,19 @@ void medCropToolBoxPrivate::generateOutput()
 
     for (unsigned int layer = 0; layer < view->layersCount(); layer++)
     {
-        medAbstractData* imageData = view->layerData(layer);
-        medAbstractData* output = nullptr;
+        medAbstractData *imageData = view->layerData(layer);
+        medAbstractData *output = nullptr;
 
-        if (DISPATCH_ON_3D_PIXEL_TYPE(&medCropToolBoxPrivate::extractCroppedImage, this, imageData, minIndices, maxIndices, &output) == DTK_SUCCEED)
+        if (DISPATCH_ON_3D_PIXEL_TYPE(&medCropToolBoxPrivate::extractCroppedImage,
+                                      this, imageData, minIndices, maxIndices, &output)
+                == medAbstractProcessLegacy::SUCCESS)
         {
             outputData.append(output);
         }
         else
         {
-            medMessageController::instance()->showError("Drop a 3D volume in the view",3000);
-            qDebug()<<"medCropToolBoxPrivate::generateOutput id "<<imageData->identifier();
+            medMessageController::instance()->showError("Drop a 3D volume in the view", 3000);
+            qDebug()<<__FILE__<<":"<<__LINE__<<imageData->identifier();
         }
     }
 }
@@ -468,12 +478,12 @@ int medCropToolBoxPrivate::extractCroppedImage(medAbstractData* input, int* minI
         {
             std::swap(minIndices[i], maxIndices[i]);
         }
-        if (maxIndices[i] < 0 || minIndices[i] >= (int)imageSize[i])
+        if (maxIndices[i] < 0 || minIndices[i] >= static_cast<int>(imageSize[i]))
         {
             return 0;
         }
         desiredStart[i] = std::max(minIndices[i], 0);
-        desiredSize[i] = std::min(maxIndices[i] + 1, (int)imageSize[i]) - desiredStart[i];
+        desiredSize[i] = std::min(maxIndices[i] + 1, static_cast<int>(imageSize[i])) - desiredStart[i];
     }
 
     typename ImageType::RegionType desiredRegion(desiredStart, desiredSize);
@@ -495,14 +505,14 @@ void medCropToolBoxPrivate::replaceViewWithOutputData(medAbstractWorkspaceLegacy
 {
     if (outputData.length() >= 0)
     {
-        medTabbedViewContainers* tabbedViewContainers = workspace.tabbedViewContainers();
-        medViewContainer* viewContainer = tabbedViewContainers->containersInTab(tabbedViewContainers->currentIndex()).at(0);
+        medTabbedViewContainers *tabbedViewContainers = workspace.tabbedViewContainers();
+        medViewContainer *viewContainer = tabbedViewContainers->containersInTab(tabbedViewContainers->currentIndex()).at(0);
 
         viewContainer->removeView();
         viewContainer->setMultiLayered(true);
         viewContainer->addData(outputData[0]);
 
-        medAbstractLayeredView* newView = qobject_cast<medAbstractLayeredView*>(viewContainer->view());
+        medAbstractLayeredView *newView = qobject_cast<medAbstractLayeredView*>(viewContainer->view());
 
         for (int layer = 1; layer < outputData.length(); layer++)
         {

--- a/src/plugins/legacy/reformat/medCropToolBox.cpp
+++ b/src/plugins/legacy/reformat/medCropToolBox.cpp
@@ -1,0 +1,521 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include "medCropToolBox.h"
+
+#include <itkRegionOfInterestImageFilter.h>
+
+#include <medAbstractDataFactory.h>
+#include <medAbstractLayeredView.h>
+#include <medDataManager.h>
+#include <medMetaDataKeys.h>
+#include <medPluginManager.h>
+#include <medTabbedViewContainers.h>
+#include <medToolBoxBody.h>
+#include <medToolBoxFactory.h>
+#include <medUtilities.h>
+#include <medUtilitiesITK.h>
+#include <medViewContainer.h>
+#include <medVtkViewBackend.h>
+
+#include <medMessageController.h>
+#include <vtkBorderRepresentation.h>
+#include <vtkBorderWidget.h>
+#include <vtkCamera.h>
+#include <vtkImageView2D.h>
+#include <vtkImageView2DCommand.h>
+#include <vtkImageView3D.h>
+#include <vtkMatrix4x4.h>
+#include <vtkPlane.h>
+#include <vtkPolyData.h>
+#include <vtkProperty2D.h>
+#include <vtkRenderer.h>
+
+class medCropCallback;
+
+class medCropToolBoxPrivate
+{
+public:
+    medAbstractLayeredView* view;
+    vtkImageView2D* view2D;
+    vtkImageView3D* view3D;
+    QPushButton* applyButton;
+    QPushButton* saveButton;
+    vtkSmartPointer<vtkBorderWidget> borderWidget;
+    int currentOrientation;
+    QList<dtkSmartPointer<medAbstractData> > outputData;
+    vtkSmartPointer<medCropCallback> cropCallback;
+    vtkMatrix4x4* orientationMatrix;
+    vtkSmartPointer<vtkMatrix4x4> inverseOrientationMatrix;
+
+    
+    void updateBorderWidgetIfVisible();
+    void updateCurrentOrientation();
+    void updateBoxWidgetFromBorderWidget();
+    void adjustBoxCornersToAnnulPlaceFactor(double* maxBoxCorner, double* minBoxCorner);
+    void updateBorderWidgetFromBoxWidget();
+    void setBorderFromWorldPoints(double* worldPoint1, double* worldPoint2);
+    void getMinAndMaxBoxCorners(double* minCorner, double* maxCorner);
+    void worldToNormalizedViewport(double* worldPoint, double* viewportPoint);
+    void normalizedViewportToWorld(double* viewportPoint, double* worldPoint);
+    void applyOrientationMatrix(double* worldPointIn, double* WorldPointOut);
+    void applyInverseOrientationMatrix(double* worldPointIn, double* worldPointOut);
+    void generateOutput();
+    template <typename ImageType> int extractCroppedImage(medAbstractData* input, int* minIndices, int* maxIndices, medAbstractData** output);
+    void replaceViewWithOutputData(medAbstractWorkspaceLegacy& workspace);
+    void importOutput();
+};
+
+class medCropCallback : public vtkCommand
+{
+
+public:
+
+    medCropToolBox* toolBox;
+
+    static medCropCallback *New()
+    {
+        return new medCropCallback();
+    }
+
+    void Execute(vtkObject *caller, unsigned long ev, void *callData )
+    {
+        if (ev == vtkCommand::InteractionEvent)
+        {
+            toolBox->handleInteractionEvent();
+        }
+        else
+        {
+            if (ev == vtkImageView2DCommand::CameraMoveEvent)
+            {
+                toolBox->handleCameraMoveEvent();
+            }
+        }
+    }
+
+};
+
+bool medCropToolBox::registered()
+{
+    return medToolBoxFactory::instance()->registerToolBox<medCropToolBox>();
+}
+
+medCropToolBox::medCropToolBox(QWidget* parent)
+    : medAbstractSelectableToolBox(parent), applyButtonName("Apply"), saveButtonName("Save"), d(new medCropToolBoxPrivate())
+{
+    d->borderWidget = vtkSmartPointer<vtkBorderWidget>::New();
+    d->borderWidget->CreateDefaultRepresentation();
+    d->borderWidget->SelectableOff();
+    static_cast<vtkBorderRepresentation*>(d->borderWidget->GetRepresentation())->GetBorderProperty()->SetColor(0,1,0);
+
+    d->applyButton = new QPushButton(applyButtonName, this);
+    d->applyButton->setObjectName(applyButtonName);
+
+    d->saveButton = new QPushButton(saveButtonName, this);
+    d->saveButton->setObjectName(saveButtonName);
+
+    QWidget* cropToolBoxBody = new QWidget(this);
+    QVBoxLayout* cropToolBoxLayout = new QVBoxLayout(cropToolBoxBody);
+    cropToolBoxBody->setLayout(cropToolBoxLayout);
+    addWidget(cropToolBoxBody);
+    cropToolBoxLayout->addWidget(d->applyButton);
+    connect(d->applyButton, SIGNAL(clicked()), this, SLOT(applyCrop()));
+    cropToolBoxLayout->addWidget(d->saveButton);
+    connect(d->saveButton, SIGNAL(clicked()), this, SLOT(saveCrop()));
+
+    d->cropCallback = vtkSmartPointer<medCropCallback>::New();
+    d->cropCallback->toolBox = this;
+
+    d->view = 0;
+    d->view2D = 0;
+    d->view3D = 0;
+}
+
+medCropToolBox::~medCropToolBox()
+{
+    delete d;
+}
+
+dtkPlugin* medCropToolBox::plugin()
+{
+    return medPluginManager::instance()->plugin("Reformat");
+}
+
+medAbstractData* medCropToolBox::processOutput()
+{
+    if (d->view)
+    {
+        d->generateOutput();
+    }
+    return d->outputData.value(0);
+}
+
+void medCropToolBox::handleInteractionEvent()
+{
+    d->updateBoxWidgetFromBorderWidget();
+}
+
+void medCropToolBox::handleCameraMoveEvent()
+{
+    d->updateBorderWidgetFromBoxWidget();
+}
+
+void medCropToolBox::updateView()
+{
+    medViewContainer* currentContainer = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainer();
+    medAbstractView *viewNotLayered = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainerView();
+    medAbstractLayeredView* view = qobject_cast<medAbstractLayeredView*>(viewNotLayered);
+
+    if (view)
+    {
+        if (view != d->view)
+        {
+            d->view = view;
+            d->view2D = static_cast<medVtkViewBackend*>(d->view->backend())->view2D;
+            d->view3D = static_cast<medVtkViewBackend*>(d->view->backend())->view3D;
+
+            connect(d->view, SIGNAL(orientationChanged()), this, SLOT(reactToOrientationChange()), Qt::UniqueConnection);
+
+            d->borderWidget->AddObserver(vtkCommand::InteractionEvent, d->cropCallback);
+            d->borderWidget->SetInteractor(d->view2D->GetInteractor());
+            d->borderWidget->On();
+
+            d->orientationMatrix = d->view2D->GetOrientationMatrix();
+            d->inverseOrientationMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+            d->inverseOrientationMatrix->DeepCopy(d->orientationMatrix);
+            d->inverseOrientationMatrix->Invert();
+
+            d->view2D->GetInteractorStyle()->AddObserver(vtkImageView2DCommand::CameraMoveEvent, d->cropCallback);
+        }
+        d->updateBorderWidgetIfVisible();
+
+        // do not allow to split the container
+        currentContainer->setUserSplittable(false);
+    }
+    else
+    {
+        d->view = 0;
+        d->view2D = 0;
+        d->view3D = 0;
+    }
+}
+
+void medCropToolBox::applyCrop()
+{
+    if (d->view)
+    {
+        d->generateOutput();
+        d->replaceViewWithOutputData(*getWorkspace());
+    }
+}
+
+void medCropToolBox::saveCrop()
+{
+    if (d->view)
+    {
+        d->importOutput();
+    }
+}
+
+void medCropToolBox::reactToOrientationChange()
+{
+    if (d->view)
+    {
+        d->updateBorderWidgetIfVisible();
+    }
+}
+
+void medCropToolBox::showEvent(QShowEvent *event)
+{
+    medAbstractSelectableToolBox::showEvent(event);
+    setEnable(true);
+}
+
+void medCropToolBox::clear()
+{
+    setEnable(false);
+
+    // allow to split container in other toolboxes
+    medViewContainer* currentContainer = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainer();
+    if (currentContainer)
+    {
+        currentContainer->setUserSplittable(true);
+    }
+}
+
+void medCropToolBox::setEnable(bool enable)
+{
+    if (d->borderWidget)
+    {
+        d->borderWidget->GetBorderRepresentation()->SetVisibility(enable);
+        d->borderWidget->SetProcessEvents(enable);
+        if (d->borderWidget->GetCurrentRenderer() && d->borderWidget->GetCurrentRenderer()->GetRenderWindow())
+        {
+            d->borderWidget->GetCurrentRenderer()->GetRenderWindow()->Render();
+        }
+    }
+}
+
+void medCropToolBoxPrivate::updateBorderWidgetIfVisible()
+{
+    updateCurrentOrientation();
+    if (borderWidget->GetCurrentRenderer() && borderWidget->GetCurrentRenderer()->GetRenderWindow())
+    {
+        updateBorderWidgetFromBoxWidget();
+        borderWidget->GetCurrentRenderer()->GetRenderWindow()->Render();
+    }
+}
+
+void medCropToolBoxPrivate::updateCurrentOrientation()
+{
+    currentOrientation = static_cast<medVtkViewBackend*>(view->backend())->view2D->GetSliceOrientation();
+}
+
+void medCropToolBoxPrivate::updateBoxWidgetFromBorderWidget()
+{
+    double minBoxCorner[3], maxBoxCorner[3], borderPoint1[3], borderPoint2[3], point1[3], point2[3];
+    double *tempPoint;
+
+    getMinAndMaxBoxCorners(minBoxCorner, maxBoxCorner);
+    tempPoint = borderWidget->GetBorderRepresentation()->GetPosition();
+    std::copy(tempPoint, tempPoint + 2, borderPoint1);
+    tempPoint = borderWidget->GetBorderRepresentation()->GetPosition2();
+    std::copy(tempPoint, tempPoint + 2, borderPoint2);
+
+    borderPoint2[0] += borderPoint1[0];
+    borderPoint2[1] += borderPoint1[1];
+
+    normalizedViewportToWorld(borderPoint1, point1);
+    normalizedViewportToWorld(borderPoint2, point2);
+
+    applyOrientationMatrix(minBoxCorner, minBoxCorner);
+    applyOrientationMatrix(maxBoxCorner, maxBoxCorner);
+
+    vtkPlane::ProjectPoint(point1, minBoxCorner, view2D->GetRenderer()->GetActiveCamera()->GetViewPlaneNormal(), minBoxCorner);
+    vtkPlane::ProjectPoint(point2, maxBoxCorner, view2D->GetRenderer()->GetActiveCamera()->GetViewPlaneNormal(), maxBoxCorner);
+
+    applyInverseOrientationMatrix(minBoxCorner, minBoxCorner);
+    applyInverseOrientationMatrix(maxBoxCorner, maxBoxCorner);
+
+    adjustBoxCornersToAnnulPlaceFactor(maxBoxCorner, minBoxCorner);
+    view3D->GetBoxWidget()->PlaceWidget(minBoxCorner[0], maxBoxCorner[0], minBoxCorner[1], maxBoxCorner[1], minBoxCorner[2], maxBoxCorner[2]);
+}
+
+void medCropToolBoxPrivate::adjustBoxCornersToAnnulPlaceFactor(double* maxBoxCorner, double* minBoxCorner)
+{
+    double center[3];
+    double placeFactor = view3D->GetBoxWidget()->GetPlaceFactor();
+
+    for (int i = 0; i < 3; i++)
+    {
+        center[i] = (minBoxCorner[i] + maxBoxCorner[i]) / 2.0;
+        minBoxCorner[i] = center[i] + (minBoxCorner[i] - center[i]) / placeFactor;
+        maxBoxCorner[i] = center[i] + (maxBoxCorner[i] - center[i]) / placeFactor;
+    }
+}
+
+void medCropToolBoxPrivate::updateBorderWidgetFromBoxWidget()
+{
+    double point1[3], point2[3];
+
+    getMinAndMaxBoxCorners(point1, point2);
+    setBorderFromWorldPoints(point1, point2);
+    borderWidget->GetBorderRepresentation()->Modified();
+}
+
+void medCropToolBoxPrivate::setBorderFromWorldPoints(double* worldPoint1, double* worldPoint2)
+{
+    double orientatedWorldPoint1[3], orientatedWorldPoint2[3], viewportPoint1[3], viewportPoint2[3];
+
+    applyOrientationMatrix(worldPoint1, orientatedWorldPoint1);
+    applyOrientationMatrix(worldPoint2, orientatedWorldPoint2);
+
+    worldToNormalizedViewport(orientatedWorldPoint1, viewportPoint1);
+    worldToNormalizedViewport(orientatedWorldPoint2, viewportPoint2);
+
+    for (int i = 0; i < 2; i++)
+    {
+        if (viewportPoint2[i] < viewportPoint1[i])
+        {
+            std::swap(viewportPoint1[i], viewportPoint2[i]);
+        }
+    }
+
+    borderWidget->GetBorderRepresentation()->SetPosition(viewportPoint1);
+    borderWidget->GetBorderRepresentation()->SetPosition2(viewportPoint2[0] - viewportPoint1[0], viewportPoint2[1] - viewportPoint1[1]);
+}
+
+void medCropToolBoxPrivate::getMinAndMaxBoxCorners(double* minCorner, double* maxCorner)
+{
+    vtkPolyData* polyData = vtkPolyData::New();
+    view3D->GetBoxWidget()->GetPolyData(polyData);
+    polyData->GetPoint(0, minCorner);
+    polyData->GetPoint(6, maxCorner);
+    polyData->Delete();
+
+    for (int i = 0; i < 2; i++)
+    {
+        if (minCorner[i] > maxCorner[i])
+        {
+            std::swap(minCorner[i], maxCorner[i]);
+        }
+    }
+}
+
+void medCropToolBoxPrivate::worldToNormalizedViewport(double* worldPoint, double* viewportPoint)
+{
+    vtkRenderer* renderer = borderWidget->GetCurrentRenderer();
+
+    if (renderer)
+    {
+        renderer->SetWorldPoint(worldPoint);
+        renderer->WorldToDisplay();
+        renderer->GetDisplayPoint(viewportPoint);
+        renderer->DisplayToNormalizedDisplay(viewportPoint[0], viewportPoint[1]);
+        renderer->NormalizedDisplayToViewport(viewportPoint[0], viewportPoint[1]);
+        renderer->ViewportToNormalizedViewport(viewportPoint[0], viewportPoint[1]);
+    }
+}
+
+void medCropToolBoxPrivate::normalizedViewportToWorld(double* viewportPoint, double* worldPoint)
+{
+    vtkRenderer* renderer = borderWidget->GetCurrentRenderer();
+    double homogeneousVector[4];
+
+    if (renderer)
+    {
+        std::copy(viewportPoint, viewportPoint + 3, homogeneousVector);
+        renderer->NormalizedViewportToViewport(homogeneousVector[0], homogeneousVector[1]);
+        renderer->ViewportToNormalizedDisplay(homogeneousVector[0], homogeneousVector[1]);
+        renderer->NormalizedDisplayToDisplay(homogeneousVector[0], homogeneousVector[1]);
+        renderer->SetDisplayPoint(homogeneousVector);
+        renderer->DisplayToWorld();
+        renderer->GetWorldPoint(homogeneousVector);
+        std::copy(homogeneousVector, homogeneousVector + 3, worldPoint);
+    }
+}
+
+void medCropToolBoxPrivate::applyOrientationMatrix(double* worldPointIn, double* worldPointOut)
+{
+    double homogeneousVector[4];
+
+    std::copy(worldPointIn, worldPointIn + 3, homogeneousVector);
+    homogeneousVector[3] = 1;
+    orientationMatrix->MultiplyPoint(homogeneousVector, homogeneousVector);
+    std::copy(homogeneousVector, homogeneousVector + 3, worldPointOut);
+}
+
+void medCropToolBoxPrivate::applyInverseOrientationMatrix(double* worldPointIn, double* worldPointOut)
+{
+    double homogeneousVector[4];
+
+    std::copy(worldPointIn, worldPointIn + 3, homogeneousVector);
+    homogeneousVector[3] = 1;
+    inverseOrientationMatrix->MultiplyPoint(homogeneousVector, homogeneousVector);
+    std::copy(homogeneousVector, homogeneousVector + 3, worldPointOut);
+}
+
+void medCropToolBoxPrivate::generateOutput()
+{
+    double minBoxCorner[3], maxBoxCorner[3];
+    int minIndices[3], maxIndices[3];
+
+    getMinAndMaxBoxCorners(minBoxCorner, maxBoxCorner);
+    applyOrientationMatrix(minBoxCorner, minBoxCorner);
+    applyOrientationMatrix(maxBoxCorner, maxBoxCorner);
+    view3D->GetImageCoordinatesFromWorldCoordinates(minBoxCorner, minIndices);
+    view3D->GetImageCoordinatesFromWorldCoordinates(maxBoxCorner, maxIndices);
+
+    outputData.clear();
+
+    for (unsigned int layer = 0; layer < view->layersCount(); layer++)
+    {
+        medAbstractData* imageData = view->layerData(layer);
+        medAbstractData* output = NULL;
+
+        if (DISPATCH_ON_3D_PIXEL_TYPE(&medCropToolBoxPrivate::extractCroppedImage, this, imageData, minIndices, maxIndices, &output) == DTK_SUCCEED)
+        {
+            outputData.append(output);
+        }
+        else
+        {
+            medMessageController::instance()->showError("Drop a 3D volume in the view",3000);
+            qDebug()<<"medCropToolBoxPrivate::generateOutput id "<<imageData->identifier();
+        }
+    }
+}
+
+template <typename ImageType>
+int medCropToolBoxPrivate::extractCroppedImage(medAbstractData* input, int* minIndices, int* maxIndices, medAbstractData** output)
+{
+    typename ImageType::Pointer inputImage = static_cast<ImageType*>(input->data());
+
+    typedef itk::RegionOfInterestImageFilter<ImageType, ImageType> FilterType;
+    typename FilterType::Pointer filter = FilterType::New();
+    typename ImageType::IndexType desiredStart;
+    typename ImageType::SizeType desiredSize;
+    typename ImageType::SizeType imageSize = inputImage->GetLargestPossibleRegion().GetSize();
+
+    for (unsigned int i = 0; i < ImageType::ImageDimension; i++)
+    {
+        if (minIndices[i] > maxIndices[i])
+        {
+            std::swap(minIndices[i], maxIndices[i]);
+        }
+        if (maxIndices[i] < 0 || minIndices[i] >= (int)imageSize[i])
+        {
+            return 0;
+        }
+        desiredStart[i] = std::max(minIndices[i], 0);
+        desiredSize[i] = std::min(maxIndices[i] + 1, (int)imageSize[i]) - desiredStart[i];
+    }
+
+    typename ImageType::RegionType desiredRegion(desiredStart, desiredSize);
+    filter->SetRegionOfInterest(desiredRegion);
+    filter->SetInput(inputImage);
+    filter->Update();
+
+    typename ImageType::Pointer filteredImage = filter->GetOutput();
+    *output = medAbstractDataFactory::instance()->create(input->identifier());
+    (*output)->setData(filteredImage);
+
+    medUtilities::setDerivedMetaData(*output, input, "cropped");
+    medUtilitiesITK::updateMetadata<ImageType>(*output);
+
+    return DTK_SUCCEED;
+}
+
+void medCropToolBoxPrivate::replaceViewWithOutputData(medAbstractWorkspaceLegacy &workspace)
+{
+    if (outputData.length() >= 0)
+    {
+        medTabbedViewContainers* tabbedViewContainers = workspace.tabbedViewContainers();
+        medViewContainer* viewContainer = tabbedViewContainers->containersInTab(tabbedViewContainers->currentIndex()).at(0);
+
+        viewContainer->removeView();
+        viewContainer->setMultiLayered(true);
+        viewContainer->addData(outputData[0]);
+        medAbstractLayeredView* newView = qobject_cast<medAbstractLayeredView*>(viewContainer->view());
+        for (int layer = 1; layer < outputData.length(); layer++)
+        {
+            newView->addLayer(outputData[layer]);
+        }
+    }
+}
+
+void medCropToolBoxPrivate::importOutput()
+{
+    foreach (medAbstractData* output, outputData)
+    {
+        medDataManager::instance()->importData(output, false);
+    }
+}

--- a/src/plugins/legacy/reformat/medCropToolBox.cpp
+++ b/src/plugins/legacy/reformat/medCropToolBox.cpp
@@ -17,17 +17,15 @@
 #include <medAbstractDataFactory.h>
 #include <medAbstractLayeredView.h>
 #include <medDataManager.h>
-#include <medMetaDataKeys.h>
+#include <medMessageController.h>
 #include <medPluginManager.h>
 #include <medTabbedViewContainers.h>
-#include <medToolBoxBody.h>
 #include <medToolBoxFactory.h>
 #include <medUtilities.h>
 #include <medUtilitiesITK.h>
 #include <medViewContainer.h>
 #include <medVtkViewBackend.h>
 
-#include <medMessageController.h>
 #include <vtkBorderRepresentation.h>
 #include <vtkBorderWidget.h>
 #include <vtkCamera.h>

--- a/src/plugins/legacy/reformat/medCropToolBox.cpp
+++ b/src/plugins/legacy/reformat/medCropToolBox.cpp
@@ -43,19 +43,18 @@ class medCropCallback;
 class medCropToolBoxPrivate
 {
 public:
-    medAbstractLayeredView* view;
-    vtkImageView2D* view2D;
-    vtkImageView3D* view3D;
-    QPushButton* applyButton;
-    QPushButton* saveButton;
+    medAbstractLayeredView *view;
+    vtkImageView2D *view2D;
+    vtkImageView3D *view3D;
+    QPushButton *applyButton;
+    QPushButton *saveButton;
     vtkSmartPointer<vtkBorderWidget> borderWidget;
     int currentOrientation;
     QList<dtkSmartPointer<medAbstractData> > outputData;
     vtkSmartPointer<medCropCallback> cropCallback;
-    vtkMatrix4x4* orientationMatrix;
+    vtkMatrix4x4 *orientationMatrix;
     vtkSmartPointer<vtkMatrix4x4> inverseOrientationMatrix;
 
-    
     void updateBorderWidgetIfVisible();
     void updateCurrentOrientation();
     void updateBoxWidgetFromBorderWidget();
@@ -78,7 +77,7 @@ class medCropCallback : public vtkCommand
 
 public:
 
-    medCropToolBox* toolBox;
+    medCropToolBox *toolBox;
 
     static medCropCallback *New()
     {
@@ -133,9 +132,9 @@ medCropToolBox::medCropToolBox(QWidget* parent)
     d->cropCallback = vtkSmartPointer<medCropCallback>::New();
     d->cropCallback->toolBox = this;
 
-    d->view = 0;
-    d->view2D = 0;
-    d->view3D = 0;
+    d->view   = nullptr;
+    d->view2D = nullptr;
+    d->view3D = nullptr;
 }
 
 medCropToolBox::~medCropToolBox()
@@ -169,9 +168,9 @@ void medCropToolBox::handleCameraMoveEvent()
 
 void medCropToolBox::updateView()
 {
-    medViewContainer* currentContainer = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainer();
+    medViewContainer *currentContainer = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainer();
     medAbstractView *viewNotLayered = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainerView();
-    medAbstractLayeredView* view = qobject_cast<medAbstractLayeredView*>(viewNotLayered);
+    medAbstractLayeredView *view = qobject_cast<medAbstractLayeredView*>(viewNotLayered);
 
     if (view)
     {
@@ -201,9 +200,9 @@ void medCropToolBox::updateView()
     }
     else
     {
-        d->view = 0;
-        d->view2D = 0;
-        d->view3D = 0;
+        d->view   = nullptr;
+        d->view2D = nullptr;
+        d->view3D = nullptr;
     }
 }
 
@@ -243,7 +242,7 @@ void medCropToolBox::clear()
     setEnable(false);
 
     // allow to split container in other toolboxes
-    medViewContainer* currentContainer = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainer();
+    medViewContainer *currentContainer = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainer();
     if (currentContainer)
     {
         currentContainer->setUserSplittable(true);
@@ -371,7 +370,7 @@ void medCropToolBoxPrivate::getMinAndMaxBoxCorners(double* minCorner, double* ma
 
 void medCropToolBoxPrivate::worldToNormalizedViewport(double* worldPoint, double* viewportPoint)
 {
-    vtkRenderer* renderer = borderWidget->GetCurrentRenderer();
+    vtkRenderer *renderer = borderWidget->GetCurrentRenderer();
 
     if (renderer)
     {
@@ -386,7 +385,7 @@ void medCropToolBoxPrivate::worldToNormalizedViewport(double* worldPoint, double
 
 void medCropToolBoxPrivate::normalizedViewportToWorld(double* viewportPoint, double* worldPoint)
 {
-    vtkRenderer* renderer = borderWidget->GetCurrentRenderer();
+    vtkRenderer *renderer = borderWidget->GetCurrentRenderer();
     double homogeneousVector[4];
 
     if (renderer)
@@ -438,7 +437,7 @@ void medCropToolBoxPrivate::generateOutput()
     for (unsigned int layer = 0; layer < view->layersCount(); layer++)
     {
         medAbstractData* imageData = view->layerData(layer);
-        medAbstractData* output = NULL;
+        medAbstractData* output = nullptr;
 
         if (DISPATCH_ON_3D_PIXEL_TYPE(&medCropToolBoxPrivate::extractCroppedImage, this, imageData, minIndices, maxIndices, &output) == DTK_SUCCEED)
         {
@@ -489,7 +488,7 @@ int medCropToolBoxPrivate::extractCroppedImage(medAbstractData* input, int* minI
     medUtilities::setDerivedMetaData(*output, input, "cropped");
     medUtilitiesITK::updateMetadata<ImageType>(*output);
 
-    return DTK_SUCCEED;
+    return medAbstractProcessLegacy::SUCCESS;
 }
 
 void medCropToolBoxPrivate::replaceViewWithOutputData(medAbstractWorkspaceLegacy &workspace)
@@ -502,7 +501,9 @@ void medCropToolBoxPrivate::replaceViewWithOutputData(medAbstractWorkspaceLegacy
         viewContainer->removeView();
         viewContainer->setMultiLayered(true);
         viewContainer->addData(outputData[0]);
+
         medAbstractLayeredView* newView = qobject_cast<medAbstractLayeredView*>(viewContainer->view());
+
         for (int layer = 1; layer < outputData.length(); layer++)
         {
             newView->addLayer(outputData[layer]);
@@ -512,7 +513,7 @@ void medCropToolBoxPrivate::replaceViewWithOutputData(medAbstractWorkspaceLegacy
 
 void medCropToolBoxPrivate::importOutput()
 {
-    foreach (medAbstractData* output, outputData)
+    foreach (medAbstractData *output, outputData)
     {
         medDataManager::instance()->importData(output, false);
     }

--- a/src/plugins/legacy/reformat/medCropToolBox.h
+++ b/src/plugins/legacy/reformat/medCropToolBox.h
@@ -1,0 +1,56 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#pragma once
+
+#include <medAbstractWorkspaceLegacy.h>
+#include <medAbstractSelectableToolBox.h>
+#include <reformatPluginExport.h>
+
+class medCropToolBoxPrivate;
+
+class REFORMATPLUGIN_EXPORT medCropToolBox : public medAbstractSelectableToolBox
+{
+    Q_OBJECT
+    MED_TOOLBOX_INTERFACE("Cropping",
+                          "Used to crop one or more datasets",
+                          <<"Reformat")
+
+public:
+    static bool registered();
+
+    const QString applyButtonName;
+    const QString saveButtonName;
+
+    medCropToolBox(QWidget *parent = nullptr);
+    virtual ~medCropToolBox();
+
+    virtual dtkPlugin* plugin();
+    virtual medAbstractData* processOutput();
+
+    void handleInteractionEvent();
+    void handleCameraMoveEvent();
+
+public slots:
+    void updateView();
+    void applyCrop();
+    void saveCrop();
+    void reactToOrientationChange();
+    void setEnable(bool enable);
+
+protected:
+    void showEvent(QShowEvent *event);
+    virtual void clear();
+
+private:
+    medCropToolBoxPrivate* const d;
+};

--- a/src/plugins/legacy/reformat/medCropToolBox.h
+++ b/src/plugins/legacy/reformat/medCropToolBox.h
@@ -12,7 +12,6 @@
 =========================================================================*/
 #pragma once
 
-#include <medAbstractWorkspaceLegacy.h>
 #include <medAbstractSelectableToolBox.h>
 #include <reformatPluginExport.h>
 

--- a/src/plugins/legacy/reformat/medReformatWorkspace.cpp
+++ b/src/plugins/legacy/reformat/medReformatWorkspace.cpp
@@ -25,7 +25,7 @@ medReformatWorkspace::medReformatWorkspace(QWidget *parent) : medSelectorWorkspa
 
 bool medReformatWorkspace::isUsable()
 {
-    medToolBoxFactory * tbFactory = medToolBoxFactory::instance();
+    medToolBoxFactory *tbFactory = medToolBoxFactory::instance();
     return (tbFactory->toolBoxesFromCategory("Reformat").size()!=0);
 }
 

--- a/src/plugins/legacy/reformat/medReformatWorkspace.cpp
+++ b/src/plugins/legacy/reformat/medReformatWorkspace.cpp
@@ -1,0 +1,35 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include "medReformatWorkspace.h"
+
+#include <medSelectorToolBox.h>
+#include <medTabbedViewContainers.h>
+#include <medToolBoxFactory.h>
+#include <medWorkspaceFactory.h>
+
+medReformatWorkspace::medReformatWorkspace(QWidget *parent) : medSelectorWorkspace(parent, staticName())
+{
+    connect(this->tabbedViewContainers(), SIGNAL(containersSelectedChanged()),
+            selectorToolBox(), SIGNAL(inputChanged()));
+}
+
+bool medReformatWorkspace::isUsable()
+{
+    medToolBoxFactory * tbFactory = medToolBoxFactory::instance();
+    return (tbFactory->toolBoxesFromCategory("Reformat").size()!=0);
+}
+
+bool medReformatWorkspace::registered()
+{
+    return medWorkspaceFactory::instance()->registerWorkspace <medReformatWorkspace>();
+}

--- a/src/plugins/legacy/reformat/medReformatWorkspace.h
+++ b/src/plugins/legacy/reformat/medReformatWorkspace.h
@@ -14,7 +14,7 @@
 #pragma once
 
 #include <medSelectorWorkspace.h>
-#include "reformatPluginExport.h"
+#include <reformatPluginExport.h>
     
 class REFORMATPLUGIN_EXPORT medReformatWorkspace : public medSelectorWorkspace
 {

--- a/src/plugins/legacy/reformat/medReformatWorkspace.h
+++ b/src/plugins/legacy/reformat/medReformatWorkspace.h
@@ -1,0 +1,31 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2019. All rights reserved.
+ See LICENSE.txt for details.
+ 
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#pragma once
+
+#include <medSelectorWorkspace.h>
+#include "reformatPluginExport.h"
+    
+class REFORMATPLUGIN_EXPORT medReformatWorkspace : public medSelectorWorkspace
+{
+    Q_OBJECT
+    MED_WORKSPACE_INTERFACE("Reformat",
+                            "Reformat workspace.",
+                            "Methodology")
+    
+public:
+    medReformatWorkspace(QWidget *parent);
+
+    static bool isUsable();
+    static bool registered();
+};

--- a/src/plugins/legacy/reformat/medResliceViewer.cpp
+++ b/src/plugins/legacy/reformat/medResliceViewer.cpp
@@ -120,7 +120,9 @@ public:
 medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medAbstractView(parent)
 {
     if (!view)
+    {
         return;
+    }
 
     inputData = static_cast<medAbstractLayeredView*>(view)->layerData(0);
     view3d = static_cast<medVtkViewBackend*>(view->backend())->view3D;
@@ -288,7 +290,7 @@ void medResliceViewer::thickMode(int val)
 {
     for (int i = 0; i < 3; i++)
     {
-        //TODO : set the axes to the reslicecursorwidget vtkimageReslice .... this will propably solve the problem of disappearance.
+        //TODO: set the axes to the reslicecursorwidget vtkimageReslice .... this will propably solve the problem of disappearance.
         riw[i]->SetThickMode(val);
         riw[i]->GetRenderer()->ResetCamera();
         riw[i]->Render();
@@ -428,7 +430,7 @@ void medResliceViewer::thickSlabChanged(double val)
             {
                 riw[0]->GetResliceCursor()->SetThickness(val,y,z); //the three windows share the same reslice cursor
             }
-            outputSpacing[0]=val;
+            outputSpacing[0] = val;
         }
 
         if (spinBoxSender->accessibleName()=="SpacingY")
@@ -437,7 +439,7 @@ void medResliceViewer::thickSlabChanged(double val)
             {
                 riw[0]->GetResliceCursor()->SetThickness(x,val,z); //the three windows share the same reslice cursor
             }
-            outputSpacing[1]=val;
+            outputSpacing[1] = val;
         }
 
         if (spinBoxSender->accessibleName()=="SpacingZ")
@@ -446,7 +448,7 @@ void medResliceViewer::thickSlabChanged(double val)
             {
                 riw[0]->GetResliceCursor()->SetThickness(x,y,val); //the three windows share the same reslice cursor
             }
-            outputSpacing[2]=val;
+            outputSpacing[2] = val;
         }
         this->render();
     }
@@ -454,15 +456,16 @@ void medResliceViewer::thickSlabChanged(double val)
 
 void medResliceViewer::extentChanged(int val)
 {
+    Q_UNUSED(val)
     medSliderSpinboxPair *pairSender = qobject_cast<medSliderSpinboxPair*>(QObject::sender());
 
     if (pairSender)
     {
-        if (pairSender->accessibleName()=="fromSlice")
+        if (pairSender->accessibleName() == "fromSlice")
         {
             fromSlice = pairSender->value();
         }
-        if (pairSender->accessibleName()=="toSlice")
+        if (pairSender->accessibleName() == "toSlice")
         {
             toSlice = pairSender->value();
         }
@@ -575,6 +578,7 @@ void medResliceViewer::calculateResliceMatrix(vtkMatrix4x4* result)
     switch (selectedView)
     {
         case 0:
+        {
             outputX = resliceY;
             outputY = resliceZ;
             outputZ = resliceX;
@@ -582,7 +586,9 @@ void medResliceViewer::calculateResliceMatrix(vtkMatrix4x4* result)
             outputOrigin[1] = resliceOrigin[2];
             outputOrigin[2] = resliceOrigin[0];
             break;
+        }
         case 1:
+        {
             outputX = resliceZ;
             outputY = resliceX;
             outputZ = resliceY;
@@ -590,7 +596,9 @@ void medResliceViewer::calculateResliceMatrix(vtkMatrix4x4* result)
             outputOrigin[1] = resliceOrigin[0];
             outputOrigin[2] = resliceOrigin[1];
             break;
+        }
         default:
+        {
             outputX = resliceX;
             outputY = resliceY;
             outputZ = resliceZ;
@@ -598,6 +606,7 @@ void medResliceViewer::calculateResliceMatrix(vtkMatrix4x4* result)
             outputOrigin[1] = resliceOrigin[1];
             outputOrigin[2] = resliceOrigin[2];
             break;
+        }
     }
 
     result->Identity();
@@ -689,7 +698,7 @@ int medResliceViewer::findMovingPlaneIndex()
 
     for (int i = 0; i < 3; i++)
     {
-        vtkPlane* plane = getResliceImageViewer(0)->GetResliceCursor()->GetPlane(i);
+        vtkPlane *plane = getResliceImageViewer(0)->GetResliceCursor()->GetPlane(i);
         double *currentNormal = plane->GetNormal();
         double normalDifference = 0;
         for (int j = 0; j < 3; j++)
@@ -758,7 +767,7 @@ void medResliceViewer::generateOutput(vtkImageReslice* reslicer, QString destTyp
 
 void medResliceViewer::applyResamplingPix()
 {
-    resampleProcess* resamplePr = new resampleProcess();
+    resampleProcess *resamplePr = new resampleProcess();
     resamplePr->setInput(outputData);
     resamplePr->setParameter(outputSpacing[0],0);
     resamplePr->setParameter(outputSpacing[1],1);

--- a/src/plugins/legacy/reformat/medResliceViewer.cpp
+++ b/src/plugins/legacy/reformat/medResliceViewer.cpp
@@ -187,7 +187,7 @@ medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medA
 
         rep->GetResliceCursorActor()->GetCursorAlgorithm()->SetReslicePlaneNormal(i);
 
-        riw[i]->SetInputData(view3d->GetInputAlgorithm(view3d->GetCurrentLayer())->GetOutput());
+        riw[i]->SetInputConnection(view3d->GetInputAlgorithm(view3d->GetCurrentLayer())->GetOutputPort());
         riw[i]->SetSliceOrientation(i);
         riw[i]->SetResliceModeToOblique();
     }
@@ -220,7 +220,7 @@ medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medA
         planeWidget[i]->SetTexturePlaneProperty(ipwProp);
         planeWidget[i]->TextureInterpolateOff();
         planeWidget[i]->SetResliceInterpolateToLinear();
-        planeWidget[i]->SetInputData(view3d->GetInputAlgorithm(view3d->GetCurrentLayer())->GetOutput());
+        planeWidget[i]->SetInputConnection(view3d->GetInputAlgorithm(view3d->GetCurrentLayer())->GetOutputPort());
         planeWidget[i]->SetPlaneOrientation(i);
         planeWidget[i]->SetSliceIndex(imageDims[i]/2);
         planeWidget[i]->DisplayTextOn();
@@ -364,7 +364,7 @@ void medResliceViewer::saveImage()
     calculateResliceMatrix(resliceMatrix);
 
     vtkImageReslice *reslicerTop = vtkImageReslice::New();
-    reslicerTop->SetInputData(view3d->GetInputAlgorithm(view3d->GetCurrentLayer())->GetOutput());
+    reslicerTop->SetInputConnection(view3d->GetInputAlgorithm(view3d->GetCurrentLayer())->GetOutputPort());
     reslicerTop->AutoCropOutputOn();
     reslicerTop->SetResliceAxes(resliceMatrix);
     reslicerTop->SetBackgroundLevel(riw[0]->GetInput()->GetScalarRange()[0]); // todo: set the background value in an automatic way.
@@ -474,7 +474,7 @@ void medResliceViewer::extentChanged(int val)
 
 bool medResliceViewer::eventFilter(QObject *object, QEvent *event)
 {
-    if (!qobject_cast<QVTKWidget*>(object))
+    if (!qobject_cast<QVTKOpenGLWidget*>(object))
     {
         return true;
     }

--- a/src/plugins/legacy/reformat/medResliceViewer.cpp
+++ b/src/plugins/legacy/reformat/medResliceViewer.cpp
@@ -368,17 +368,18 @@ void medResliceViewer::saveImage()
     calculateResliceMatrix(resliceMatrix);
 
     vtkImageReslice *reslicerTop = vtkImageReslice::New();
-    reslicerTop->SetInputConnection(view3d->GetInputAlgorithm(view3d->GetCurrentLayer())->GetOutputPort());
+    reslicerTop->SetInputData(view3d->GetInputAlgorithm(view3d->GetCurrentLayer())->GetOutput());
     reslicerTop->AutoCropOutputOn();
     reslicerTop->SetResliceAxes(resliceMatrix);
     reslicerTop->SetBackgroundLevel(riw[0]->GetInput()->GetScalarRange()[0]);
+    reslicerTop->SetInterpolationModeToLinear();
 
     // Apply resampling in mm
     if (reformaTlbx->findChild<QComboBox*>("bySpacingOrDimension")->currentText() == "Spacing")
     {
         reslicerTop->SetOutputSpacing(outputSpacing);
     }
-    reslicerTop->SetInterpolationModeToLinear();
+    reslicerTop->Update();
 
     // Apply orientation changes
     switch (reslicerTop->GetOutput()->GetScalarType())

--- a/src/plugins/legacy/reformat/medResliceViewer.cpp
+++ b/src/plugins/legacy/reformat/medResliceViewer.cpp
@@ -50,82 +50,79 @@ public:
         return new medResliceCursorCallback;
     }
 
-    void Execute( vtkObject *caller, unsigned long ev,
-                  void *callData ) override
+    void Execute(vtkObject *caller, unsigned long ev, void *callData )
     {
-
-        if (ev == vtkResliceCursorWidget::WindowLevelEvent ||
-                ev == vtkCommand::WindowLevelEvent ||
-                ev == vtkResliceCursorWidget::ResliceThicknessChangedEvent)
+        switch (ev)
         {
-            // Render everything
-            for (int i = 0; i < 3; i++)
+            case vtkResliceCursorWidget::ResliceAxesChangedEvent:
             {
-                this->RCW[i]->Render();
+                reformatViewer->ensureOrthogonalPlanes();
+                break;
             }
-            this->IPW[0]->GetInteractor()->GetRenderWindow()->Render();
-            return;
+            case vtkResliceCursorWidget::ResetCursorEvent:
+            {
+                reformatViewer->resetViews();
+                reformatViewer->applyRadiologicalConvention();
+                break;
+            }
         }
 
-        vtkImagePlaneWidget* ipw =
-                dynamic_cast< vtkImagePlaneWidget* >( caller );
+        vtkImagePlaneWidget *ipw = dynamic_cast< vtkImagePlaneWidget* >(caller);
         if (ipw)
         {
-            double* wl = static_cast<double*>( callData );
+            double *wl = static_cast<double*>(callData);
 
-            if ( ipw == this->IPW[0] )
+            if (ipw == reformatViewer->getImagePlaneWidget(0))
             {
-                this->IPW[1]->SetWindowLevel(wl[0],wl[1],1);
-                this->IPW[2]->SetWindowLevel(wl[0],wl[1],1);
+                reformatViewer->getImagePlaneWidget(1)->SetWindowLevel(wl[0],wl[1],1);
+                reformatViewer->getImagePlaneWidget(2)->SetWindowLevel(wl[0],wl[1],1);
             }
-            else if( ipw == this->IPW[1] )
+            else if(ipw == reformatViewer->getImagePlaneWidget(1))
             {
-                this->IPW[0]->SetWindowLevel(wl[0],wl[1],1);
-                this->IPW[2]->SetWindowLevel(wl[0],wl[1],1);
+                reformatViewer->getImagePlaneWidget(0)->SetWindowLevel(wl[0],wl[1],1);
+                reformatViewer->getImagePlaneWidget(2)->SetWindowLevel(wl[0],wl[1],1);
             }
-            else if (ipw == this->IPW[2])
+            else if (ipw == reformatViewer->getImagePlaneWidget(2))
             {
-                this->IPW[0]->SetWindowLevel(wl[0],wl[1],1);
-                this->IPW[1]->SetWindowLevel(wl[0],wl[1],1);
+                reformatViewer->getImagePlaneWidget(0)->SetWindowLevel(wl[0],wl[1],1);
+                reformatViewer->getImagePlaneWidget(1)->SetWindowLevel(wl[0],wl[1],1);
             }
         }
 
-        vtkResliceCursorWidget *rcw = dynamic_cast<
-                vtkResliceCursorWidget * >(caller);
+        vtkResliceCursorWidget *rcw = dynamic_cast<vtkResliceCursorWidget*>(caller);
         if (rcw)
         {
-            vtkResliceCursorLineRepresentation *rep = dynamic_cast<
-                    vtkResliceCursorLineRepresentation * >(rcw->GetRepresentation());
+            vtkResliceCursorLineRepresentation *rep = dynamic_cast<vtkResliceCursorLineRepresentation*>(rcw->GetRepresentation());
             // Although the return value is not used, we keep the get calls
             // in case they had side-effects
             rep->GetResliceCursorActor()->GetCursorAlgorithm()->GetResliceCursor();
+
             for (int i = 0; i < 3; i++)
             {
-                vtkPlaneSource *ps = static_cast< vtkPlaneSource * >(
-                            this->IPW[i]->GetPolyDataAlgorithm());
-                ps->SetOrigin(this->RCW[i]->GetResliceCursorRepresentation()->
-                              GetPlaneSource()->GetOrigin());
-                ps->SetPoint1(this->RCW[i]->GetResliceCursorRepresentation()->
-                              GetPlaneSource()->GetPoint1());
-                ps->SetPoint2(this->RCW[i]->GetResliceCursorRepresentation()->
-                              GetPlaneSource()->GetPoint2());
+                vtkPlaneSource *ps = static_cast< vtkPlaneSource * >(reformatViewer->getImagePlaneWidget(i)->GetPolyDataAlgorithm());
+                ps->SetOrigin(reformatViewer->getResliceImageViewer(i)->GetResliceCursorWidget()
+                              ->GetResliceCursorRepresentation()->GetPlaneSource()->GetOrigin());
+                ps->SetPoint1(reformatViewer->getResliceImageViewer(i)->GetResliceCursorWidget()
+                              ->GetResliceCursorRepresentation()->GetPlaneSource()->GetPoint1());
+                ps->SetPoint2(reformatViewer->getResliceImageViewer(i)->GetResliceCursorWidget()
+                              ->GetResliceCursorRepresentation()->GetPlaneSource()->GetPoint2());
 
                 // If the reslice plane has modified, update it on the 3D widget
-                this->IPW[i]->UpdatePlacement();
+                reformatViewer->getImagePlaneWidget(i)->UpdatePlacement();
             }
         }
 
         // Render everything
         for (int i = 0; i < 3; i++)
         {
-            this->RCW[i]->Render();
+            reformatViewer->getResliceImageViewer(i)->GetResliceCursorWidget()->Render();
         }
-        this->IPW[0]->GetInteractor()->GetRenderWindow()->Render();
+        reformatViewer->getImagePlaneWidget(0)->GetInteractor()->GetRenderWindow()->Render();
     }
 
-    void vtkResliceCursorCallback() {}
-    vtkImagePlaneWidget* IPW[3];
-    vtkResliceCursorWidget *RCW[3];
+    medResliceCursorCallback() {}
+
+    medResliceViewer *reformatViewer;
 };
 
 medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medAbstractView(parent)
@@ -145,44 +142,36 @@ medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medA
 
     viewBody = new QWidget(parent);
 
+    // Build reslice viewers
     for (int i = 0; i < 3; i++)
     {
         riw[i] = vtkSmartPointer<vtkResliceImageViewer>::New();
         vtkNew<vtkGenericOpenGLRenderWindow> renderWindow;
         riw[i]->SetRenderWindow(renderWindow);
+        riw[i]->GetRenderer()->SetBackground(0,0,0); // black background
     }
 
+    // Build views
     for (int i = 0; i < 4; i++)
     {
-        frames[i] = new QVTKFrame(viewBody);
-        views[i] = frames[i]->getView();
-        views[i]->setSizePolicy ( QSizePolicy::Minimum, QSizePolicy::Minimum );
-
-        // Color border of these views
-        if (i==0)
-        {
-            frames[i]->setStyleSheet("* {border : 1px solid #FF0000;}");
-        }
-        else if (i==1)
-        {
-            frames[i]->setStyleSheet("* {border : 1px solid #00FF00;}");
-        }
-        else if (i==2)
-        {
-            frames[i]->setStyleSheet("* {border : 1px solid #0000FF;}");
-        }
-
+        views[i] = new QVTKOpenGLWidget();
+        views[i]->setEnableHiDPI(true);
+        views[i]->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
         views[i]->installEventFilter(this);
     }
 
     // Position of the new views in tab
     QGridLayout *gridLayout = new QGridLayout(parent);
-    gridLayout->addWidget(frames[2], 0, 0);
-    gridLayout->addWidget(frames[3], 0, 1);
-    gridLayout->addWidget(frames[1], 1, 0);
-    gridLayout->addWidget(frames[0], 1, 1);
+    gridLayout->addWidget(views[2], 0, 0);
+    gridLayout->addWidget(views[3], 0, 1);
+    gridLayout->addWidget(views[1], 1, 0);
+    gridLayout->addWidget(views[0], 1, 1);
     gridLayout->setColumnStretch(0, 0);
     gridLayout->setColumnStretch(1, 0);
+    gridLayout->setColumnMinimumWidth(0, imageDims[0]);
+    gridLayout->setColumnMinimumWidth(1, imageDims[0]);
+    gridLayout->setRowMinimumHeight(0, imageDims[1]);
+    gridLayout->setRowMinimumHeight(1, imageDims[1]);
     gridLayout->setRowStretch(0, 0);
     gridLayout->setRowStretch(1, 0);
     viewBody->setLayout(gridLayout);
@@ -197,6 +186,11 @@ medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medA
     views[2]->SetRenderWindow(riw[2]->GetRenderWindow());
     riw[2]->SetupInteractor(views[2]->GetRenderWindow()->GetInteractor());
 
+    vtkSmartPointer<vtkRenderer> ren = vtkSmartPointer<vtkRenderer>::New();
+    vtkNew<vtkGenericOpenGLRenderWindow> renderWindow;
+    views[3]->SetRenderWindow(renderWindow);
+    views[3]->GetRenderWindow()->AddRenderer(ren);
+
     // Make them all share the same reslice cursor object.
     for (int i = 0; i < 3; i++)
     {
@@ -208,7 +202,7 @@ medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medA
 
         riw[i]->SetInputData(view3d->GetInputAlgorithm(view3d->GetCurrentLayer())->GetOutput());
         riw[i]->SetSliceOrientation(i);
-        riw[i]->SetResliceModeToAxisAligned();
+        riw[i]->SetResliceModeToOblique();
     }
 
     vtkSmartPointer<vtkCellPicker> picker = vtkSmartPointer<vtkCellPicker>::New();
@@ -216,26 +210,20 @@ medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medA
 
     vtkSmartPointer<vtkProperty> ipwProp = vtkSmartPointer<vtkProperty>::New();
 
-    vtkSmartPointer<vtkRenderer> ren = vtkSmartPointer<vtkRenderer>::New();
-    vtkNew<vtkGenericOpenGLRenderWindow> renderWindow;
-    views[3]->SetRenderWindow(renderWindow);
-    views[3]->GetRenderWindow()->AddRenderer(ren);
-
     vtkRenderWindowInteractor *iren = views[3]->GetInteractor();
 
+    // Build planes on views
     for (int i = 0; i < 3; i++)
     {
         planeWidget[i] = vtkSmartPointer<vtkImagePlaneWidget>::New();
         planeWidget[i]->SetInteractor(iren);
         planeWidget[i]->SetPicker(picker);
         planeWidget[i]->RestrictPlaneToVolumeOn();
+
+        // Plane colors
         double color[3] = {0, 0, 0};
         color[i] = 1;
         planeWidget[i]->GetPlaneProperty()->SetColor(color);
-        color[0] /= 4.0;
-        color[1] /= 4.0;
-        color[2] /= 4.0;
-        riw[i]->GetRenderer()->SetBackground(color);
 
         planeWidget[i]->SetTexturePlaneProperty(ipwProp);
         planeWidget[i]->TextureInterpolateOff();
@@ -245,18 +233,15 @@ medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medA
         planeWidget[i]->SetSliceIndex(imageDims[i]/2);
         planeWidget[i]->DisplayTextOn();
         planeWidget[i]->SetDefaultRenderer(ren);
-        planeWidget[i]->SetWindowLevel(1358, -27);
         planeWidget[i]->On();
         planeWidget[i]->InteractionOn();
     }
 
     vtkSmartPointer<medResliceCursorCallback> cbk = vtkSmartPointer<medResliceCursorCallback>::New();
+    cbk->reformatViewer = this;
 
     for (int i = 0; i < 3; i++)
     {
-        cbk->IPW[i] = planeWidget[i];
-        cbk->RCW[i] = riw[i]->GetResliceCursorWidget();
-
         riw[i]->GetResliceCursorWidget()->AddObserver(vtkResliceCursorWidget::ResliceAxesChangedEvent, cbk);
         riw[i]->GetResliceCursorWidget()->AddObserver(vtkResliceCursorWidget::WindowLevelEvent, cbk);
         riw[i]->GetResliceCursorWidget()->AddObserver(vtkResliceCursorWidget::ResliceThicknessChangedEvent, cbk);
@@ -272,6 +257,7 @@ medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medA
         planeWidget[i]->SetColorMap(riw[i]->GetResliceCursorWidget()->GetResliceCursorRepresentation()->GetColorMap());
     }
 
+    resetViews();
     applyRadiologicalConvention();
     updatePlaneNormals();
 
@@ -282,8 +268,6 @@ medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medA
     views[0]->show();
     views[1]->show();
     views[2]->show();
-
-    this->render();
 
     this->initialiseNavigators();
 }
@@ -312,6 +296,7 @@ void medResliceViewer::thickMode(int val)
     for (int i = 0; i < 3; i++)
     {
         riw[i]->SetThickMode(val);
+        riw[i]->GetRenderer()->ResetCamera();
         riw[i]->Render();
     }
 }
@@ -358,27 +343,14 @@ void medResliceViewer::reset()
 
 void medResliceViewer::resetViews()
 {
-    // Reset the reslice image views
     for (int i = 0; i < 3; i++)
     {
-        riw[i]->Reset();
+        riw[i]->GetRenderer()->ResetCamera();
     }
 
-    // Also sync the Image plane widget on the 3D top right view with any
-    // changes to the reslice cursor.
-    for (int i = 0; i < 3; i++)
-    {
-        vtkPlaneSource *ps = static_cast< vtkPlaneSource * >(
-                    planeWidget[i]->GetPolyDataAlgorithm());
-        ps->SetNormal(riw[0]->GetResliceCursor()->GetPlane(i)->GetNormal());
-        ps->SetCenter(riw[0]->GetResliceCursor()->GetPlane(i)->GetOrigin());
-
-        // If the reslice plane has modified, update it on the 3D widget
-        this->planeWidget[i]->UpdatePlacement();
-    }
-
-    // Render in response to changes.
-    this->render();
+    riw[0]->GetRenderer()->GetActiveCamera()->SetViewUp(0, 0, 1);
+    riw[1]->GetRenderer()->GetActiveCamera()->SetViewUp(0, 0, 1);
+    riw[2]->GetRenderer()->GetActiveCamera()->SetViewUp(0, -1, 0);
 }
 
 void medResliceViewer::render()
@@ -386,9 +358,8 @@ void medResliceViewer::render()
     for (int i = 0; i < 3; i++)
     {
         riw[i]->Render();
+        views[i]->GetRenderWindow()->Render();
     }
-
-    views[3]->GetRenderWindow()->Render();
 }
 
 void medResliceViewer::saveImage()
@@ -400,10 +371,9 @@ void medResliceViewer::saveImage()
     reslicerTop->SetInputConnection(view3d->GetInputAlgorithm(view3d->GetCurrentLayer())->GetOutputPort());
     reslicerTop->AutoCropOutputOn();
     reslicerTop->SetResliceAxes(resliceMatrix);
-    reslicerTop->SetBackgroundLevel(riw[0]->GetInput()->GetScalarRange()[0]); // todo: set the background value in an automatic way.
+    reslicerTop->SetBackgroundLevel(riw[0]->GetInput()->GetScalarRange()[0]);
 
     // Apply resampling in mm
-
     if (reformaTlbx->findChild<QComboBox*>("bySpacingOrDimension")->currentText() == "Spacing")
     {
         reslicerTop->SetOutputSpacing(outputSpacing);
@@ -411,7 +381,7 @@ void medResliceViewer::saveImage()
     reslicerTop->SetInterpolationModeToLinear();
 
     // Apply orientation changes
-    switch (view3d->GetMedVtkImageInfo()->scalarType)
+    switch (reslicerTop->GetOutput()->GetScalarType())
     {
         case VTK_CHAR:
             generateOutput<char>(reslicerTop, "itkDataImageChar3");
@@ -518,36 +488,12 @@ bool medResliceViewer::eventFilter(QObject *object, QEvent *event)
         {
             if (views[i]==object)
             {
-                if (i==0)
-                {
-                    frames[i]->setStyleSheet("QFrame {border : 5px solid #FF0000;}");
-                }
-                else if (i==1)
-                {
-                    frames[i]->setStyleSheet("QFrame {border : 5px solid #00FF00;}");
-                }
-                else if (i==2)
-                {
-                    frames[i]->setStyleSheet("QFrame {border : 5px solid #0000FF;}");
-                }
-
-                if (selectedView==0)
-                {
-                    frames[0]->setStyleSheet("* {border : 1px solid #FF0000;}");
-                }
-                else if (selectedView==1)
-                {
-                    frames[1]->setStyleSheet("* {border : 1px solid #00FF00;}");
-                }
-                else if (selectedView==2)
-                {
-                    frames[2]->setStyleSheet("* {border : 1px solid #0000FF;}");
-                }
                 selectedView = i;
             }
         }
         return false;
     }
+
     if (event->type() == QEvent::FocusOut)
     {
         return false;
@@ -775,7 +721,6 @@ void medResliceViewer::generateOutput(vtkImageReslice* reslicer, QString destTyp
     typename FilterType::Pointer filter = FilterType::New();
     filter->SetInput(reslicer->GetOutput());
     filter->Update();
-    filter->GetOutput()->Update();
 
     outputData = medAbstractDataFactory::instance()->createSmartPointer(destType);
     outputData->setData(filter->GetOutput());
@@ -802,9 +747,9 @@ void medResliceViewer::applyResamplingPix()
 {
     resampleProcess *resamplePr = new resampleProcess();
     resamplePr->setInput(outputData);
-    resamplePr->setParameter(outputSpacing[0],0);
-    resamplePr->setParameter(outputSpacing[1],1);
-    resamplePr->setParameter(outputSpacing[2],2);
+    resamplePr->setParameter(outputSpacing[0], 0);
+    resamplePr->setParameter(outputSpacing[1], 1);
+    resamplePr->setParameter(outputSpacing[2], 2);
     resamplePr->update();
 
     outputData = resamplePr->output();

--- a/src/plugins/legacy/reformat/medResliceViewer.cpp
+++ b/src/plugins/legacy/reformat/medResliceViewer.cpp
@@ -1,0 +1,882 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include "medResliceViewer.h"
+#include "resampleProcess.h"
+
+#include <itkVTKImageToImageFilter.h>
+#include <medAbstractDataFactory.h>
+#include <medAbstractLayeredView.h>
+#include <medSliderSpinboxPair.h>
+#include <medUtilities.h>
+#include <medUtilitiesITK.h>
+#include <medVtkViewBackend.h>
+#include <mscTransform.h>
+#include <vtkBorderRepresentation.h>
+#include <vtkCamera.h>
+#include <vtkCellPicker.h>
+#include <vtkImageMapToColors.h>
+#include <vtkImageSlabReslice.h>
+#include <vtkImageView3D.h>
+#include <vtkMath.h>
+#include <vtkMatrix4x4.h>
+#include <vtkPlane.h>
+#include <vtkPlaneSource.h>
+#include <vtkProperty.h>
+#include <vtkRenderer.h>
+#include <vtkRenderWindow.h>
+#include <vtkResliceCursor.h>
+#include <vtkResliceCursorActor.h>
+#include <vtkResliceCursorPolyDataAlgorithm.h>
+#include <vtkResliceCursorThickLineRepresentation.h>
+#include <vtkResliceCursorWidget.h>
+#include <vtkTransform.h>
+
+class medResliceCursorCallback : public vtkCommand
+{
+public:
+    static medResliceCursorCallback *New()
+    {
+        return new medResliceCursorCallback;
+    }
+
+    void Execute(vtkObject *caller, unsigned long ev, void *callData )
+    {
+        switch (ev)
+        {
+        case vtkResliceCursorWidget::ResliceAxesChangedEvent:
+            reformatViewer->ensureOrthogonalPlanes();
+            break;
+        case vtkResliceCursorWidget::ResetCursorEvent:
+            reformatViewer->resetViews();
+            reformatViewer->applyRadiologicalConvention();
+            break;
+        }
+
+        vtkImagePlaneWidget *ipw = dynamic_cast< vtkImagePlaneWidget* >( caller );
+        if (ipw)
+        {
+            double *wl = static_cast<double*>( callData );
+
+            if (ipw == reformatViewer->getImagePlaneWidget(0))
+            {
+                reformatViewer->getImagePlaneWidget(1)->SetWindowLevel(wl[0],wl[1],1);
+                reformatViewer->getImagePlaneWidget(2)->SetWindowLevel(wl[0],wl[1],1);
+            }
+            else if(ipw == reformatViewer->getImagePlaneWidget(1))
+            {
+                reformatViewer->getImagePlaneWidget(0)->SetWindowLevel(wl[0],wl[1],1);
+                reformatViewer->getImagePlaneWidget(2)->SetWindowLevel(wl[0],wl[1],1);
+            }
+            else if (ipw == reformatViewer->getImagePlaneWidget(2))
+            {
+                reformatViewer->getImagePlaneWidget(0)->SetWindowLevel(wl[0],wl[1],1);
+                reformatViewer->getImagePlaneWidget(1)->SetWindowLevel(wl[0],wl[1],1);
+            }
+        }
+
+        vtkResliceCursorWidget *rcw = dynamic_cast<vtkResliceCursorWidget*>(caller);
+        if (rcw)
+        {
+            vtkResliceCursorLineRepresentation *rep = dynamic_cast<vtkResliceCursorLineRepresentation*>(rcw->GetRepresentation());
+            // Although the return value is not used, we keep the get calls
+            // in case they had side-effects
+            rep->GetResliceCursorActor()->GetCursorAlgorithm()->GetResliceCursor();
+
+            for (int i = 0; i < 3; i++)
+            {
+                vtkPlaneSource *ps = static_cast< vtkPlaneSource * >(reformatViewer->getImagePlaneWidget(i)->GetPolyDataAlgorithm());
+                ps->SetOrigin(reformatViewer->getResliceImageViewer(i)->GetResliceCursorWidget()->GetResliceCursorRepresentation()->GetPlaneSource()->GetOrigin());
+                ps->SetPoint1(reformatViewer->getResliceImageViewer(i)->GetResliceCursorWidget()->GetResliceCursorRepresentation()->GetPlaneSource()->GetPoint1());
+                ps->SetPoint2(reformatViewer->getResliceImageViewer(i)->GetResliceCursorWidget()->GetResliceCursorRepresentation()->GetPlaneSource()->GetPoint2());
+
+                // If the reslice plane has modified, update it on the 3D widget
+                reformatViewer->getImagePlaneWidget(i)->UpdatePlacement();
+            }
+        }
+
+        // Render everything
+        for (int i = 0; i < 3; i++)
+        {
+            reformatViewer->getResliceImageViewer(i)->GetResliceCursorWidget()->Render();
+        }
+        reformatViewer->getImagePlaneWidget(0)->GetInteractor()->GetRenderWindow()->Render();
+    }
+
+    medResliceCursorCallback() {}
+
+    medResliceViewer *reformatViewer;
+};
+
+medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medAbstractView(parent)
+{
+    if (!view)
+        return;
+
+    inputData = static_cast<medAbstractLayeredView*>(view)->layerData(0);
+    view3d = static_cast<medVtkViewBackend*>(view->backend())->view3D;
+
+    int *imageDims;
+    imageDims = view3d->GetMedVtkImageInfo()->dimensions;
+
+    viewBody = new QWidget(parent);
+    for (int i = 0; i < 3; i++)
+    {
+        riw[i] = vtkSmartPointer<vtkResliceImageViewer>::New();
+        frames[i] = new QVTKFrame(viewBody);
+        views[i] = frames[i]->getView();
+        views[i]->setSizePolicy ( QSizePolicy::Minimum, QSizePolicy::Minimum );
+        if (i==0)
+        {
+            frames[i]->setStyleSheet("* {border : 1px solid #FF0000;}");
+        }
+        else if (i==1)
+        {
+            frames[i]->setStyleSheet("* {border : 1px solid #00FF00;}");
+        }
+        else if (i==2)
+        {
+            frames[i]->setStyleSheet("* {border : 1px solid #0000FF;}");
+        }
+        views[i]->installEventFilter(this);
+    }
+    frames[3] = new QVTKFrame(viewBody);
+    views[3] = frames[3]->getView();
+    views[3]->setSizePolicy ( QSizePolicy::Minimum, QSizePolicy::Minimum );
+
+    QGridLayout *gridLayout = new QGridLayout(parent);
+    gridLayout->addWidget(frames[2],0,0);
+    gridLayout->addWidget(frames[3],0,1);
+    gridLayout->addWidget(frames[1],1,0);
+    gridLayout->addWidget(frames[0],1,1);
+
+    gridLayout->setColumnStretch ( 0, 0 );
+    gridLayout->setColumnStretch ( 1, 0 );
+    gridLayout->setRowStretch ( 0, 0 );
+    gridLayout->setRowStretch ( 1, 0 );
+
+    viewBody->setLayout(gridLayout);
+    
+    views[0]->SetRenderWindow(riw[0]->GetRenderWindow()); 
+    riw[0]->SetupInteractor(views[0]->GetRenderWindow()->GetInteractor());
+
+    views[1]->SetRenderWindow(riw[1]->GetRenderWindow());
+    riw[1]->SetupInteractor(views[1]->GetRenderWindow()->GetInteractor());
+
+    views[2]->SetRenderWindow(riw[2]->GetRenderWindow());
+    riw[2]->SetupInteractor(views[2]->GetRenderWindow()->GetInteractor());
+
+    for (int i = 0; i < 3; i++)
+    {
+        // make them all share the same reslice cursor object.
+
+        vtkResliceCursorLineRepresentation *rep = vtkResliceCursorLineRepresentation::SafeDownCast(
+                    riw[i]->GetResliceCursorWidget()->GetRepresentation());
+        riw[i]->SetResliceCursor(riw[2]->GetResliceCursor());
+
+        rep->GetResliceCursorActor()->GetCursorAlgorithm()->SetReslicePlaneNormal(i);
+
+        riw[i]->SetInputData(view3d->GetInputAlgorithm(0)->GetImageDataInput(0));
+        riw[i]->SetSliceOrientation(i);
+        riw[i]->SetResliceModeToOblique();
+    }
+
+    outputSpacing = view3d->GetMedVtkImageInfo()->spacing;
+
+    vtkSmartPointer<vtkCellPicker> picker = vtkSmartPointer<vtkCellPicker>::New();
+    picker->SetTolerance(0.005);
+
+    vtkSmartPointer<vtkProperty> ipwProp = vtkSmartPointer<vtkProperty>::New();
+
+    vtkSmartPointer< vtkRenderer > ren = vtkSmartPointer< vtkRenderer >::New();
+
+    views[3]->GetRenderWindow()->AddRenderer(ren);
+    vtkRenderWindowInteractor *iren = views[3]->GetInteractor();
+
+    for (int i = 0; i < 3; i++)
+    {
+        planeWidget[i] = vtkSmartPointer<vtkImagePlaneWidget>::New();
+        planeWidget[i]->SetInteractor( iren );
+        planeWidget[i]->SetPicker(picker);
+        planeWidget[i]->RestrictPlaneToVolumeOn();
+        double color[3] = {0, 0, 0};
+        color[i] = 1;
+        planeWidget[i]->GetPlaneProperty()->SetColor(color);
+
+        color[0] /= 4.0;
+        color[1] /= 4.0;
+        color[2] /= 4.0;
+        riw[i]->GetRenderer()->SetBackground( 0,0,0 );
+
+        planeWidget[i]->SetTexturePlaneProperty(ipwProp);
+        planeWidget[i]->TextureInterpolateOff();
+        planeWidget[i]->SetResliceInterpolateToLinear();
+        planeWidget[i]->SetInputData(view3d->GetInputAlgorithm(0)->GetImageDataInput(0));
+        planeWidget[i]->SetPlaneOrientation(i);
+        planeWidget[i]->SetSliceIndex(imageDims[i]/2);
+        planeWidget[i]->DisplayTextOn();
+        planeWidget[i]->SetDefaultRenderer(ren);
+        planeWidget[i]->On();
+        planeWidget[i]->InteractionOn();
+    }
+
+    vtkSmartPointer<medResliceCursorCallback> cbk = vtkSmartPointer<medResliceCursorCallback>::New();
+    cbk->reformatViewer = this;
+
+    for (int i = 0; i < 3; i++)
+    {
+        riw[i]->GetResliceCursorWidget()->AddObserver(vtkResliceCursorWidget::ResliceAxesChangedEvent, cbk);
+        riw[i]->GetResliceCursorWidget()->AddObserver(vtkResliceCursorWidget::WindowLevelEvent, cbk);
+        riw[i]->GetResliceCursorWidget()->AddObserver(vtkResliceCursorWidget::ResliceThicknessChangedEvent, cbk);
+        riw[i]->GetResliceCursorWidget()->AddObserver(vtkResliceCursorWidget::ResetCursorEvent, cbk);
+        riw[i]->GetInteractorStyle()->AddObserver(vtkCommand::WindowLevelEvent, cbk);
+        riw[i]->GetInteractorStyle()->AddObserver(vtkCommand::MouseMoveEvent, cbk);
+
+        // Make them all share the same color map.
+        riw[i]->SetLookupTable(riw[2]->GetLookupTable());
+        riw[i]->SetColorLevel(view3d->GetColorLevel());
+        riw[i]->SetColorWindow(view3d->GetColorWindow());
+
+        planeWidget[i]->GetColorMap()->SetLookupTable(riw[2]->GetLookupTable());
+        planeWidget[i]->SetColorMap(riw[i]->GetResliceCursorWidget()->GetResliceCursorRepresentation()->GetColorMap());
+    }
+
+    resetViews();
+    applyRadiologicalConvention();
+    updatePlaneNormals();
+
+    planeWidget[0]->GetCurrentRenderer()->ResetCamera();
+    planeWidget[0]->GetCurrentRenderer()->GetActiveCamera()->Azimuth(180);
+    planeWidget[0]->GetCurrentRenderer()->GetActiveCamera()->Roll(180);
+
+    views[0]->show();
+    views[1]->show();
+    views[2]->show();
+
+    selectedView = 2;
+
+    this->initialiseNavigators();
+}
+
+medResliceViewer::~medResliceViewer()
+{
+    for (int i = 0; i < 3; i++)
+    {
+        riw[i] = nullptr;
+        planeWidget[i] = nullptr;
+    }
+}
+
+QString medResliceViewer::identifier() const
+{
+    return "medResliceViewer";
+}
+
+void medResliceViewer::setToolBox(resliceToolBox *tlbx)
+{
+    reformaTlbx = tlbx;
+}
+
+void medResliceViewer::thickMode(int val)
+{
+    for (int i = 0; i < 3; i++)
+    {
+        //TODO : set the axes to the reslicecursorwidget vtkimageReslice .... this will propably solve the problem of disappearance.
+        riw[i]->SetThickMode(val);
+        riw[i]->GetRenderer()->ResetCamera();
+        riw[i]->Render();
+    }
+}
+
+void medResliceViewer::blendMode(int val)
+{
+    if (val)
+    {
+        SetBlendModeToMinIP();
+    }
+}
+
+void medResliceViewer::SetBlendMode(int m)
+{
+    for (int i = 0; i < 3; i++)
+    {
+        vtkImageSlabReslice *thickSlabReslice = vtkImageSlabReslice::SafeDownCast(
+            vtkResliceCursorThickLineRepresentation::SafeDownCast(
+            riw[i]->GetResliceCursorWidget()->GetRepresentation())->GetReslice());
+        thickSlabReslice->SetBlendMode(m);
+        riw[i]->Render();
+    }
+}
+
+void medResliceViewer::SetBlendModeToMaxIP()
+{
+    this->SetBlendMode(VTK_IMAGE_SLAB_MAX);
+}
+
+void medResliceViewer::SetBlendModeToMinIP()
+{
+    this->SetBlendMode(VTK_IMAGE_SLAB_MIN);
+}
+
+void medResliceViewer::SetBlendModeToMeanIP()
+{
+    this->SetBlendMode(VTK_IMAGE_SLAB_MEAN);
+}
+
+void medResliceViewer::reset()
+{
+    resetViews();
+}
+
+void medResliceViewer::resetViews()
+{
+    for (int i = 0; i < 3; i++)
+    {
+        riw[i]->GetRenderer()->ResetCamera();
+    }
+
+    riw[0]->GetRenderer()->GetActiveCamera()->SetViewUp(0, 0, 1);
+    riw[1]->GetRenderer()->GetActiveCamera()->SetViewUp(0, 0, 1);
+    riw[2]->GetRenderer()->GetActiveCamera()->SetViewUp(0, -1, 0);
+}
+
+void medResliceViewer::render()
+{
+    for (int i = 0; i < 3; i++)
+    {
+        riw[i]->Render();
+        views[i]->GetRenderWindow()->Render();
+    }
+}
+
+void medResliceViewer::saveImage()
+{
+    vtkSmartPointer<vtkMatrix4x4> resliceMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+    calculateResliceMatrix(resliceMatrix);
+
+    vtkImageReslice *reslicerTop = vtkImageReslice::New();
+   reslicerTop->SetInputData(view3d->GetInputAlgorithm(0)->GetInput());
+    reslicerTop->AutoCropOutputOn();
+    reslicerTop->SetResliceAxes(resliceMatrix);
+    reslicerTop->SetBackgroundLevel(riw[0]->GetInput()->GetScalarRange()[0]); // todo: set the background value in an automatic way.
+
+    // Apply resampling in mm
+
+    if (reformaTlbx->findChild<QComboBox*>("bySpacingOrDimension")->currentText() == "Spacing")
+    {
+        reslicerTop->SetOutputSpacing(outputSpacing);
+    }
+    reslicerTop->SetInterpolationModeToLinear();
+
+    // Apply orientation changes
+    switch (view3d->GetMedVtkImageInfo()->scalarType)
+    {
+    case VTK_CHAR:
+        generateOutput<char>(reslicerTop, "itkDataImageChar3");
+        break;
+    case VTK_UNSIGNED_CHAR:
+        generateOutput<unsigned char>(reslicerTop, "itkDataImageUChar3");
+        break;
+    case VTK_SHORT:
+        generateOutput<short>(reslicerTop, "itkDataImageShort3");
+        break;
+    case VTK_UNSIGNED_SHORT:
+        generateOutput<unsigned short>(reslicerTop, "itkDataImageUShort3");
+        break;
+    case VTK_INT:
+        generateOutput<int>(reslicerTop, "itkDataImageInt3");
+        break;
+    case VTK_UNSIGNED_INT:
+        generateOutput<unsigned int>(reslicerTop, "itkDataImageUInt3");
+        break;
+    case VTK_LONG:
+        generateOutput<long>(reslicerTop, "itkDataImageLong3");
+        break;
+    case VTK_UNSIGNED_LONG:
+        generateOutput<unsigned long>(reslicerTop, "itkDataImageULong3");
+        break;
+    case VTK_FLOAT:
+        generateOutput<float>(reslicerTop, "itkDataImageFloat3");
+        break;
+    case VTK_DOUBLE:
+        generateOutput<double>(reslicerTop, "itkDataImageDouble3");
+        break;
+    }
+
+    emit imageReformatedGenerated();
+}
+
+void medResliceViewer::thickSlabChanged(double val)
+{
+    QDoubleSpinBox * spinBoxSender = qobject_cast<QDoubleSpinBox*>(QObject::sender());
+
+    if (spinBoxSender)
+    {
+        double x,y,z;
+        riw[2]->GetResliceCursor()->GetThickness(x,y,z);
+
+        if (spinBoxSender->accessibleName()=="SpacingX")
+        {
+            if (reformaTlbx->findChild<QComboBox*>("bySpacingOrDimension")->currentText() == "Spacing")
+            {
+                riw[0]->GetResliceCursor()->SetThickness(val,y,z); //the three windows share the same reslice cursor
+            }
+            outputSpacing[0]=val;
+        }
+
+        if (spinBoxSender->accessibleName()=="SpacingY")
+        {
+            if (reformaTlbx->findChild<QComboBox*>("bySpacingOrDimension")->currentText() == "Spacing")
+            {
+                riw[0]->GetResliceCursor()->SetThickness(x,val,z); //the three windows share the same reslice cursor
+            }
+            outputSpacing[1]=val;
+        }
+
+        if (spinBoxSender->accessibleName()=="SpacingZ")
+        {
+            if (reformaTlbx->findChild<QComboBox*>("bySpacingOrDimension")->currentText() == "Spacing")
+            {
+                riw[0]->GetResliceCursor()->SetThickness(x,y,val); //the three windows share the same reslice cursor
+            }
+            outputSpacing[2]=val;
+        }
+        this->render();
+    }
+}
+
+void medResliceViewer::extentChanged(int val)
+{
+    medSliderSpinboxPair * pairSender = qobject_cast<medSliderSpinboxPair*>(QObject::sender());
+
+    if (pairSender)
+    {
+        if (pairSender->accessibleName()=="fromSlice")
+        {
+            fromSlice = pairSender->value();
+        }
+        if (pairSender->accessibleName()=="toSlice")
+        {
+            toSlice = pairSender->value();
+        }
+    }
+}
+
+bool medResliceViewer::eventFilter(QObject * object,QEvent * event)
+{
+    if (!qobject_cast<QVTKWidget*>(object))
+    {
+        return true;
+    }
+
+    if (event->type()==QEvent::FocusIn)
+    {
+        for(int i = 0;i<3;i++)
+        {
+            if (views[i]==object)
+            {
+                if (i==0)
+                {
+                    frames[i]->setStyleSheet("QFrame {border : 5px solid #FF0000;}");
+                }
+                else if (i==1)
+                {
+                    frames[i]->setStyleSheet("QFrame {border : 5px solid #00FF00;}");
+                }
+                else if (i==2)
+                {
+                    frames[i]->setStyleSheet("QFrame {border : 5px solid #0000FF;}");
+                }
+
+                if (selectedView==0)
+                {
+                    frames[0]->setStyleSheet("* {border : 1px solid #FF0000;}");
+                }
+                else if (selectedView==1)
+                {
+                    frames[1]->setStyleSheet("* {border : 1px solid #00FF00;}");
+                }
+                else if (selectedView==2)
+                {
+                    frames[2]->setStyleSheet("* {border : 1px solid #0000FF;}");
+                }
+                selectedView = i;
+            }
+        }
+        return false;
+    }
+    if (event->type() == QEvent::FocusOut)
+    {
+        return false;
+    }
+    return false;
+}
+
+vtkResliceImageViewer* medResliceViewer::getResliceImageViewer(int i)
+{
+    assert(0 <= i <= 3);
+
+    return riw[i];
+}
+
+vtkImagePlaneWidget* medResliceViewer::getImagePlaneWidget(int i)
+{
+    assert(0 <= i <= 3);
+
+    return planeWidget[i];
+}
+
+dtkSmartPointer<medAbstractData> medResliceViewer::getOutput()
+{
+    if (!outputData)
+    {
+        blockSignals(true);
+        saveImage();
+        blockSignals(false);
+    }
+    return outputData;
+}
+
+void medResliceViewer::applyRadiologicalConvention()
+{
+    double normal[3];
+
+    getResliceImageViewer(0)->GetResliceCursorWidget()->GetResliceCursorRepresentation()->GetResliceCursor()->GetPlane(2)->GetNormal(normal);
+    for (int i = 0; i < 3; i++)
+    {
+        normal[i] = -normal[i];
+    }
+    getResliceImageViewer(0)->GetResliceCursorWidget()->GetResliceCursorRepresentation()->GetResliceCursor()->GetPlane(2)->SetNormal(normal);
+    getResliceImageViewer(0)->GetResliceCursorWidget()->GetResliceCursorRepresentation()->GetResliceCursor()->Update();
+    for (int i = 0; i < 3; i++)
+    {
+        getResliceImageViewer(i)->GetResliceCursorWidget()->Render();
+    }
+    getImagePlaneWidget(0)->GetInteractor()->GetRenderWindow()->Render();
+}
+
+void medResliceViewer::calculateResliceMatrix(vtkMatrix4x4* result)
+{
+    double resliceX[3], resliceY[3], resliceZ[3], resliceOrigin[3], outputOrigin[3];
+    double *outputX, *outputY, *outputZ;
+
+    riw[0]->GetResliceCursor()->GetXAxis(resliceX);
+    riw[0]->GetResliceCursor()->GetYAxis(resliceY);
+    riw[0]->GetResliceCursor()->GetZAxis(resliceZ);
+    riw[0]->GetResliceCursor()->GetCenter(resliceOrigin);
+
+    switch (selectedView)
+    {
+    case 0:
+        outputX = resliceY;
+        outputY = resliceZ;
+        outputZ = resliceX;
+        outputOrigin[0] = resliceOrigin[1];
+        outputOrigin[1] = resliceOrigin[2];
+        outputOrigin[2] = resliceOrigin[0];
+        break;
+    case 1:
+        outputX = resliceZ;
+        outputY = resliceX;
+        outputZ = resliceY;
+        outputOrigin[0] = resliceOrigin[2];
+        outputOrigin[1] = resliceOrigin[0];
+        outputOrigin[2] = resliceOrigin[1];
+        break;
+    default:
+        outputX = resliceX;
+        outputY = resliceY;
+        outputZ = resliceZ;
+        outputOrigin[0] = resliceOrigin[0];
+        outputOrigin[1] = resliceOrigin[1];
+        outputOrigin[2] = resliceOrigin[2];
+        break;
+    }
+
+    result->Identity();
+    for (int i = 0; i < 3; i++)
+    {
+        result->SetElement(i, 0, outputX[i]);
+        result->SetElement(i, 1, outputY[i]);
+        result->SetElement(i, 2, outputZ[i]);
+        result->SetElement(i, 3, outputOrigin[i]);
+    }
+
+    adjustResliceMatrixToViewUp(result);
+}
+
+void medResliceViewer::adjustResliceMatrixToViewUp(vtkMatrix4x4* resliceMatrix)
+{
+    double dotX, dotY, X[3], Y[3], viewUp[3];
+
+    for (int i = 0; i < 3; i++)
+    {
+        X[i] = resliceMatrix->GetElement(i, 0);
+        Y[i] = resliceMatrix->GetElement(i, 1);
+    }
+
+    riw[selectedView]->GetRenderer()->GetActiveCamera()->GetViewUp(viewUp);
+
+    dotX = vtkMath::Dot(viewUp, X);
+    dotY = vtkMath::Dot(viewUp, Y);
+
+    if (std::abs(dotY) > std::abs(dotX))
+    {
+        if (dotY < 0)
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                resliceMatrix->SetElement(i, 0, -X[i]);
+                resliceMatrix->SetElement(i, 1, -Y[i]);
+            }
+        }
+    }
+    else
+    {
+        if (dotX < 0)
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                resliceMatrix->SetElement(i, 0, Y[i]);
+                resliceMatrix->SetElement(i, 1, -X[i]);
+            }
+        }
+        else
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                resliceMatrix->SetElement(i, 0, -Y[i]);
+                resliceMatrix->SetElement(i, 1, X[i]);
+            }
+        }
+    }
+}
+
+void medResliceViewer::updatePlaneNormals()
+{
+    for (int i = 0; i < 3; i++)
+    {
+        double* normal = getResliceImageViewer(0)->GetResliceCursor()->GetPlane(i)->GetNormal();
+        std::copy(normal, normal + 3, planeNormal[i]);
+    }
+}
+
+// The two fixed planes must be moved so that they stay orthogonal to the moving plane
+void medResliceViewer::ensureOrthogonalPlanes()
+{
+    int movingPlaneIndex = findMovingPlaneIndex();
+    vtkPlane* movingPlane = getResliceImageViewer(0)->GetResliceCursor()->GetPlane(movingPlaneIndex);
+    vtkPlane* fixedPlane1 = getResliceImageViewer(0)->GetResliceCursor()->GetPlane((movingPlaneIndex + 1) % 3);
+    vtkPlane* fixedPlane2 = getResliceImageViewer(0)->GetResliceCursor()->GetPlane((movingPlaneIndex + 2) % 3);
+
+    makePlaneOrthogonalToOtherPlanes(fixedPlane1, movingPlane, fixedPlane2);
+    makePlaneOrthogonalToOtherPlanes(fixedPlane2, movingPlane, fixedPlane1);
+    updatePlaneNormals();
+}
+
+// The plane who's normal has changed the most is the currently moving plane.
+int medResliceViewer::findMovingPlaneIndex()
+{
+    int movingPlaneIndex = 0;
+    double maxNormalDifference = -1;
+
+    for (int i = 0; i < 3; i++)
+    {
+        vtkPlane* plane = getResliceImageViewer(0)->GetResliceCursor()->GetPlane(i);
+        double* currentNormal = plane->GetNormal();
+        double normalDifference = 0;
+        for (int j = 0; j < 3; j++)
+        {
+            normalDifference += pow(planeNormal[i][j] - currentNormal[j], 2);
+        }
+        if (normalDifference > maxNormalDifference)
+        {
+            maxNormalDifference = normalDifference;
+            movingPlaneIndex = i;
+        }
+    }
+
+    return movingPlaneIndex;
+}
+
+void medResliceViewer::makePlaneOrthogonalToOtherPlanes(vtkPlane* targetPlane, vtkPlane* plane1, vtkPlane* plane2)
+{
+    double idealNormal[3];
+
+    vtkMath::Cross(plane1->GetNormal(), plane2->GetNormal(), idealNormal);
+    vtkMath::Normalize(idealNormal);
+
+    // Make sure the ideal normal is on the same side as the current normal
+    if (vtkMath::Dot(targetPlane->GetNormal(), idealNormal) < 0)
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            idealNormal[i] = -idealNormal[i];
+        }
+    }
+    targetPlane->SetNormal(idealNormal);
+}
+
+template <typename DATA_TYPE>
+void medResliceViewer::generateOutput(vtkImageReslice* reslicer, QString destType)
+{
+    typedef itk::Image<DATA_TYPE, 3> ImageType;
+
+    typedef itk::VTKImageToImageFilter<ImageType> FilterType;
+    typename FilterType::Pointer filter = FilterType::New();
+    filter->SetInput(reslicer->GetOutput());
+    filter->Update();
+    filter->GetOutput()->Update();
+
+    outputData = medAbstractDataFactory::instance()->createSmartPointer(destType);
+    outputData->setData(filter->GetOutput());
+
+    // Apply resampling in pix
+    if (reformaTlbx->findChild<QComboBox*>("bySpacingOrDimension")->currentText() == "Dimension")
+    {
+        applyResamplingPix();
+    }
+
+    typename ImageType::Pointer outputImage = static_cast<itk::Image<DATA_TYPE, 3>*>(outputData->data());
+
+    compensateForRadiologicalView<DATA_TYPE>(outputImage);
+    correctOutputTransform<DATA_TYPE>(outputImage, reslicer->GetResliceAxes());
+
+    // Final output image
+    outputData->setData(outputImage);
+
+    medUtilities::setDerivedMetaData(outputData, inputData, "reformatted");
+    medUtilitiesITK::updateMetadata<ImageType>(outputData);
+}
+
+void medResliceViewer::applyResamplingPix()
+{
+    resampleProcess* resamplePr = new resampleProcess();
+    resamplePr->setInput(outputData);
+    resamplePr->setParameter(outputSpacing[0],0);
+    resamplePr->setParameter(outputSpacing[1],1);
+    resamplePr->setParameter(outputSpacing[2],2);
+    resamplePr->update();
+
+    outputData = resamplePr->output();
+    delete resamplePr;
+}
+
+template <typename DATA_TYPE>
+void medResliceViewer::compensateForRadiologicalView(itk::Image<DATA_TYPE, 3>* outputImage)
+{
+    vtkSmartPointer<vtkMatrix4x4> transformMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+    mscTransform::getTransform(*outputImage, *transformMatrix);
+    for (int i = 0; i < 3; i++)
+    {
+        transformMatrix->SetElement(i, 1, -transformMatrix->GetElement(i, 1));
+        transformMatrix->SetElement(i, 2, -transformMatrix->GetElement(i, 2));
+    }
+    mscTransform::setTransform(*outputImage, *transformMatrix);
+}
+
+/*
+ * The new image "contains" a rotated version of the initial image.
+ * The corrective transformation is composed of the following :
+ * 1. Inverse of the output image transformation. This places the image with it's origin at (0, 0, 0)
+ * and its axes aligned with the world axes.
+ * 2. Translate the image so that its center is at (0, 0, 0). This places the center of rotation at
+ * the center of the image.
+ * 3. Rotate the image by the reslice rotation. This aligns the initial image with the world axes.
+ * 4. Translate the image so the initial origin is at (0, 0, 0).
+ * 5. Apply the initial transformation (the one it had before the reslice)
+*/
+template <typename DATA_TYPE>
+void medResliceViewer::correctOutputTransform(itk::Image<DATA_TYPE, 3>* outputImage, vtkMatrix4x4* resliceMatrix)
+{
+    typedef itk::Image<DATA_TYPE, 3> ImageType;
+    typename ImageType::Pointer inputImage = static_cast<ImageType*>(inputData->data());
+
+    vtkSmartPointer<vtkMatrix4x4> inputTransformMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+    vtkSmartPointer<vtkMatrix4x4> outputInverseTransformMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+    mscTransform::getTransform<DATA_TYPE>(*inputImage, *inputTransformMatrix);
+    mscTransform::getTransform<DATA_TYPE>(*outputImage, *outputInverseTransformMatrix);
+    outputInverseTransformMatrix->Invert();
+
+    double inputCenter[3], outputCenter[3];
+    getImageCenterInLocalSpace<DATA_TYPE>(inputImage, inputCenter);
+    getImageCenterInLocalSpace<DATA_TYPE>(outputImage, outputCenter);
+
+    vtkSmartPointer<vtkTransform> transform = vtkSmartPointer<vtkTransform>::New();
+    transform->PostMultiply();
+    transform->Concatenate(outputInverseTransformMatrix);
+    transform->Translate(-outputCenter[0], -outputCenter[1], -outputCenter[2]);
+    transform->Concatenate(getResliceRotationMatrix(resliceMatrix));
+    transform->Translate(inputCenter[0], inputCenter[1], inputCenter[2]);
+    transform->Concatenate(inputTransformMatrix);
+
+    mscTransform::applyTransform<DATA_TYPE>(*outputImage, *transform->GetMatrix());
+}
+
+template <typename DATA_TYPE>
+void medResliceViewer::getImageCenterInLocalSpace(itk::Image<DATA_TYPE, 3>* image, double center[3])
+{
+    typedef itk::Image<DATA_TYPE, 3> ImageType;
+    typename ImageType::SizeType size;
+    typename ImageType::SpacingType spacing;
+
+    size = image->GetLargestPossibleRegion().GetSize();
+    spacing = image->GetSpacing();
+
+    for (int i = 0; i < 3; i++)
+    {
+        center[i] = 0.5 * (size[i] - 1) * spacing[i];
+    }
+}
+
+vtkSmartPointer<vtkMatrix4x4> medResliceViewer::getResliceRotationMatrix(vtkMatrix4x4* resliceMatrix)
+{
+    vtkSmartPointer<vtkMatrix4x4> resliceRotationMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+
+    resliceRotationMatrix->DeepCopy(resliceMatrix);
+    for (int i = 0; i < 3; i++)
+    {
+        resliceRotationMatrix->SetElement(i, 3, 0);
+    }
+
+    return resliceRotationMatrix;
+}
+
+QString medResliceViewer::description() const
+{
+    return QString("");
+}
+
+medViewBackend * medResliceViewer::backend() const
+{
+    return nullptr;
+}
+
+QWidget* medResliceViewer::navigatorWidget()
+{
+    return nullptr;
+}
+
+QWidget *medResliceViewer::viewWidget()
+{
+    return viewBody;
+}
+
+QWidget *medResliceViewer::mouseInteractionWidget()
+{
+    return nullptr;
+}
+
+QImage medResliceViewer::buildThumbnail(const QSize &size)
+{
+    return QImage();
+}

--- a/src/plugins/legacy/reformat/medResliceViewer.h
+++ b/src/plugins/legacy/reformat/medResliceViewer.h
@@ -20,7 +20,7 @@
 
 #include <QFrame>
 #include <QHBoxLayout>
-#include <QVTKWidget.h>
+#include <QVTKOpenGLWidget.h>
 
 #include <resliceToolBox.h>
 
@@ -35,7 +35,7 @@ public:
     QVTKFrame(QWidget *parent) : QFrame(parent)
     {
         QHBoxLayout *layout = new QHBoxLayout(this);
-        view = new QVTKWidget(this);
+        view = new QVTKOpenGLWidget(this);
         layout->addWidget(view);
         this->setLayout(layout);
     }
@@ -45,13 +45,13 @@ public:
         delete view;
     }
 
-    QVTKWidget * getView()
+    QVTKOpenGLWidget * getView()
     {
         return view;
     }
 
 private:
-    QVTKWidget *view;
+    QVTKOpenGLWidget *view;
 
 };
 
@@ -112,7 +112,7 @@ protected:
     vtkSmartPointer<vtkImagePlaneWidget> planeWidget[3];
     double planeNormal[3][3];
     QWidget *viewBody;
-    QVTKWidget *views[4];
+    QVTKOpenGLWidget *views[4];
     QVTKFrame *frames[4];
     dtkSmartPointer<medAbstractData> inputData;
     double *outputSpacing;

--- a/src/plugins/legacy/reformat/medResliceViewer.h
+++ b/src/plugins/legacy/reformat/medResliceViewer.h
@@ -18,8 +18,6 @@
 
 #include <medAbstractView.h>
 
-#include <QFrame>
-#include <QHBoxLayout>
 #include <QVTKOpenGLWidget.h>
 
 #include <resliceToolBox.h>
@@ -29,40 +27,10 @@
 #include <vtkResliceImageViewer.h>
 #include <vtkSmartPointer.h>
 
-class QVTKFrame : public QFrame
-{
-public:
-    QVTKFrame(QWidget *parent) : QFrame(parent)
-    {
-        QHBoxLayout *layout = new QHBoxLayout(this);
-
-        view = new QVTKOpenGLWidget(this);
-        view->setEnableHiDPI(true);
-
-        layout->addWidget(view);
-        this->setLayout(layout);
-    }
-
-    ~QVTKFrame()
-    {
-        delete view;
-    }
-
-    QVTKOpenGLWidget * getView()
-    {
-        return view;
-    }
-
-private:
-    QVTKOpenGLWidget *view;
-
-};
-
 class medResliceCursorCallback;
 
 class medResliceViewer : public medAbstractView
 {
-
     friend class medResliceCursorCallback;
 
     Q_OBJECT
@@ -116,7 +84,6 @@ protected:
     double planeNormal[3][3];
     QWidget *viewBody;
     QVTKOpenGLWidget *views[4];
-    QVTKFrame *frames[4];
     dtkSmartPointer<medAbstractData> inputData;
     double *outputSpacing;
     unsigned char selectedView;

--- a/src/plugins/legacy/reformat/medResliceViewer.h
+++ b/src/plugins/legacy/reformat/medResliceViewer.h
@@ -1,0 +1,150 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#pragma once
+
+#include <dtkCoreSupport/dtkSmartPointer.h>
+#include <itkImage.h>
+#include <medAbstractView.h>
+#include <QFrame>
+#include <QHBoxLayout>
+#include <QVTKWidget.h>
+#include <resliceToolBox.h>
+#include <vtkImageData.h>
+#include <vtkImagePlaneWidget.h>
+#include <vtkResliceImageViewer.h>
+#include <vtkSmartPointer.h>
+#include <vtkMatrix4x4.h>
+#include <vtkImageView3D.h>
+
+class QVTKFrame : public QFrame
+{
+public:
+    QVTKFrame(QWidget * parent):QFrame(parent)
+    {
+        QHBoxLayout * layout = new QHBoxLayout(this);
+        view = new QVTKWidget(this);
+        layout->addWidget(view);
+        this->setLayout(layout);
+    }
+
+    ~QVTKFrame()
+    {
+        delete view;
+    }
+
+    QVTKWidget * getView()
+    {
+        return view;
+    }
+
+private:
+    QVTKWidget * view;
+
+};
+
+class medResliceCursorCallback;
+
+class medResliceViewer : public medAbstractView
+{
+
+    friend class medResliceCursorCallback;
+
+    Q_OBJECT
+
+public:
+
+    medResliceViewer(medAbstractView *view, QWidget *parent = nullptr);
+    ~medResliceViewer();
+    virtual QString identifier() const;
+    void setToolBox(resliceToolBox *);
+
+    virtual QString description() const;
+
+    virtual medViewBackend * backend() const;
+
+    virtual QWidget* navigatorWidget();
+    virtual QWidget *viewWidget();
+    virtual QWidget *mouseInteractionWidget();
+
+public slots:
+
+    virtual void thickMode(int);
+    virtual void blendMode(int);
+    virtual void SetBlendModeToMaxIP();
+    virtual void SetBlendModeToMinIP();
+    virtual void SetBlendModeToMeanIP();
+    virtual void SetBlendMode(int);
+    virtual void reset();
+    virtual void resetViews();
+    virtual void render();
+
+    void saveImage();
+    void thickSlabChanged(double);
+    void extentChanged(int);
+    bool eventFilter(QObject *object, QEvent *event);
+
+    vtkResliceImageViewer* getResliceImageViewer(int i);
+    vtkImagePlaneWidget* getImagePlaneWidget(int i);
+    dtkSmartPointer<medAbstractData> getOutput();
+
+    virtual void update(){}
+
+signals:
+
+    void imageReformatedGenerated();
+
+protected:
+
+    vtkSmartPointer<vtkResliceImageViewer> riw[3];
+    vtkSmartPointer<vtkImagePlaneWidget> planeWidget[3];
+    double planeNormal[3][3];
+    QWidget *viewBody;
+    QVTKWidget *views[4];
+    QVTKFrame *frames[4];
+    dtkSmartPointer<medAbstractData> inputData;
+    double *outputSpacing;
+    unsigned char selectedView;
+    vtkImageView3D *view3d;
+    dtkSmartPointer<medAbstractData> outputData;
+    int fromSlice, toSlice;
+    resliceToolBox *reformaTlbx;
+
+    void applyRadiologicalConvention();
+    void calculateResliceMatrix(vtkMatrix4x4* result);
+    void adjustResliceMatrixToViewUp(vtkMatrix4x4* resliceMatrix);
+    void updatePlaneNormals();
+    void ensureOrthogonalPlanes();
+    int findMovingPlaneIndex();
+    void makePlaneOrthogonalToOtherPlanes(vtkPlane* targetPlane, vtkPlane* plane1, vtkPlane* plane2);
+
+    template <typename DATA_TYPE>
+    void generateOutput(vtkImageReslice* reslicer, QString destType);
+
+    void applyResamplingPix();
+
+    template <typename DATA_TYPE>
+    void compensateForRadiologicalView(itk::Image<DATA_TYPE, 3>* image);
+
+    template <typename DATA_TYPE>
+    void correctOutputTransform(itk::Image<DATA_TYPE, 3>* outputImage, vtkMatrix4x4* resliceMatrix);
+
+    template <typename DATA_TYPE>
+    void getImageCenterInLocalSpace(itk::Image<DATA_TYPE, 3>* image, double center[3]);
+
+    vtkSmartPointer<vtkMatrix4x4> getResliceRotationMatrix(vtkMatrix4x4* resliceMatrix);
+
+private:
+
+    virtual QImage buildThumbnail(const QSize &size);
+
+};

--- a/src/plugins/legacy/reformat/medResliceViewer.h
+++ b/src/plugins/legacy/reformat/medResliceViewer.h
@@ -35,7 +35,10 @@ public:
     QVTKFrame(QWidget *parent) : QFrame(parent)
     {
         QHBoxLayout *layout = new QHBoxLayout(this);
+
         view = new QVTKOpenGLWidget(this);
+        view->setEnableHiDPI(true);
+
         layout->addWidget(view);
         this->setLayout(layout);
     }

--- a/src/plugins/legacy/reformat/medResliceViewer.h
+++ b/src/plugins/legacy/reformat/medResliceViewer.h
@@ -13,25 +13,28 @@
 #pragma once
 
 #include <dtkCoreSupport/dtkSmartPointer.h>
+
 #include <itkImage.h>
+
 #include <medAbstractView.h>
+
 #include <QFrame>
 #include <QHBoxLayout>
 #include <QVTKWidget.h>
+
 #include <resliceToolBox.h>
-#include <vtkImageData.h>
+
 #include <vtkImagePlaneWidget.h>
+#include <vtkImageView3D.h>
 #include <vtkResliceImageViewer.h>
 #include <vtkSmartPointer.h>
-#include <vtkMatrix4x4.h>
-#include <vtkImageView3D.h>
 
 class QVTKFrame : public QFrame
 {
 public:
-    QVTKFrame(QWidget * parent):QFrame(parent)
+    QVTKFrame(QWidget *parent) : QFrame(parent)
     {
-        QHBoxLayout * layout = new QHBoxLayout(this);
+        QHBoxLayout *layout = new QHBoxLayout(this);
         view = new QVTKWidget(this);
         layout->addWidget(view);
         this->setLayout(layout);
@@ -48,7 +51,7 @@ public:
     }
 
 private:
-    QVTKWidget * view;
+    QVTKWidget *view;
 
 };
 

--- a/src/plugins/legacy/reformat/reformatPlugin.cpp
+++ b/src/plugins/legacy/reformat/reformatPlugin.cpp
@@ -1,0 +1,71 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2019. All rights reserved.
+ See LICENSE.txt for details.
+ 
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#include <medCropToolBox.h>
+#include "medReformatWorkspace.h"
+#include "reformatPlugin.h"
+#include <resliceToolBox.h>
+#include <resampleProcess.h>
+
+reformatPlugin::reformatPlugin(QObject *parent) : medPluginLegacy(parent)
+{
+}
+
+bool reformatPlugin::initialize()
+{
+    if(!medReformatWorkspace::registered())
+    {
+        qWarning() << "Unable to register medReformatWorkspace type";
+    }
+    if (!resliceToolBox::registered())
+    {
+        qWarning() << "Unable to register resliceToolBox type";
+    }
+    if (!medCropToolBox::registered())
+    {
+        qWarning() << "Unable to register medCropToolBox type";
+    }
+    if (!resampleProcess::registered())
+    {
+        qWarning() << "Unable to register resample process";
+    }
+    return true;
+}
+
+QString reformatPlugin::description() const
+{
+  QString description = \
+          "This plugin implements two toolboxes: \
+          <br><h5>Cropping</h5><br>  \
+          Crop a volume into a smaller one. \
+          <br><h5>Reslice</h5><br>  \
+          Reorient a volume, change its spacing or dimension. \
+          <br><br>This plugin uses the <a href=\"https://itk.org/\" style=\"color: #cc0000\" >ITK</a> \
+          and <a href=\"https://www.vtk.org/\" style=\"color: #cc0000\" >VTK</a> libraries.";
+  return description;
+}
+
+QString reformatPlugin::name() const
+{
+    return "Reformat";
+}
+
+QString reformatPlugin::version() const
+{
+    return REFORMATPLUGIN_VERSION;
+}
+
+QStringList reformatPlugin::types() const
+{
+    return QStringList() << "medReformatWorkspace" << "medCropToolBox" << "resliceToolBox" << "resampleProcess";
+}

--- a/src/plugins/legacy/reformat/reformatPlugin.cpp
+++ b/src/plugins/legacy/reformat/reformatPlugin.cpp
@@ -12,8 +12,9 @@
 =========================================================================*/
 
 #include <medCropToolBox.h>
-#include "medReformatWorkspace.h"
-#include "reformatPlugin.h"
+#include <medReformatWorkspace.h>
+
+#include <reformatPlugin.h>
 #include <resliceToolBox.h>
 #include <resampleProcess.h>
 

--- a/src/plugins/legacy/reformat/reformatPlugin.h
+++ b/src/plugins/legacy/reformat/reformatPlugin.h
@@ -1,0 +1,33 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2019. All rights reserved.
+ See LICENSE.txt for details.
+ 
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#pragma once
+
+#include <medPluginLegacy.h>
+#include "reformatPluginExport.h"
+
+class REFORMATPLUGIN_EXPORT reformatPlugin : public medPluginLegacy
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "fr.inria.reformatPlugin" FILE "reformatPlugin.json")
+    Q_INTERFACES(dtkPlugin)
+
+public:
+    reformatPlugin(QObject *parent = nullptr);
+    virtual bool initialize();
+
+    virtual QString description() const;
+    virtual QString name() const;
+    virtual QString version() const;
+    virtual QStringList types() const;
+};

--- a/src/plugins/legacy/reformat/reformatPlugin.h
+++ b/src/plugins/legacy/reformat/reformatPlugin.h
@@ -14,7 +14,7 @@
 #pragma once
 
 #include <medPluginLegacy.h>
-#include "reformatPluginExport.h"
+#include <reformatPluginExport.h>
 
 class REFORMATPLUGIN_EXPORT reformatPlugin : public medPluginLegacy
 {

--- a/src/plugins/legacy/reformat/reformatPlugin.json
+++ b/src/plugins/legacy/reformat/reformatPlugin.json
@@ -1,0 +1,5 @@
+{
+            "name" : "reformatPlugin",
+         "version" : "0.0.1",
+    "dependencies" : []
+}

--- a/src/plugins/legacy/reformat/reformatPluginExport.h
+++ b/src/plugins/legacy/reformat/reformatPluginExport.h
@@ -1,0 +1,26 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2019. All rights reserved.
+ See LICENSE.txt for details.
+ 
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#pragma once
+
+#ifdef WIN32
+    #ifdef reformatPlugin_EXPORTS
+        #define REFORMATPLUGIN_EXPORT __declspec(dllexport) 
+    #else
+        #define REFORMATPLUGIN_EXPORT __declspec(dllimport) 
+    #endif
+#else
+    #define REFORMATPLUGIN_EXPORT
+#endif
+
+

--- a/src/plugins/legacy/reformat/resampleProcess.cpp
+++ b/src/plugins/legacy/reformat/resampleProcess.cpp
@@ -60,14 +60,17 @@ resampleProcess::~resampleProcess(void)
     delete d;
     d = nullptr;
 }
+
 bool resampleProcess::registered(void)
 {
     return dtkAbstractProcessFactory::instance()->registerProcessType("resampleProcess", createResampleProcess);
 }
+
 QString resampleProcess::description(void) const
 {
     return "resampleProcess";
 }
+
 void resampleProcess::setInput ( medAbstractData *data)
 {
     if ( data )
@@ -86,13 +89,13 @@ void resampleProcess::setParameter ( double data, int channel)
     switch (channel)
     {
     case 0:
-        d->dimX = (int)data;
+        d->dimX = static_cast<int>(data);
         break;
     case 1:
-        d->dimY = (int)data;
+        d->dimY = static_cast<int>(data);
         break;
     case 2:
-        d->dimZ = (int)data;
+        d->dimZ = static_cast<int>(data);
         break;
     case 3:
         d->spacingX = data;
@@ -136,16 +139,16 @@ int resampleProcess::resample(medAbstractData* inputData)
 
     typename ResampleFilterType::Pointer resampleFilter = ResampleFilterType::New();
     
-    //// Fetch original image size.
+    // Fetch original image size.
     const typename ImageType::RegionType& inputRegion = inputImage->GetLargestPossibleRegion();
     const typename ImageType::SizeType& vnInputSize = inputRegion.GetSize();
     unsigned int nOldX = vnInputSize[0];
     unsigned int nOldY = vnInputSize[1];
     unsigned int nOldZ = vnInputSize[2];
 
-    //// Fetch original image spacing.
+    // Fetch original image spacing.
     const typename ImageType::SpacingType& vfInputSpacing = inputImage->GetSpacing();
-    double vfOutputSpacing[3]={d->spacingX,d->spacingY,d->spacingZ};
+    double vfOutputSpacing[3] = {d->spacingX,d->spacingY,d->spacingZ};
     if (d->dimX || d->dimY || d->dimZ)
     {
         vfOutputSpacing[0] = vfInputSpacing[0] * (double) nOldX / (double) d->dimX;
@@ -170,6 +173,7 @@ int resampleProcess::resample(medAbstractData* inputData)
     resampleFilter->SetOutputOrigin( inputImage->GetOrigin() );
     resampleFilter->SetOutputDirection(inputImage->GetDirection() );
     resampleFilter->UpdateLargestPossibleRegion();
+
     d->output = medAbstractDataFactory::instance()->create(inputData->identifier());
     d->output->setData(resampleFilter->GetOutput());
 
@@ -180,7 +184,7 @@ int resampleProcess::resample(medAbstractData* inputData)
 
 medAbstractData * resampleProcess::output ( void )
 {
-    return ( d->output );
+    return d->output;
 }
 
 // /////////////////////////////////////////////////////////////////

--- a/src/plugins/legacy/reformat/resampleProcess.cpp
+++ b/src/plugins/legacy/reformat/resampleProcess.cpp
@@ -10,16 +10,19 @@
   PURPOSE.
 
 =========================================================================*/
-#include "resampleProcess.h"
+
 #include <dtkCoreSupport/dtkAbstractProcessFactory.h>
-#include <medAbstractDataFactory.h>
-#include <medAbstractProcess.h>
-#include <medMetaDataKeys.h>
-#include <medUtilitiesITK.h>
 
 #include <itkResampleImageFilter.h>
 #include <itkBSplineInterpolateImageFunction.h>
+
+#include <medAbstractDataFactory.h>
+#include <medAbstractProcess.h>
+#include <medMetaDataKeys.h>
 #include <medUtilities.h>
+#include <medUtilitiesITK.h>
+
+#include <resampleProcess.h>
 
 // /////////////////////////////////////////////////////////////////
 // resampleProcessPrivate

--- a/src/plugins/legacy/reformat/resampleProcess.cpp
+++ b/src/plugins/legacy/reformat/resampleProcess.cpp
@@ -1,0 +1,189 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include "resampleProcess.h"
+#include <dtkCoreSupport/dtkAbstractProcessFactory.h>
+#include <medAbstractDataFactory.h>
+#include <medAbstractProcess.h>
+#include <medMetaDataKeys.h>
+#include <medUtilitiesITK.h>
+
+#include <itkResampleImageFilter.h>
+#include <itkBSplineInterpolateImageFunction.h>
+#include <medUtilities.h>
+
+// /////////////////////////////////////////////////////////////////
+// resampleProcessPrivate
+// /////////////////////////////////////////////////////////////////
+class resampleProcessPrivate
+{
+public:
+    resampleProcess *parent;
+    resampleProcessPrivate(resampleProcess *p)
+    {
+        parent = p;
+    }
+    medAbstractData* input;
+    medAbstractData* output;
+    int interpolator;
+    int dimX, dimY, dimZ;
+    double spacingX, spacingY, spacingZ;
+};
+
+// /////////////////////////////////////////////////////////////////
+// resampleProcess
+// /////////////////////////////////////////////////////////////////
+resampleProcess::resampleProcess(void) : d(new resampleProcessPrivate(this))
+{
+    d->dimX = 0;
+    d->dimY = 0;
+    d->dimZ = 0;
+    d->spacingX = 0.0;
+    d->spacingY = 0.0;
+    d->spacingZ = 0.0;
+}
+
+resampleProcess::~resampleProcess(void)
+{
+    delete d;
+    d = nullptr;
+}
+bool resampleProcess::registered(void)
+{
+    return dtkAbstractProcessFactory::instance()->registerProcessType("resampleProcess", createResampleProcess);
+}
+QString resampleProcess::description(void) const
+{
+    return "resampleProcess";
+}
+void resampleProcess::setInput ( medAbstractData *data)
+{
+    if ( data )
+    {
+        d->input = data;
+    }
+}
+
+void resampleProcess::setInput ( medAbstractData *data , int channel)
+{
+    setInput(data);
+}
+
+void resampleProcess::setParameter ( double data, int channel)
+{
+    switch (channel)
+    {
+    case 0:
+        d->dimX = (int)data;
+        break;
+    case 1:
+        d->dimY = (int)data;
+        break;
+    case 2:
+        d->dimZ = (int)data;
+        break;
+    case 3:
+        d->spacingX = data;
+        break;
+    case 4:
+        d->spacingY = data;
+        break;
+    case 5:
+        d->spacingZ = data;
+        break;
+    }
+}
+
+int resampleProcess::update ( void )
+{
+    int result = medAbstractProcessLegacy::FAILURE;
+
+    if (!d->input)
+    {
+        qDebug() << "in update method: d->input is null";
+    }
+    else
+    {
+        result = DISPATCH_ON_3D_PIXEL_TYPE(&resampleProcess::resample, this, d->input);
+
+        if (result == medAbstractProcessLegacy::PIXEL_TYPE)
+        {
+            result = DISPATCH_ON_4D_PIXEL_TYPE(&resampleProcess::resample, this, d->input);
+        }
+    }
+
+    return result;
+}
+
+template <class ImageType>
+int resampleProcess::resample(medAbstractData* inputData)
+{
+    typename ImageType::Pointer inputImage = static_cast<ImageType*>(inputData->data());
+
+    typedef typename itk::ResampleImageFilter<ImageType, ImageType,double> ResampleFilterType;
+
+    typename ResampleFilterType::Pointer resampleFilter = ResampleFilterType::New();
+    
+    //// Fetch original image size.
+    const typename ImageType::RegionType& inputRegion = inputImage->GetLargestPossibleRegion();
+    const typename ImageType::SizeType& vnInputSize = inputRegion.GetSize();
+    unsigned int nOldX = vnInputSize[0];
+    unsigned int nOldY = vnInputSize[1];
+    unsigned int nOldZ = vnInputSize[2];
+
+    //// Fetch original image spacing.
+    const typename ImageType::SpacingType& vfInputSpacing = inputImage->GetSpacing();
+    double vfOutputSpacing[3]={d->spacingX,d->spacingY,d->spacingZ};
+    if (d->dimX || d->dimY || d->dimZ)
+    {
+        vfOutputSpacing[0] = vfInputSpacing[0] * (double) nOldX / (double) d->dimX;
+        vfOutputSpacing[1] = vfInputSpacing[1] * (double) nOldY / (double) d->dimY;
+        vfOutputSpacing[2] = vfInputSpacing[2] * (double) nOldZ / (double) d->dimZ;
+    }
+    else
+    {
+        d->dimX =  floor((vfInputSpacing[0] * (double) nOldX / (double) vfOutputSpacing[0]) +0.5);
+        d->dimY =  floor((vfInputSpacing[1] * (double) nOldY / (double) vfOutputSpacing[1]) +0.5);
+        d->dimZ =  floor((vfInputSpacing[2] * (double) nOldZ / (double) vfOutputSpacing[2]) +0.5);
+    }
+    
+    typename ImageType::SizeType vnOutputSize;
+    vnOutputSize[0] = d->dimX;
+    vnOutputSize[1] = d->dimY;
+    vnOutputSize[2] = d->dimZ;
+    
+    resampleFilter->SetInput(inputImage);
+    resampleFilter->SetSize(vnOutputSize);
+    resampleFilter->SetOutputSpacing(vfOutputSpacing);
+    resampleFilter->SetOutputOrigin( inputImage->GetOrigin() );
+    resampleFilter->SetOutputDirection(inputImage->GetDirection() );
+    resampleFilter->UpdateLargestPossibleRegion();
+    d->output = medAbstractDataFactory::instance()->create(inputData->identifier());
+    d->output->setData(resampleFilter->GetOutput());
+
+    medUtilities::setDerivedMetaData(d->output, inputData, "resampled");
+
+    return medAbstractProcessLegacy::SUCCESS;
+}
+
+medAbstractData * resampleProcess::output ( void )
+{
+    return ( d->output );
+}
+
+// /////////////////////////////////////////////////////////////////
+// Type instantiation
+// /////////////////////////////////////////////////////////////////
+dtkAbstractProcess *createResampleProcess(void)
+{
+    return new resampleProcess;
+}

--- a/src/plugins/legacy/reformat/resampleProcess.h
+++ b/src/plugins/legacy/reformat/resampleProcess.h
@@ -1,0 +1,47 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#pragma once
+#include <medAbstractProcessLegacy.h>
+#include <medAbstractData.h>
+#include <reformatPluginExport.h>
+
+class resampleProcessPrivate;
+class REFORMATPLUGIN_EXPORT resampleProcess : public medAbstractProcessLegacy
+{
+    Q_OBJECT
+
+public:
+    resampleProcess(void);
+    virtual ~resampleProcess(void);
+    virtual QString description(void) const;
+    static bool registered(void);
+
+public slots:
+    //! Input data to the plugin is set through here
+    void setInput(medAbstractData *data);
+    void setInput(medAbstractData *,int);
+
+    //! Parameters are set through here, channel allows to handle multiple parameters
+    void setParameter(double data, int channel);
+
+    //! Method to actually start the filter
+    int update(void);
+
+    //! The output will be available through here
+    medAbstractData *output(void);
+
+private:
+    template <class ImageType> int resample(medAbstractData* inputData);
+    resampleProcessPrivate *d;
+};
+dtkAbstractProcess *createResampleProcess();

--- a/src/plugins/legacy/reformat/resampleProcess.h
+++ b/src/plugins/legacy/reformat/resampleProcess.h
@@ -11,6 +11,7 @@
 
 =========================================================================*/
 #pragma once
+
 #include <medAbstractProcessLegacy.h>
 #include <medAbstractData.h>
 #include <reformatPluginExport.h>
@@ -29,16 +30,16 @@ public:
 public slots:
     //! Input data to the plugin is set through here
     void setInput(medAbstractData *data);
-    void setInput(medAbstractData *,int);
+    void setInput(medAbstractData *data , int channel);
 
     //! Parameters are set through here, channel allows to handle multiple parameters
     void setParameter(double data, int channel);
 
     //! Method to actually start the filter
-    int update(void);
+    int update();
 
     //! The output will be available through here
-    medAbstractData *output(void);
+    medAbstractData *output();
 
 private:
     template <class ImageType> int resample(medAbstractData* inputData);

--- a/src/plugins/legacy/reformat/resampleProcess.h
+++ b/src/plugins/legacy/reformat/resampleProcess.h
@@ -30,7 +30,7 @@ public:
 public slots:
     //! Input data to the plugin is set through here
     void setInput(medAbstractData *data);
-    void setInput(medAbstractData *data , int channel);
+    void setInput(medAbstractData *data, int channel);
 
     //! Parameters are set through here, channel allows to handle multiple parameters
     void setParameter(double data, int channel);

--- a/src/plugins/legacy/reformat/resliceToolBox.cpp
+++ b/src/plugins/legacy/reformat/resliceToolBox.cpp
@@ -15,6 +15,7 @@
 #include <medAbstractImageData.h>
 #include <medAbstractLayeredView.h>
 #include <medDataManager.h>
+#include <medDoubleParameterL.h>
 #include <medMessageController.h>
 #include <medPluginManager.h>
 #include <medResliceViewer.h>
@@ -28,12 +29,12 @@ class resliceToolBoxPrivate
 public:
     QPushButton *b_startReslice, *b_stopReslice, *b_saveImage, *b_reset;
     QComboBox *bySpacingOrDimension;
-    QLabel *spacingXLab, *spacingYLab, *spacingZLab, *help0;
-    QDoubleSpinBox *spacingX, *spacingY, *spacingZ;
-    medAbstractLayeredView * currentView;
-    medResliceViewer * resliceViewer;
+    QLabel *helpBegin;
+    medDoubleParameterL *spacingX, *spacingY, *spacingZ;
+    medAbstractLayeredView *currentView;
+    medResliceViewer *resliceViewer;
     dtkSmartPointer<medAbstractData> reformatedImage;
-    QWidget* reformatOptions;
+    QWidget *reformatOptions;
 };
 
 resliceToolBox::resliceToolBox (QWidget *parent) : medAbstractSelectableToolBox (parent), d(new resliceToolBoxPrivate)
@@ -52,7 +53,7 @@ resliceToolBox::resliceToolBox (QWidget *parent) : medAbstractSelectableToolBox 
 
     // User can choose pixel or millimeter resample
     QHBoxLayout * resampleLayout = new QHBoxLayout();
-    QLabel* bySpacingOrDimensionLabel = new QLabel("Select your resample parameter:", resliceToolBoxBody);
+    QLabel *bySpacingOrDimensionLabel = new QLabel("Select your resample parameter ", resliceToolBoxBody);
     d->bySpacingOrDimension = new QComboBox(resliceToolBoxBody);
     d->bySpacingOrDimension->setObjectName("bySpacingOrDimension");
     d->bySpacingOrDimension->addItem("Spacing");
@@ -62,50 +63,64 @@ resliceToolBox::resliceToolBox (QWidget *parent) : medAbstractSelectableToolBox 
     connect(d->bySpacingOrDimension, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(switchSpacingAndDimension(const QString&)));
 
     // Spinboxes of resample values
-    QWidget * spinBoxes = new QWidget(resliceToolBoxBody);
-    QVBoxLayout * spacingSpinBoxLayout = new QVBoxLayout(resliceToolBoxBody);
-    d->spacingXLab = new QLabel("X : ");
-    d->spacingX = new QDoubleSpinBox(resliceToolBoxBody);
-    d->spacingX->setAccessibleName("SpacingX");
+    QWidget *spinBoxes = new QWidget(resliceToolBoxBody);
+    QVBoxLayout *spacingSpinBoxLayout = new QVBoxLayout(resliceToolBoxBody);
+
+    QHBoxLayout *spacingSpinBoxLayoutX = new QHBoxLayout();
+    spacingSpinBoxLayoutX->setAlignment(Qt::AlignCenter);
+    d->spacingX = new medDoubleParameterL("X", this);
+    d->spacingX->getSpinBox()->setAccessibleName("SpacingX");
     d->spacingX->setObjectName("SpacingX");
     d->spacingX->setRange(0,100);
-    d->spacingX->setSuffix(" mm");
+    d->spacingX->getSpinBox()->setSuffix(" mm");
     d->spacingX->setSingleStep(0.1f);
-    spacingSpinBoxLayout->addWidget(d->spacingXLab);
-    spacingSpinBoxLayout->addWidget(d->spacingX);
-    d->spacingYLab = new QLabel("Y : ");
-    d->spacingY = new QDoubleSpinBox(resliceToolBoxBody);
-    d->spacingY->setAccessibleName("SpacingY");
+    spacingSpinBoxLayoutX->addWidget(d->spacingX->getLabel());
+    spacingSpinBoxLayoutX->addWidget(d->spacingX->getSpinBox());
+    spacingSpinBoxLayout->addLayout(spacingSpinBoxLayoutX);
+
+    QHBoxLayout *spacingSpinBoxLayoutY = new QHBoxLayout();
+    spacingSpinBoxLayoutY->setAlignment(Qt::AlignCenter);
+    d->spacingY = new medDoubleParameterL("Y", this);
+    d->spacingY->getSpinBox()->setAccessibleName("SpacingY");
     d->spacingY->setObjectName("SpacingY");
     d->spacingY->setRange(0,100);
-    d->spacingY->setSuffix(" mm");
+    d->spacingY->getSpinBox()->setSuffix(" mm");
     d->spacingY->setSingleStep(0.1f);
-    spacingSpinBoxLayout->addWidget(d->spacingYLab);
-    spacingSpinBoxLayout->addWidget(d->spacingY);
-    d->spacingZLab = new QLabel("Z : ");
-    d->spacingZ = new QDoubleSpinBox(resliceToolBoxBody);
-    d->spacingZ->setAccessibleName("SpacingZ");
+    spacingSpinBoxLayoutY->addWidget(d->spacingY->getLabel());
+    spacingSpinBoxLayoutY->addWidget(d->spacingY->getSpinBox());
+    spacingSpinBoxLayout->addLayout(spacingSpinBoxLayoutY);
+
+    QHBoxLayout *spacingSpinBoxLayoutZ = new QHBoxLayout();
+    spacingSpinBoxLayoutZ->setAlignment(Qt::AlignCenter);
+    d->spacingZ = new medDoubleParameterL("Z", this);
+    d->spacingZ->getSpinBox()->setAccessibleName("SpacingZ");
     d->spacingZ->setObjectName("SpacingZ");
     d->spacingZ->setRange(0,100);
-    d->spacingZ->setSuffix(" mm");
+    d->spacingZ->getSpinBox()->setSuffix(" mm");
     d->spacingZ->setSingleStep(0.1f);
-    spacingSpinBoxLayout->addWidget(d->spacingZLab);
-    spacingSpinBoxLayout->addWidget(d->spacingZ);
+    spacingSpinBoxLayoutZ->addWidget(d->spacingZ->getLabel());
+    spacingSpinBoxLayoutZ->addWidget(d->spacingZ->getSpinBox());
+    spacingSpinBoxLayout->addLayout(spacingSpinBoxLayoutZ);
+
     spinBoxes->setLayout(spacingSpinBoxLayout);
 
     QVBoxLayout *resliceToolBoxLayout =  new QVBoxLayout(resliceToolBoxBody);
-    d->help0 = new QLabel("Open a data volume and launch:",resliceToolBoxBody);
-    d->help0->setObjectName("help0");
-    resliceToolBoxLayout->addWidget(d->help0);
+    d->helpBegin = new QLabel("Drop a data in the view and click on 'Start Reslice'", resliceToolBoxBody);
+    d->helpBegin->setObjectName("helpBegin");
+    d->helpBegin->setStyleSheet("font: italic");
+    resliceToolBoxLayout->addWidget(d->helpBegin);
 
-    QLabel * help1 = new QLabel("To reset axes in a view press 'o'",resliceToolBoxBody);
-    QLabel * help2 = new QLabel("To change the windowing left click on a 2D view",resliceToolBoxBody);
-    QLabel * help3 = new QLabel("To reset windowing in a view press 'r'",resliceToolBoxBody);
+    QLabel *help1 = new QLabel("To change the windowing left click on a 2D view.", resliceToolBoxBody);
+    QLabel *help2 = new QLabel("To reset axes in a view press 'o'.",               resliceToolBoxBody);
+    QLabel *help3 = new QLabel("To reset windowing in a view press 'r'.\n",        resliceToolBoxBody);
+    help1->setStyleSheet("font: italic");
+    help2->setStyleSheet("font: italic");
+    help3->setStyleSheet("font: italic");
 
     resliceToolBoxLayout->addWidget(d->b_startReslice);
 
     d->reformatOptions = new QWidget(resliceToolBoxBody);
-    QVBoxLayout* reformatOptionsLayout = new QVBoxLayout(d->reformatOptions);
+    QVBoxLayout *reformatOptionsLayout = new QVBoxLayout(d->reformatOptions);
     d->reformatOptions->setLayout(reformatOptionsLayout);
     d->reformatOptions->hide();
 
@@ -163,7 +178,7 @@ void resliceToolBox::startReformat()
 
         if (d->currentView->layersCount() && is3D)
         {
-            d->help0->hide();
+            d->helpBegin->hide();
             d->reformatOptions->show();
             d->b_startReslice->hide();
 
@@ -204,7 +219,7 @@ void resliceToolBox::stopReformat()
     if (getWorkspace())
     {
         d->bySpacingOrDimension->setCurrentIndex(0); // init resample parameter
-        d->help0->show();
+        d->helpBegin->show();
         d->reformatOptions->hide();
         d->b_startReslice->show();
 
@@ -255,14 +270,14 @@ void resliceToolBox::displayInfoOnCurrentView()
 
     if (d->bySpacingOrDimension->currentIndex() == 0) // Spacing
     {        
-        double* spacing = view2d->GetMedVtkImageInfo()->spacing;
+        double *spacing = view2d->GetMedVtkImageInfo()->spacing;
         d->spacingX->setValue(spacing[0]);
         d->spacingY->setValue(spacing[1]);
         d->spacingZ->setValue(spacing[2]);
     }
     else // Dimension
     {
-        int* dimension = view2d->GetMedVtkImageInfo()->dimensions;
+        int *dimension = view2d->GetMedVtkImageInfo()->dimensions;
         d->spacingX->setValue(dimension[0]);
         d->spacingY->setValue(dimension[1]);
         d->spacingZ->setValue(dimension[2]);
@@ -290,26 +305,26 @@ void resliceToolBox::switchSpacingAndDimension(const QString & value)
 {
     if (value == "Spacing")
     {
-        d->spacingX->setSuffix(" mm");
-        d->spacingX->setRange(0,100);
+        d->spacingX->getSpinBox()->setSuffix(" mm");
+        d->spacingX->setRange(0, 100);
         d->spacingX->setSingleStep(0.1f);
-        d->spacingY->setSuffix(" mm");
-        d->spacingY->setRange(0,100);
+        d->spacingY->getSpinBox()->setSuffix(" mm");
+        d->spacingY->setRange(0, 100);
         d->spacingY->setSingleStep(0.1f);
-        d->spacingZ->setSuffix(" mm");
-        d->spacingZ->setRange(0,100);
+        d->spacingZ->getSpinBox()->setSuffix(" mm");
+        d->spacingZ->setRange(0, 100);
         d->spacingZ->setSingleStep(0.1f);
     }
     else // Dimension
     {
-        d->spacingX->setSuffix(" px");
-        d->spacingX->setRange(0,10000);
+        d->spacingX->getSpinBox()->setSuffix(" px");
+        d->spacingX->setRange(0, 10000);
         d->spacingX->setSingleStep(10);
-        d->spacingY->setSuffix(" px");
-        d->spacingY->setRange(0,10000);
+        d->spacingY->getSpinBox()->setSuffix(" px");
+        d->spacingY->setRange(0, 10000);
         d->spacingY->setSingleStep(10);
-        d->spacingZ->setSuffix(" px");
-        d->spacingZ->setRange(0,10000);
+        d->spacingZ->getSpinBox()->setSuffix(" px");
+        d->spacingZ->setRange(0, 10000);
         d->spacingZ->setSingleStep(10);
     }
     displayInfoOnCurrentView();

--- a/src/plugins/legacy/reformat/resliceToolBox.cpp
+++ b/src/plugins/legacy/reformat/resliceToolBox.cpp
@@ -1,0 +1,341 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include "resliceToolBox.h"
+
+#include <medAbstractImageData.h>
+#include <medAbstractLayeredView.h>
+#include <medDataManager.h>
+#include <medMessageController.h>
+#include <medPluginManager.h>
+#include <medResliceViewer.h>
+#include <medTabbedViewContainers.h>
+#include <medToolBoxFactory.h>
+#include <medViewContainer.h>
+#include <medVtkViewBackend.h>
+
+class resliceToolBoxPrivate
+{
+public:
+    QPushButton *b_startReslice, *b_stopReslice, *b_saveImage, *b_reset;
+    QComboBox *bySpacingOrDimension;
+    QLabel *spacingXLab, *spacingYLab, *spacingZLab, *help0;
+    QDoubleSpinBox *spacingX, *spacingY, *spacingZ;
+    medAbstractLayeredView * currentView;
+    medResliceViewer * resliceViewer;
+    dtkSmartPointer<medAbstractData> reformatedImage;
+    QWidget* reformatOptions;
+};
+
+resliceToolBox::resliceToolBox (QWidget *parent) : medAbstractSelectableToolBox (parent), d(new resliceToolBoxPrivate)
+{
+    // Fill the toolBox
+    QWidget *resliceToolBoxBody = new QWidget(this);
+    d->b_startReslice = new QPushButton("Start Reslice", resliceToolBoxBody);
+    d->b_startReslice->setCheckable(false);
+    d->b_startReslice->setObjectName("startReformatButton");
+    d->b_stopReslice = new QPushButton("Stop Reslice", resliceToolBoxBody);
+    d->b_stopReslice->setCheckable(false);
+    d->b_stopReslice->setObjectName("stopReformatButton");
+    d->b_saveImage = new QPushButton("Save Image", resliceToolBoxBody);
+    d->b_saveImage->setCheckable(false);
+    d->b_saveImage->setObjectName("saveImageButton");
+
+    // User can choose pixel or millimeter resample
+    QHBoxLayout * resampleLayout = new QHBoxLayout();
+    QLabel* bySpacingOrDimensionLabel = new QLabel("Select your resample parameter:", resliceToolBoxBody);
+    d->bySpacingOrDimension = new QComboBox(resliceToolBoxBody);
+    d->bySpacingOrDimension->setObjectName("bySpacingOrDimension");
+    d->bySpacingOrDimension->addItem("Spacing");
+    d->bySpacingOrDimension->addItem("Dimension");
+    resampleLayout->addWidget(bySpacingOrDimensionLabel);
+    resampleLayout->addWidget(d->bySpacingOrDimension);
+    connect(d->bySpacingOrDimension, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(switchSpacingAndDimension(const QString&)));
+
+    // Spinboxes of resample values
+    QWidget * spinBoxes = new QWidget(resliceToolBoxBody);
+    QVBoxLayout * spacingSpinBoxLayout = new QVBoxLayout(resliceToolBoxBody);
+    d->spacingXLab = new QLabel("X : ");
+    d->spacingX = new QDoubleSpinBox(resliceToolBoxBody);
+    d->spacingX->setAccessibleName("SpacingX");
+    d->spacingX->setObjectName("SpacingX");
+    d->spacingX->setRange(0,100);
+    d->spacingX->setSuffix(" mm");
+    d->spacingX->setSingleStep(0.1f);
+    spacingSpinBoxLayout->addWidget(d->spacingXLab);
+    spacingSpinBoxLayout->addWidget(d->spacingX);
+    d->spacingYLab = new QLabel("Y : ");
+    d->spacingY = new QDoubleSpinBox(resliceToolBoxBody);
+    d->spacingY->setAccessibleName("SpacingY");
+    d->spacingY->setObjectName("SpacingY");
+    d->spacingY->setRange(0,100);
+    d->spacingY->setSuffix(" mm");
+    d->spacingY->setSingleStep(0.1f);
+    spacingSpinBoxLayout->addWidget(d->spacingYLab);
+    spacingSpinBoxLayout->addWidget(d->spacingY);
+    d->spacingZLab = new QLabel("Z : ");
+    d->spacingZ = new QDoubleSpinBox(resliceToolBoxBody);
+    d->spacingZ->setAccessibleName("SpacingZ");
+    d->spacingZ->setObjectName("SpacingZ");
+    d->spacingZ->setRange(0,100);
+    d->spacingZ->setSuffix(" mm");
+    d->spacingZ->setSingleStep(0.1f);
+    spacingSpinBoxLayout->addWidget(d->spacingZLab);
+    spacingSpinBoxLayout->addWidget(d->spacingZ);
+    spinBoxes->setLayout(spacingSpinBoxLayout);
+
+    QVBoxLayout *resliceToolBoxLayout =  new QVBoxLayout(resliceToolBoxBody);
+    d->help0 = new QLabel("Open a data volume and launch:",resliceToolBoxBody);
+    d->help0->setObjectName("help0");
+    resliceToolBoxLayout->addWidget(d->help0);
+
+    QLabel * help1 = new QLabel("To reset axes in a view press 'o'",resliceToolBoxBody);
+    QLabel * help2 = new QLabel("To change the windowing left click on a 2D view",resliceToolBoxBody);
+    QLabel * help3 = new QLabel("To reset windowing in a view press 'r'",resliceToolBoxBody);
+
+    resliceToolBoxLayout->addWidget(d->b_startReslice);
+
+    d->reformatOptions = new QWidget(resliceToolBoxBody);
+    QVBoxLayout* reformatOptionsLayout = new QVBoxLayout(d->reformatOptions);
+    d->reformatOptions->setLayout(reformatOptionsLayout);
+    d->reformatOptions->hide();
+
+    resliceToolBoxLayout->addWidget(d->reformatOptions);
+    reformatOptionsLayout->addWidget(help1);
+    reformatOptionsLayout->addWidget(help2);
+    reformatOptionsLayout->addWidget(help3);
+    reformatOptionsLayout->addLayout(resampleLayout);
+    reformatOptionsLayout->addWidget(spinBoxes);
+    reformatOptionsLayout->addWidget(d->b_saveImage);
+    reformatOptionsLayout->addWidget(d->b_stopReslice);
+    resliceToolBoxBody->setLayout(resliceToolBoxLayout);
+    this->addWidget(resliceToolBoxBody);
+
+    // Connections
+    connect(d->b_startReslice,SIGNAL(clicked()),this,SLOT(startReformat()));
+    connect(d->b_stopReslice,SIGNAL(clicked()),this,SLOT(stopReformat()));
+
+    d->resliceViewer  = 0;
+    d->currentView     = 0;
+}
+resliceToolBox::~resliceToolBox()
+{
+    delete d->resliceViewer;
+    d->resliceViewer = nullptr;
+    d->currentView = 0;
+
+    delete d;
+    d = nullptr;
+}
+
+bool resliceToolBox::registered()
+{
+    return medToolBoxFactory::instance()->registerToolBox<resliceToolBox>();
+}
+
+dtkPlugin* resliceToolBox::plugin()
+{
+    medPluginManager* pm = medPluginManager::instance();
+    dtkPlugin* plugin = pm->plugin ( "Reformat" );
+    return plugin;
+}
+
+void resliceToolBox::startReformat()
+{
+    if (d->currentView && getWorkspace())
+    {
+        medAbstractData* data = d->currentView->layerData(d->currentView->currentLayer());
+        bool is3D = false;
+        if ((data->identifier().contains("itkDataImage"))
+                && (dynamic_cast<medAbstractImageData *>(data)->Dimension() == 3))
+        {
+            is3D = true;
+        }
+
+        if (d->currentView->layersCount() && is3D)
+        {
+            d->help0->hide();
+            d->reformatOptions->show();
+            d->b_startReslice->hide();
+
+            d->resliceViewer = new medResliceViewer(d->currentView,getWorkspace()->tabbedViewContainers());
+            d->resliceViewer->setToolBox(this);
+            getWorkspace()->tabbedViewContainers()->setAcceptDrops(false);
+            connect(d->resliceViewer,SIGNAL(imageReformatedGenerated()),this,SLOT(saveReformatedImage()));
+            medViewContainer * container = getWorkspace()->tabbedViewContainers()->insertNewTab(0,"Reslice");
+            getWorkspace()->tabbedViewContainers()->setCurrentIndex(0);
+            container->setDefaultWidget(d->resliceViewer->viewWidget());
+            connect(container, SIGNAL(viewRemoved()),this, SLOT(stopReformat()), Qt::UniqueConnection);
+
+            connect(d->spacingX, SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));
+            connect(d->spacingY, SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));
+            connect(d->spacingZ, SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));
+            connect(d->b_saveImage, SIGNAL(clicked()), d->resliceViewer, SLOT(saveImage()));
+
+            d->reformatedImage = nullptr;
+
+            // close the initial tab which is not needed anymore
+            getWorkspace()->tabbedViewContainers()->removeTab(1);
+            updateView();
+        }
+        else
+        {
+            medMessageController::instance()->showError(tr("Drop a 3D volume in the view"), 3000);
+        }
+    }
+    else
+    {
+        medMessageController::instance()->showError(tr("Drop a 3D volume in the view"), 3000);
+    }
+}
+
+void resliceToolBox::stopReformat()
+{
+    if (getWorkspace())
+    {
+        d->bySpacingOrDimension->setCurrentIndex(0); // init resample parameter
+        d->help0->show();
+        d->reformatOptions->hide();
+        d->b_startReslice->show();
+
+        getWorkspace()->tabbedViewContainers()->removeTab(0);
+        getWorkspace()->tabbedViewContainers()->insertNewTab(0, getWorkspace()->name());
+        getWorkspace()->tabbedViewContainers()->setCurrentIndex(0);
+
+        if (d->currentView)
+        {
+            getWorkspace()->tabbedViewContainers()->getFirstSelectedContainer()->addData(d->currentView->layerData(0));
+        }
+
+        processOutput();
+        disconnect(d->resliceViewer);
+        delete d->resliceViewer;
+
+        d->resliceViewer = nullptr;
+        QList<medToolBox*> toolBoxes = getWorkspace()->toolBoxes();
+        for (int i = 0; i < toolBoxes.length(); i++)
+        {
+            toolBoxes[i]->show();
+        }
+    }
+}
+
+void resliceToolBox::clear()
+{
+    stopReformat();
+}
+
+void resliceToolBox::updateView()
+{
+    medAbstractView* view = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainerView();
+
+    if (view && d->currentView!= view)
+    {
+        medAbstractLayeredView * layeredView = qobject_cast<medAbstractLayeredView*>(view);
+        if (dynamic_cast<medAbstractImageData*>(layeredView->layerData(layeredView->currentLayer())))
+        {
+            d->currentView = layeredView;
+            displayInfoOnCurrentView();
+        }
+    }
+}
+
+void resliceToolBox::displayInfoOnCurrentView()
+{
+    vtkImageView2D *view2d = static_cast<medVtkViewBackend*>(d->currentView->backend())->view2D;
+
+    if (d->bySpacingOrDimension->currentIndex() == 0) // Spacing
+    {        
+        double* spacing = view2d->GetMedVtkImageInfo()->spacing;
+        d->spacingX->setValue(spacing[0]);
+        d->spacingY->setValue(spacing[1]);
+        d->spacingZ->setValue(spacing[2]);
+    }
+    else // Dimension
+    {
+        int* dimension = view2d->GetMedVtkImageInfo()->dimensions;
+        d->spacingX->setValue(dimension[0]);
+        d->spacingY->setValue(dimension[1]);
+        d->spacingZ->setValue(dimension[2]);
+    }
+}
+
+void resliceToolBox::saveReformatedImage()
+{
+    generateReformatedImage();
+    if (d->reformatedImage && d->reformatedImage->data())
+    {
+        medDataManager::instance()->importData(d->reformatedImage, false);
+    }
+}
+
+void resliceToolBox::generateReformatedImage()
+{
+    if (d->resliceViewer)
+    {
+        d->reformatedImage = d->resliceViewer->getOutput();
+    }
+}
+
+void resliceToolBox::switchSpacingAndDimension(const QString & value)
+{
+    if (value == "Spacing")
+    {
+        d->spacingX->setSuffix(" mm");
+        d->spacingX->setRange(0,100);
+        d->spacingX->setSingleStep(0.1f);
+        d->spacingY->setSuffix(" mm");
+        d->spacingY->setRange(0,100);
+        d->spacingY->setSingleStep(0.1f);
+        d->spacingZ->setSuffix(" mm");
+        d->spacingZ->setRange(0,100);
+        d->spacingZ->setSingleStep(0.1f);
+    }
+    else // Dimension
+    {
+        d->spacingX->setSuffix(" px");
+        d->spacingX->setRange(0,10000);
+        d->spacingX->setSingleStep(10);
+        d->spacingY->setSuffix(" px");
+        d->spacingY->setRange(0,10000);
+        d->spacingY->setSingleStep(10);
+        d->spacingZ->setSuffix(" px");
+        d->spacingZ->setRange(0,10000);
+        d->spacingZ->setSingleStep(10);
+    }
+    displayInfoOnCurrentView();
+}
+
+medAbstractData *resliceToolBox::processOutput()
+{
+    if (!d->reformatedImage)
+    {
+        generateReformatedImage();
+    }
+    return d->reformatedImage;
+}
+
+void resliceToolBox::changeButtonValue(QString buttonName, double value)
+{
+    if (buttonName == "SpacingX")
+    {
+        d->spacingX->setValue(value);
+    }
+    else if (buttonName == "SpacingY")
+    {
+        d->spacingY->setValue(value);
+    }
+    else if (buttonName == "SpacingZ")
+    {
+        d->spacingZ->setValue(value);
+    }
+}

--- a/src/plugins/legacy/reformat/resliceToolBox.cpp
+++ b/src/plugins/legacy/reformat/resliceToolBox.cpp
@@ -167,7 +167,8 @@ void resliceToolBox::startReformat()
             d->reformatOptions->show();
             d->b_startReslice->hide();
 
-            d->resliceViewer = new medResliceViewer(d->currentView,getWorkspace()->tabbedViewContainers());
+            d->resliceViewer = new medResliceViewer(d->currentView,
+                                                    getWorkspace()->tabbedViewContainers());
             d->resliceViewer->setToolBox(this);
             getWorkspace()->tabbedViewContainers()->setAcceptDrops(false);
             connect(d->resliceViewer,SIGNAL(imageReformatedGenerated()),this,SLOT(saveReformatedImage()));

--- a/src/plugins/legacy/reformat/resliceToolBox.cpp
+++ b/src/plugins/legacy/reformat/resliceToolBox.cpp
@@ -217,7 +217,6 @@ void resliceToolBox::stopReformat()
             getWorkspace()->tabbedViewContainers()->getFirstSelectedContainer()->addData(d->currentView->layerData(0));
         }
 
-        processOutput();
         disconnect(d->resliceViewer);
         delete d->resliceViewer;
 

--- a/src/plugins/legacy/reformat/resliceToolBox.cpp
+++ b/src/plugins/legacy/reformat/resliceToolBox.cpp
@@ -124,14 +124,14 @@ resliceToolBox::resliceToolBox (QWidget *parent) : medAbstractSelectableToolBox 
     connect(d->b_startReslice,SIGNAL(clicked()),this,SLOT(startReformat()));
     connect(d->b_stopReslice,SIGNAL(clicked()),this,SLOT(stopReformat()));
 
-    d->resliceViewer  = 0;
-    d->currentView     = 0;
+    d->resliceViewer = nullptr;
+    d->currentView   = nullptr;
 }
 resliceToolBox::~resliceToolBox()
 {
     delete d->resliceViewer;
     d->resliceViewer = nullptr;
-    d->currentView = 0;
+    d->currentView = nullptr;
 
     delete d;
     d = nullptr;
@@ -171,7 +171,7 @@ void resliceToolBox::startReformat()
             d->resliceViewer->setToolBox(this);
             getWorkspace()->tabbedViewContainers()->setAcceptDrops(false);
             connect(d->resliceViewer,SIGNAL(imageReformatedGenerated()),this,SLOT(saveReformatedImage()));
-            medViewContainer * container = getWorkspace()->tabbedViewContainers()->insertNewTab(0,"Reslice");
+            medViewContainer * container = getWorkspace()->tabbedViewContainers()->insertNewTab(0, "Reslice");
             getWorkspace()->tabbedViewContainers()->setCurrentIndex(0);
             container->setDefaultWidget(d->resliceViewer->viewWidget());
             connect(container, SIGNAL(viewRemoved()),this, SLOT(stopReformat()), Qt::UniqueConnection);
@@ -240,7 +240,7 @@ void resliceToolBox::updateView()
 
     if (view && d->currentView!= view)
     {
-        medAbstractLayeredView * layeredView = qobject_cast<medAbstractLayeredView*>(view);
+        medAbstractLayeredView *layeredView = qobject_cast<medAbstractLayeredView*>(view);
         if (dynamic_cast<medAbstractImageData*>(layeredView->layerData(layeredView->currentLayer())))
         {
             d->currentView = layeredView;

--- a/src/plugins/legacy/reformat/resliceToolBox.cpp
+++ b/src/plugins/legacy/reformat/resliceToolBox.cpp
@@ -105,7 +105,7 @@ resliceToolBox::resliceToolBox (QWidget *parent) : medAbstractSelectableToolBox 
     spinBoxes->setLayout(spacingSpinBoxLayout);
 
     QVBoxLayout *resliceToolBoxLayout =  new QVBoxLayout(resliceToolBoxBody);
-    d->helpBegin = new QLabel("Drop a data in the view and click on 'Start Reslice'", resliceToolBoxBody);
+    d->helpBegin = new QLabel("Drop a data in the view and click on 'Start Reslice'.", resliceToolBoxBody);
     d->helpBegin->setObjectName("helpBegin");
     d->helpBegin->setStyleSheet("font: italic");
     resliceToolBoxLayout->addWidget(d->helpBegin);

--- a/src/plugins/legacy/reformat/resliceToolBox.h
+++ b/src/plugins/legacy/reformat/resliceToolBox.h
@@ -27,7 +27,7 @@ class resliceToolBoxPrivate;
  * "SpacingX" : QDoubleSpinBox\n
  * "SpacingY" : QDoubleSpinBox\n
  * "SpacingZ" : QDoubleSpinBox\n
- * "help0" : QLabel
+ * "helpBegin" : QLabel
  */
 class REFORMATPLUGIN_EXPORT resliceToolBox : public medAbstractSelectableToolBox
 {

--- a/src/plugins/legacy/reformat/resliceToolBox.h
+++ b/src/plugins/legacy/reformat/resliceToolBox.h
@@ -1,0 +1,63 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#pragma once
+
+#include <medAbstractSelectableToolBox.h>
+#include <medAbstractWorkspaceLegacy.h>
+#include "reformatPluginExport.h"
+
+class resliceToolBoxPrivate;
+
+/*! \brief Toolbox to reslice a volume.
+ *
+ * This toolbox has several named widgets which can be accessed in python pipelines:\n\n
+ * "startReformatButton" : QPushButton\n
+ * "stopReformatButton" : QPushButton\n
+ * "saveImageButton" : QPushButton\n
+ * "bySpacingOrDimension" : medComboBox\n
+ * "SpacingX" : QDoubleSpinBox\n
+ * "SpacingY" : QDoubleSpinBox\n
+ * "SpacingZ" : QDoubleSpinBox\n
+ * "help0" : QLabel
+ */
+class REFORMATPLUGIN_EXPORT resliceToolBox : public medAbstractSelectableToolBox
+{
+    Q_OBJECT
+
+    MED_TOOLBOX_INTERFACE("Reslice",
+                          "Used to reslice an image",
+                          << "Reformat")
+        
+public:
+    resliceToolBox(QWidget *parentToolBox = nullptr);
+    ~resliceToolBox();
+    static bool registered();
+    dtkPlugin* plugin();
+    medAbstractData *processOutput();
+    void changeButtonValue(QString buttonName, double value);
+
+private:
+    resliceToolBoxPrivate *d;
+
+public slots:
+    void startReformat();
+    void stopReformat();
+    void updateView();
+    void displayInfoOnCurrentView();
+    void saveReformatedImage();
+    void generateReformatedImage();
+    void switchSpacingAndDimension(const QString &value);
+
+protected:
+    virtual void clear();
+};

--- a/src/plugins/legacy/reformat/resliceToolBox.h
+++ b/src/plugins/legacy/reformat/resliceToolBox.h
@@ -13,8 +13,7 @@
 #pragma once
 
 #include <medAbstractSelectableToolBox.h>
-#include <medAbstractWorkspaceLegacy.h>
-#include "reformatPluginExport.h"
+#include <reformatPluginExport.h>
 
 class resliceToolBoxPrivate;
 


### PR DESCRIPTION
This PR adds:
 * the Reformat workspace, 
 * the Crop toolbox to "crop" data,
 * the Reslice toolbox to manually change the orientation and center of a data, and choose the data size and spacing.

The Reslice toolbox was a bit complicated to adapt because of VTK8 and the viewer we create. Thx to @Florent2305 which helped me (that's why there are commits from both of us).

edit: this PR is going to be rebased after the merge of the other linked PR
:m: