### PR TITLE
[music3] Meshing Workspace + 4 toolboxes

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medDataManager.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDataManager.cpp
@@ -372,17 +372,20 @@ void medDataManager::garbageCollect()
     }
 }
 
-
 QUuid medDataManager::makePersistent(medAbstractData* data)
 {
     if (!data)
+    {
         return QUuid();
+    }
 
     Q_D(medDataManager);
 
     // If already persistent
     if (data->dataIndex().dataSourceId() == d->dbController->dataSourceId())
+    {
         return QUuid();
+    }
 
     QUuid jobUuid;
 

--- a/src/layers/legacy/medCoreLegacy/gui/commonWidgets/medComboBox.h
+++ b/src/layers/legacy/medCoreLegacy/gui/commonWidgets/medComboBox.h
@@ -1,0 +1,34 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2014. All rights reserved.
+ See LICENSE.txt for details.
+ 
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#pragma once
+
+#include <QComboBox>
+
+#include <medCoreLegacyExport.h>
+
+class MEDCORELEGACY_EXPORT medComboBox: public QComboBox
+{
+
+    Q_OBJECT
+
+public:
+
+    medComboBox(QWidget* parent = nullptr): QComboBox(parent)
+    {
+        this->setFocusPolicy(Qt::StrongFocus);
+    }
+    
+    // No wheel event for these QCombobox to avoid changes during a scroll
+    void wheelEvent(QWheelEvent*){}
+};

--- a/src/layers/legacy/medCoreLegacy/gui/database/medDatabaseView.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/database/medDatabaseView.cpp
@@ -438,8 +438,8 @@ void medDatabaseView::onSaveSelectedItemRequested(void)
         // Copy the data index, because the data item may cease to be valid.
         medDataIndex index = item->dataIndex();
         medDataManager::instance()->makePersistent(medDataManager::instance()->retrieveData(index));
-        dtkDebug() << "DEBUG : onMenuSaveClicked() after storeNonPersistentSingleDataToDatabase";
-        dtkDebug() << "DEBUG : index" << index;
+        qDebug() << "onMenuSaveClicked() after storeNonPersistentSingleDataToDatabase";
+        qDebug() << "index" << index;
     }
 }
 

--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medSelectorToolBox.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medSelectorToolBox.cpp
@@ -20,7 +20,7 @@
 class medSelectorToolBoxPrivate
 {
 public:
-    QComboBox *chooseComboBox;
+    medComboBox *chooseComboBox;
     medAbstractSelectableToolBox *currentToolBox;
     QHash<QString, medAbstractSelectableToolBox*> toolBoxes;
     QVBoxLayout *mainLayout;
@@ -33,7 +33,7 @@ medSelectorToolBox::medSelectorToolBox(QWidget *parent, QString tlbxId)
 {
     d->currentToolBox = nullptr;
 
-    d->chooseComboBox = new QComboBox;
+    d->chooseComboBox = new medComboBox;
     d->chooseComboBox->addItem("* Choose a toolbox *");
     d->chooseComboBox->setToolTip(tr("Choose a toolbox in the list"));
     d->chooseComboBox->setItemData(0, "Choose a toolbox", Qt::ToolTipRole);
@@ -168,7 +168,7 @@ medAbstractData* medSelectorToolBox::data()
     return d->inputData;
 }
 
-QComboBox *medSelectorToolBox::comboBox()
+medComboBox *medSelectorToolBox::comboBox()
 {
     return d->chooseComboBox;
 }

--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medSelectorToolBox.h
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medSelectorToolBox.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <medComboBox.h>
 #include <medCoreLegacyExport.h>
 #include <medToolBox.h>
 
@@ -40,7 +41,7 @@ public:
     /**
      * @brief returns the comboBox
      */
-    QComboBox* comboBox();
+    medComboBox* comboBox();
 
     int getIndexOfToolBox(const QString &toolboxName);
 

--- a/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.cpp
@@ -912,6 +912,7 @@ void medViewContainer::droppedDataReady(medDataIndex index, QUuid uuid)
 {
     bool bFind = false;
     int i = 0;
+
     while (!bFind && i < static_cast<int>(d->oQuuidVect.size()))
     {
         if (!d->oQuuidVect[i].second)

--- a/src/layers/legacy/medCoreLegacy/medMessageController.cpp
+++ b/src/layers/legacy/medCoreLegacy/medMessageController.cpp
@@ -78,7 +78,7 @@ medMessageInfo::medMessageInfo(
         medMessage(parent,text, timeout)
 {
     icon->setPixmap(QPixmap(":/icons/information.png"));
-    this->setFixedWidth(200);
+    this->setFixedWidth(500);
 }
 
 medMessageInfo::~medMessageInfo(void)
@@ -95,7 +95,7 @@ medMessageError::medMessageError(
         medMessage(parent, text, timeout)
 {
     icon->setPixmap(QPixmap(":/icons/exclamation.png"));
-    this->setFixedWidth(350);
+    this->setFixedWidth(500);
 }
 
 medMessageError::~medMessageError(void)
@@ -152,7 +152,7 @@ void medMessageProgress::failure(void)
 void medMessageProgress::associateTimer(void)
 {
     this->timer = new QTimer(this);
-    timeout = 2000;
+    timeout = 1000;
     connect(timer, SIGNAL(timeout()), this, SLOT(remove()));
 }
 

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSet.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSet.cxx
@@ -29,7 +29,7 @@
 #include <vtksys/SystemTools.hxx>
 
 //----------------------------------------------------------------------------
-vtkStandardNewMacro( vtkMetaDataSet );
+vtkStandardNewMacro( vtkMetaDataSet )
 
 //----------------------------------------------------------------------------
 vtkMetaDataSet::vtkMetaDataSet()

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -58,6 +58,11 @@ set(PLUGIN_LIST
   legacy/variationalSegmentation                                         ON
   legacy/voiCutter                                                       ON
   legacy/reformat                                                        ON
+  legacy/medMeshingWorkspace                                             ON
+  legacy/medCreateMeshFromMask                                           ON
+  legacy/medRemeshing                                                    ON
+  legacy/meshMapping                                                     ON
+  legacy/meshManipulation                                                ON
   process/arithmetic_operation                                           ON
   process/bias_correction                                                ON
   process/dwi_basic_thresholding                                         ON

--- a/src/plugins/legacy/manualRegistration/manualRegistrationToolBox.h
+++ b/src/plugins/legacy/manualRegistration/manualRegistrationToolBox.h
@@ -24,7 +24,7 @@ class manualRegistrationToolBoxPrivate;
  *
  * This toolbox has several named widgets which can be accessed in python pipelines:\n\n
  * "startManualRegistrationButton" : QPushButton\n
- * "transformType" : medComboBox\n
+ * "transformType" : QComboBox\n
  * "computeRegistrationButton" : QPushButton\n
  * "resetButton" : QPushButton
  */

--- a/src/plugins/legacy/medCreateMeshFromMask/CMakeLists.txt
+++ b/src/plugins/legacy/medCreateMeshFromMask/CMakeLists.txt
@@ -1,0 +1,86 @@
+################################################################################
+#
+# medInria
+#
+# Copyright (c) INRIA 2013 - 2019. All rights reserved.
+# See LICENSE.txt for details.
+# 
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.
+#
+################################################################################
+
+set(TARGET_NAME medCreateMeshFromMaskPlugin)
+
+## #############################################################################
+## Setup version numbering
+## #############################################################################
+
+set(${TARGET_NAME}_VERSION ${MEDINRIA_VERSION})
+
+string(TOUPPER ${TARGET_NAME} TARGET_NAME_UP)
+add_definitions(-D${TARGET_NAME_UP}_VERSION="${${TARGET_NAME}_VERSION}")
+
+set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
+
+## #############################################################################
+## Resolve dependencies
+## #############################################################################
+
+find_package(dtk REQUIRED)
+include_directories(${dtk_INCLUDE_DIRS})
+
+find_package(ITK REQUIRED)
+include(${ITK_USE_FILE})
+
+find_package(VTK REQUIRED)
+include(${VTK_USE_FILE})
+
+## #############################################################################
+## List Sources
+## #############################################################################
+
+list_source_files(${TARGET_NAME}
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+
+## #############################################################################
+## include directories
+## #############################################################################
+
+list_header_directories_to_include(${TARGET_NAME}
+  ${${TARGET_NAME}_HEADERS}
+  )
+
+include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
+  ${MEDINRIA_INCLUDE_DIRS}
+  )
+
+## #############################################################################
+## add library
+## #############################################################################
+
+add_library(${TARGET_NAME} SHARED
+  ${${TARGET_NAME}_CFILES}
+  ${${TARGET_NAME}_QRC}
+  )
+
+## #############################################################################
+## Link
+## #############################################################################
+
+target_link_libraries(${TARGET_NAME}
+  ${QT_LIBRARIES}
+  medCore
+  medVtkInria
+  medUtilities
+  )
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+## #############################################################################
+## Install rules
+## #############################################################################
+
+set_plugin_install_rules_legacy(${TARGET_NAME})

--- a/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMask.cpp
+++ b/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMask.cpp
@@ -1,0 +1,298 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <dtkCoreSupport/dtkAbstractProcessFactory.h>
+#include <dtkCoreSupport/dtkSmartPointer.h>
+
+#include <medAbstractData.h>
+#include <medAbstractDataFactory.h>
+#include <medCreateMeshFromMask.h>
+#include <medUtilities.h>
+
+#include <itkImage.h>
+#include <itkImageToVTKImageFilter.h>
+
+#include <vtkContourFilter.h>
+#include <vtkDecimatePro.h>
+#include <vtkMetaSurfaceMesh.h>
+#include <vtkSmartPointer.h>
+#include <vtkSmoothPolyDataFilter.h>
+#include <vtkTransform.h>
+#include <vtkTransformPolyDataFilter.h>
+#include <vtkTriangleFilter.h>
+
+// /////////////////////////////////////////////////////////////////
+// medCreateMeshFromMaskPrivate
+// /////////////////////////////////////////////////////////////////
+
+class medCreateMeshFromMaskPrivate
+{
+public:
+    dtkSmartPointer <medAbstractData> input;
+    dtkSmartPointer <medAbstractData> output;
+    double isoValue;
+    double targetReduction;
+    bool decimate;
+    bool smooth;
+    int iterations;
+    double relaxationFactor;
+    int nbTriangles;
+
+    template <class PixelType> int update();
+};
+
+template <class PixelType> int medCreateMeshFromMaskPrivate::update()
+{
+    typedef itk::Image<PixelType, 3> ImageType;
+    typedef itk::ImageToVTKImageFilter<ImageType>  FilterType;
+    typename FilterType::Pointer filter = FilterType::New();
+
+    typename ImageType::Pointer img = static_cast<ImageType *>(input->data());
+    filter->SetInput(img);
+    filter->Update();
+
+    // ----- Hack to keep the itkImages info (origin and orientation)
+    vtkMatrix4x4 *matrix = vtkMatrix4x4::New();
+    matrix->Identity();
+    for (unsigned int x=0; x<3; x++)
+    {
+        for (unsigned int y=0; y<3; y++)
+        {
+            matrix->SetElement(x, y, img->GetDirection()[x][y]);
+        }
+    }
+
+    typename itk::ImageBase<3>::PointType origin = img->GetOrigin();
+    double v_origin[4], v_origin2[4];
+    for (int i=0; i<3; i++)
+    {
+        v_origin[i] = origin[i];
+    }
+    v_origin[3] = 1.0;
+    matrix->MultiplyPoint(v_origin, v_origin2);
+    for (int i=0; i<3; i++)
+    {
+        matrix->SetElement(i, 3, v_origin[i]-v_origin2[i]);
+    }
+
+    //------------------------------------------------------
+
+    vtkImageData *vtkImage = filter->GetOutput();
+
+    vtkContourFilter *contour = vtkContourFilter::New();
+    contour->SetInputData(vtkImage);
+    contour->SetValue(0, isoValue);
+    contour->Update();
+
+    vtkTriangleFilter *contourTrian = vtkTriangleFilter::New();
+    contourTrian->SetInputConnection(contour->GetOutputPort());
+    contourTrian->PassVertsOn();
+    contourTrian->PassLinesOn();
+    contourTrian->Update();
+
+    vtkPolyDataAlgorithm *lastAlgo = contourTrian;
+
+    vtkDecimatePro *contourDecimated = nullptr;
+    if (decimate)
+    {
+        // Decimate the mesh if required
+        contourDecimated = vtkDecimatePro::New();
+        contourDecimated->SetInputConnection(lastAlgo->GetOutputPort());
+        contourDecimated->SetTargetReduction(targetReduction);
+        contourDecimated->SplittingOff();
+        contourDecimated->PreserveTopologyOn();
+        contourDecimated->Update();
+        lastAlgo = contourDecimated;
+    }
+
+    vtkSmoothPolyDataFilter *contourSmoothed = nullptr;
+    if(smooth)
+    {
+        // Smooth the mesh if required
+        contourSmoothed = vtkSmoothPolyDataFilter::New();
+        contourSmoothed->SetInputConnection(lastAlgo->GetOutputPort());
+        contourSmoothed->SetNumberOfIterations(iterations);
+        contourSmoothed->SetRelaxationFactor(relaxationFactor);
+        contourSmoothed->Update();
+        lastAlgo = contourSmoothed;
+    }
+
+    vtkPolyData *polydata = lastAlgo->GetOutput();
+    nbTriangles = polydata->GetNumberOfPolys();
+
+    if (nbTriangles > 0)
+    {
+        // To get the itkImage info back
+        vtkSmartPointer<vtkTransform> t = vtkSmartPointer<vtkTransform>::New();
+        t->SetMatrix(matrix);
+
+        vtkSmartPointer<vtkTransformPolyDataFilter> transformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+        transformFilter->SetInputConnection(lastAlgo->GetOutputPort());
+        transformFilter->SetTransform(t);
+        transformFilter->Update();
+
+        polydata->DeepCopy(transformFilter->GetOutput());
+
+        vtkMetaSurfaceMesh *smesh = vtkMetaSurfaceMesh::New();
+        smesh->SetDataSet(polydata);
+
+        contour->Delete();
+        contourTrian->Delete();
+        if (contourDecimated)
+        {
+            contourDecimated->Delete();
+        }
+        if (contourSmoothed)
+        {
+            contourSmoothed->Delete();
+        }
+
+        output = medAbstractDataFactory::instance()->createSmartPointer("vtkDataMesh");
+        medUtilities::setDerivedMetaData(output, input, "mesh from mask");
+        output->setData(smesh);
+
+        return medAbstractProcessLegacy::SUCCESS;
+    }
+
+    output = nullptr;
+    return medAbstractProcessLegacy::FAILURE;
+}
+
+// /////////////////////////////////////////////////////////////////
+// medCreateMeshFromMask
+// /////////////////////////////////////////////////////////////////
+
+medCreateMeshFromMask::medCreateMeshFromMask() : medAbstractProcessLegacy(), d(new medCreateMeshFromMaskPrivate)
+{
+    d->output = nullptr;
+}
+
+medCreateMeshFromMask::~medCreateMeshFromMask()
+{
+    delete d;
+    d = nullptr;
+}
+
+bool medCreateMeshFromMask::registered()
+{
+    return dtkAbstractProcessFactory::instance()->registerProcessType("medCreateMeshFromMask", createmedCreateMeshFromMask);
+}
+
+QString medCreateMeshFromMask::description() const
+{
+    return "medCreateMeshFromMask";
+}
+
+void medCreateMeshFromMask::setInput ( medAbstractData *data, int channel )
+{
+    d->input = data;
+}
+
+void medCreateMeshFromMask::setParameter ( double data, int channel )
+{
+    switch (channel)
+    {
+        case 0:
+            d->isoValue = data;
+            break;
+        case 1:
+            d->decimate = (data > 0) ? true : false;
+            break;
+        case 2:
+            d->targetReduction = data;
+            break;
+        case 3:
+            d->smooth = (data > 0) ? true : false;
+            break;
+        case 4:
+            d->iterations = data;
+            break;
+        case 5:
+            d->relaxationFactor = data;
+            break;
+    }
+}
+
+int medCreateMeshFromMask::update()
+{
+    int res = medAbstractProcessLegacy::FAILURE;
+
+    if ( d->input )
+    {
+        const QString& id = d->input->identifier();
+
+        if (id == "itkDataImageChar3")
+        {
+            res = d->update<char>();
+        }
+        else if (id == "itkDataImageUChar3")
+        {
+            res = d->update<unsigned char>();
+        }
+        else if (id == "itkDataImageShort3")
+        {
+            res = d->update<short>();
+        }
+        else if (id == "itkDataImageUShort3")
+        {
+            res = d->update<unsigned short>();
+        }
+        else if (id == "itkDataImageInt3")
+        {
+            res = d->update<int>();
+        }
+        else if (id == "itkDataImageUInt3")
+        {
+            res = d->update<unsigned int>();
+        }
+        else if (id == "itkDataImageLong3")
+        {
+            res = d->update<long>();
+        }
+        else if (id== "itkDataImageULong3")
+        {
+            res = d->update<unsigned long>();
+        }
+        else if (id == "itkDataImageFloat3")
+        {
+            res = d->update<float>();
+        }
+        else if (id == "itkDataImageDouble3")
+        {
+            res = d->update<double>();
+        }
+        else
+        {
+            res = medAbstractProcessLegacy::PIXEL_TYPE;
+        }
+    }
+    return res;
+}
+
+medAbstractData * medCreateMeshFromMask::output()
+{
+    return d->output;
+}
+
+int medCreateMeshFromMask::getNumberOfTriangles()
+{
+    return d->nbTriangles;
+}
+
+// /////////////////////////////////////////////////////////////////
+// Type instantiation
+// /////////////////////////////////////////////////////////////////
+
+dtkAbstractProcess *createmedCreateMeshFromMask()
+{
+    return new medCreateMeshFromMask;
+}

--- a/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMask.h
+++ b/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMask.h
@@ -1,0 +1,51 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medAbstractData.h>
+#include <medAbstractProcessLegacy.h>
+#include <medCreateMeshFromMaskPluginExport.h>
+
+class medCreateMeshFromMaskPrivate;
+
+class MEDCREATEMESHFROMMASKPLUGIN_EXPORT medCreateMeshFromMask : public medAbstractProcessLegacy
+{
+    Q_OBJECT
+
+public:
+    medCreateMeshFromMask();
+    virtual ~medCreateMeshFromMask();
+
+    virtual QString description() const;
+
+    static bool registered();
+
+public slots:
+
+    //! Input data to the plugin is set through here
+    void setInput(medAbstractData *data, int channel = 0);
+
+    //! Parameters are set through here, channel allows to handle multiple parameters
+    void setParameter(double data, int channel);
+
+    //! Method to actually start the filter
+    int update();
+
+    //! The output will be available through here
+    medAbstractData *output();
+
+    int getNumberOfTriangles();
+
+private:
+    medCreateMeshFromMaskPrivate *d;
+};
+
+dtkAbstractProcess *createmedCreateMeshFromMask();

--- a/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMaskPlugin.cpp
+++ b/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMaskPlugin.cpp
@@ -1,0 +1,56 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medCreateMeshFromMask.h>
+#include <medCreateMeshFromMaskPlugin.h>
+#include <medCreateMeshFromMaskToolBox.h>
+
+medCreateMeshFromMaskPlugin::medCreateMeshFromMaskPlugin(QObject *parent) : medPluginLegacy(parent)
+{
+}
+
+bool medCreateMeshFromMaskPlugin::initialize()
+{
+    if( !medCreateMeshFromMask::registered() )
+    {
+        qWarning() << "Unable to register medCreateMeshFromMask process";
+    }
+    if ( !medCreateMeshFromMaskToolBox::registered() )
+    {
+        qWarning() << "Unable to register medCreateMeshFromMask toolbox";
+    }
+
+    return true;
+}
+
+QString medCreateMeshFromMaskPlugin::description() const
+{
+    QString description = \
+            tr("Convert a mask to a closed surface mesh.\
+               <br><br>This plugin uses the <a href=\"https://www.vtk.org/\" style=\"color: #cc0000\" >VTK library</a>.");
+    return description;
+}
+
+QString medCreateMeshFromMaskPlugin::name() const
+{
+    return "Create Mesh From Mask";
+}
+
+QString medCreateMeshFromMaskPlugin::version() const
+{
+    return MEDCREATEMESHFROMMASKPLUGIN_VERSION;
+}
+
+QStringList medCreateMeshFromMaskPlugin::types() const
+{
+    return QStringList() << "medCreateMeshFromMask";
+}

--- a/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMaskPlugin.h
+++ b/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMaskPlugin.h
@@ -1,0 +1,33 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#include <medCreateMeshFromMaskPluginExport.h>
+#include <medPluginLegacy.h>
+
+class MEDCREATEMESHFROMMASKPLUGIN_EXPORT medCreateMeshFromMaskPlugin : public medPluginLegacy
+{
+    Q_OBJECT
+    Q_INTERFACES(dtkPlugin)
+    Q_PLUGIN_METADATA(IID "fr.inria.medCreateMeshFromMaskPlugin" FILE "medCreateMeshFromMaskPlugin.json")
+    
+public:
+    medCreateMeshFromMaskPlugin(QObject *parent = nullptr);
+    virtual bool initialize();
+
+    virtual QString description() const;
+    virtual QString name() const;
+    virtual QString version() const;
+    virtual QStringList types() const;
+};
+
+

--- a/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMaskPlugin.json
+++ b/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMaskPlugin.json
@@ -1,0 +1,5 @@
+{
+            "name" : "medCreateMeshFromMaskPlugin",
+         "version" : "0.0.1", 	
+    "dependencies" : []
+}

--- a/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMaskPluginExport.h
+++ b/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMaskPluginExport.h
@@ -1,0 +1,25 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#pragma once
+
+#ifdef WIN32
+    #ifdef medCreateMeshFromMaskPlugin_EXPORTS
+        #define MEDCREATEMESHFROMMASKPLUGIN_EXPORT __declspec(dllexport)
+    #else
+        #define MEDCREATEMESHFROMMASKPLUGIN_EXPORT __declspec(dllimport)
+    #endif
+#else
+    #define MEDCREATEMESHFROMMASKPLUGIN_EXPORT
+#endif
+
+

--- a/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMaskToolBox.cpp
+++ b/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMaskToolBox.cpp
@@ -1,0 +1,245 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medAbstractLayeredView.h>
+#include <medCreateMeshFromMask.h>
+#include <medCreateMeshFromMaskToolBox.h>
+#include <medDoubleParameterL.h>
+#include <medPluginManager.h>
+#include <medRunnableProcess.h>
+#include <medTabbedViewContainers.h>
+#include <medToolBoxFactory.h>
+#include <statsROI.h>
+
+class medCreateMeshFromMaskToolBoxPrivate
+{
+public:
+
+    medCreateMeshFromMask *process;
+    medAbstractLayeredView *view;
+    medDoubleParameterL *thresholdSlider;
+    QDoubleSpinBox *reductionSpinBox;
+    QCheckBox *decimateCheckbox;
+    QCheckBox *smoothCheckbox;
+    QSpinBox *iterationsSpinBox;
+    QDoubleSpinBox *relaxationSpinBox;
+    QLabel *trianglesLabel;
+};
+
+medCreateMeshFromMaskToolBox::medCreateMeshFromMaskToolBox(QWidget *parent)
+    : medAbstractSelectableToolBox(parent)
+    , d(new medCreateMeshFromMaskToolBoxPrivate)
+{
+    // Threshold label/slider/spinbox
+    d->thresholdSlider = new medDoubleParameterL("Threshold", this);
+    d->thresholdSlider->setToolTip(tr("Only keep values over or equal to threshold"));
+    d->thresholdSlider->setValue(1);
+    d->thresholdSlider->setRange(0, 2000);
+    d->thresholdSlider->getSlider()->setPageStep(200);
+    d->thresholdSlider->getSlider()->setOrientation(Qt::Horizontal);
+
+    QHBoxLayout *thresholdLayout = new QHBoxLayout;
+    thresholdLayout->addWidget(d->thresholdSlider->getLabel());
+    thresholdLayout->addWidget(d->thresholdSlider->getSlider());
+    thresholdLayout->addWidget(d->thresholdSlider->getSpinBox());
+
+    // Decimation
+    d->decimateCheckbox = new QCheckBox("Decimate mesh");
+    d->decimateCheckbox->setChecked(true);
+
+    d->reductionSpinBox = new QDoubleSpinBox;
+    d->reductionSpinBox->setRange(0.0, 1.0);
+    d->reductionSpinBox->setSingleStep(0.01);
+    d->reductionSpinBox->setDecimals(2);
+    d->reductionSpinBox->setValue(0.8);
+    connect(d->decimateCheckbox, SIGNAL(toggled(bool)), d->reductionSpinBox, SLOT(setEnabled(bool)));
+
+    QLabel *reductionLabel = new QLabel("Reduction target ");
+    QHBoxLayout *reductionLayout = new QHBoxLayout;
+    reductionLayout->addWidget(reductionLabel);
+    reductionLayout->addWidget(d->reductionSpinBox);
+    reductionLayout->setAlignment(Qt::AlignRight);
+
+    // Smoothing
+    d->smoothCheckbox = new QCheckBox("Smooth mesh");
+    d->smoothCheckbox->setChecked(true);
+
+    d->iterationsSpinBox = new QSpinBox;
+    d->iterationsSpinBox->setRange(0, 100);
+    d->iterationsSpinBox->setSingleStep(1);
+    d->iterationsSpinBox->setValue(30);
+    connect(d->smoothCheckbox, SIGNAL(toggled(bool)), d->iterationsSpinBox, SLOT(setEnabled(bool)));
+
+    QLabel *iterationsLabel = new QLabel("Iterations ");
+    QHBoxLayout *iterationsLayout = new QHBoxLayout;
+    iterationsLayout->addWidget(iterationsLabel);
+    iterationsLayout->addWidget(d->iterationsSpinBox);
+    iterationsLayout->setAlignment(Qt::AlignRight);
+
+    d->relaxationSpinBox = new QDoubleSpinBox;
+    d->relaxationSpinBox->setRange(0.0, 1.0);
+    d->relaxationSpinBox->setSingleStep(0.01);
+    d->relaxationSpinBox->setDecimals(2);
+    d->relaxationSpinBox->setValue(0.2);
+    connect(d->smoothCheckbox, SIGNAL(toggled(bool)), d->relaxationSpinBox, SLOT(setEnabled(bool)));
+
+    QLabel *relaxationLabel = new QLabel("Relaxation factor ");
+    QHBoxLayout *relaxationLayout = new QHBoxLayout;
+    relaxationLayout->addWidget(relaxationLabel);
+    relaxationLayout->addWidget(d->relaxationSpinBox);
+    relaxationLayout->setAlignment(Qt::AlignRight);
+
+    QPushButton *runButton = new QPushButton(tr("Run"));
+
+    QFont font;
+    font.setItalic(true);
+    d->trianglesLabel = new QLabel;
+    d->trianglesLabel->setFont(font);
+    d->trianglesLabel->hide();
+
+    QWidget *widget = new QWidget(this);
+
+    QVBoxLayout *displayLayout = new QVBoxLayout();
+
+    displayLayout->addLayout(thresholdLayout);
+    displayLayout->addWidget(d->decimateCheckbox);
+    displayLayout->addLayout(reductionLayout);
+    displayLayout->addWidget(d->smoothCheckbox);
+    displayLayout->addLayout(iterationsLayout);
+    displayLayout->addLayout(relaxationLayout);
+    displayLayout->addWidget(runButton);
+    displayLayout->addWidget(d->trianglesLabel);
+    widget->setLayout(displayLayout);
+
+    this->addWidget(widget);
+
+    d->view = nullptr;
+
+    connect(runButton, SIGNAL(clicked()), this, SLOT(run()));
+}
+
+medCreateMeshFromMaskToolBox::~medCreateMeshFromMaskToolBox()
+{
+    delete d;
+    d = nullptr;
+}
+
+bool medCreateMeshFromMaskToolBox::registered()
+{
+    return medToolBoxFactory::instance()->
+    registerToolBox<medCreateMeshFromMaskToolBox>();
+}
+
+dtkPlugin* medCreateMeshFromMaskToolBox::plugin()
+{
+    medPluginManager *pm = medPluginManager::instance();
+    dtkPlugin *plugin = pm->plugin("Create Mesh From Mask");
+    return plugin;
+}
+
+medAbstractData* medCreateMeshFromMaskToolBox::processOutput()
+{
+    if(!d->process)
+    {
+        return nullptr;
+    }
+    return d->process->output();
+}
+
+void medCreateMeshFromMaskToolBox::updateView()
+{
+    medAbstractView *view = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainerView();
+
+    if(!view)
+    {
+        clear();
+        return;
+    }
+
+    medAbstractLayeredView *medView = dynamic_cast<medAbstractLayeredView *> (view);
+
+    if ((d->view) && (d->view != medView))
+    {
+        clear();
+    }
+    d->view = medView;
+
+    medAbstractData *data = d->view->layerData(d->view->currentLayer());
+
+    // Compute min and max of the data
+    if (data && !data->identifier().contains("vtkDataMesh"))
+    {
+        statsROI statsProcess;
+        statsProcess.setInput(data, 0); // Data
+        statsProcess.setParameter(statsROI::MINMAX);
+
+        if(statsProcess.update() == medAbstractProcessLegacy::SUCCESS)
+        {
+            double m_MinValueImage = statsProcess.output().at(0);
+            double m_MaxValueImage = statsProcess.output().at(1);
+
+            // Update threshold slider/spinbox
+            d->thresholdSlider->setRange(m_MinValueImage, m_MaxValueImage);
+            d->thresholdSlider->setValue(m_MinValueImage + 1);
+            d->thresholdSlider->getSlider()->setPageStep((m_MaxValueImage-m_MinValueImage)/10);
+        }
+    }
+}
+
+void medCreateMeshFromMaskToolBox::addMeshToView()
+{
+    medAbstractData *data = this->processOutput();
+
+    int current = d->view->currentLayer();
+    d->view->addLayer(data);
+    d->view->setCurrentLayer(current);
+}
+
+void medCreateMeshFromMaskToolBox::clear()
+{
+    d->trianglesLabel->hide();
+    d->view = nullptr;
+}
+
+void medCreateMeshFromMaskToolBox::run()
+{
+    if(d->view)
+    {
+        if (d->view->layersCount() > 0)
+        {
+            this->setToolBoxOnWaitStatus();
+
+            d->process = new medCreateMeshFromMask();
+            d->process->setInput(d->view->layerData(d->view->currentLayer()));
+
+            d->process->setParameter(static_cast<double>(d->thresholdSlider->value()),      0); // iso value
+            d->process->setParameter(static_cast<double>(d->decimateCheckbox->isChecked()), 1); // decimation
+            d->process->setParameter(d->reductionSpinBox->value(),                          2); // reduction
+            d->process->setParameter(static_cast<double>(d->smoothCheckbox->isChecked()),   3); // smooth
+            d->process->setParameter(static_cast<double>(d->iterationsSpinBox->value()),    4); // iterations
+            d->process->setParameter(d->relaxationSpinBox->value(),                         5); // relaxation factor
+
+            medRunnableProcess *runProcess = new medRunnableProcess;
+            runProcess->setProcess (d->process);
+            connect (runProcess, SIGNAL (success  (QObject*)), this, SLOT (addMeshToView()));
+            connect (runProcess, SIGNAL (success  (QObject*)), this, SLOT (displayNumberOfTriangles()));
+            connect (runProcess, SIGNAL (failure  (int)),      this, SLOT (handleDisplayError(int)));
+            this->addConnectionsAndStartJob(runProcess);
+        }
+    }
+}
+
+void medCreateMeshFromMaskToolBox::displayNumberOfTriangles()
+{
+    d->trianglesLabel->setText("Number of triangles: " + QString::number(d->process->getNumberOfTriangles()));
+    d->trianglesLabel->show();
+}

--- a/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMaskToolBox.h
+++ b/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMaskToolBox.h
@@ -1,0 +1,55 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medAbstractSelectableToolBox.h>
+#include <medCreateMeshFromMaskPluginExport.h>
+
+class medCreateMeshFromMaskToolBoxPrivate;
+
+/*!
+ * \brief Toolbox to convert a mask to a closed surface mesh.
+ */
+class MEDCREATEMESHFROMMASKPLUGIN_EXPORT medCreateMeshFromMaskToolBox : public medAbstractSelectableToolBox
+{
+    Q_OBJECT
+    MED_TOOLBOX_INTERFACE("Create Mesh from Mask",
+                          "Converts a mask to a closed surface mesh.",
+                          <<"Meshing")
+    
+public:
+    medCreateMeshFromMaskToolBox(QWidget *parent = nullptr);
+    ~medCreateMeshFromMaskToolBox();
+    
+    medAbstractData *processOutput();
+    
+    static bool registered();
+    dtkPlugin *plugin();
+    
+    void clear();
+
+signals:
+    void success();
+    void failure();
+    
+public slots:
+    void run();
+    void displayNumberOfTriangles();
+    void updateView();
+    
+protected slots :
+    void addMeshToView();
+
+private:
+    medCreateMeshFromMaskToolBoxPrivate *d;
+};
+
+

--- a/src/plugins/legacy/medMeshingWorkspace/CMakeLists.txt
+++ b/src/plugins/legacy/medMeshingWorkspace/CMakeLists.txt
@@ -1,0 +1,79 @@
+################################################################################
+#
+# medInria
+#
+# Copyright (c) INRIA 2013 - 2019. All rights reserved.
+# See LICENSE.txt for details.
+# 
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.
+#
+################################################################################
+
+set(TARGET_NAME medMeshingWorkspacePlugin)
+
+## #############################################################################
+## Setup version numbering
+## #############################################################################
+
+set(${TARGET_NAME}_VERSION ${MEDINRIA_VERSION})
+
+string(TOUPPER ${TARGET_NAME} TARGET_NAME_UP)
+add_definitions(-D${TARGET_NAME_UP}_VERSION="${${TARGET_NAME}_VERSION}")
+
+set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
+
+## #############################################################################
+## Resolve dependencies
+## #############################################################################
+
+find_package(dtk REQUIRED)
+include_directories(${dtk_INCLUDE_DIRS})
+
+## #############################################################################
+## List Sources
+## #############################################################################
+
+list_source_files(${TARGET_NAME}
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+
+## #############################################################################
+## include directories
+## #############################################################################
+
+list_header_directories_to_include(${TARGET_NAME}
+  ${${TARGET_NAME}_HEADERS}
+  )
+
+include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
+  ${MEDINRIA_INCLUDE_DIRS}
+  )
+
+## #############################################################################
+## add library
+## #############################################################################
+
+add_library(${TARGET_NAME} SHARED
+  ${${TARGET_NAME}_CFILES}
+  ${${TARGET_NAME}_QRC}
+  )
+
+## #############################################################################
+## Link
+## #############################################################################
+
+target_link_libraries(${TARGET_NAME}
+  ${QT_LIBRARIES}
+  medCore
+  medUtilities
+  )
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+## #############################################################################
+## Install rules
+## #############################################################################
+
+set_plugin_install_rules_legacy(${TARGET_NAME})

--- a/src/plugins/legacy/medMeshingWorkspace/medMeshingWorkspace.cpp
+++ b/src/plugins/legacy/medMeshingWorkspace/medMeshingWorkspace.cpp
@@ -1,0 +1,35 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medMeshingWorkspace.h>
+#include <medSelectorToolBox.h>
+#include <medTabbedViewContainers.h>
+#include <medToolBoxFactory.h>
+#include <medWorkspaceFactory.h>
+
+medMeshingWorkspace::medMeshingWorkspace(QWidget *parent)
+    : medSelectorWorkspace(parent, staticName())
+{
+    connect(this->tabbedViewContainers(), SIGNAL(containersSelectedChanged()),
+            selectorToolBox(), SIGNAL(inputChanged()));
+}
+
+bool medMeshingWorkspace::isUsable()
+{
+    medToolBoxFactory *tbFactory = medToolBoxFactory::instance();
+    return (tbFactory->toolBoxesFromCategory("Meshing").size()!=0);
+}
+
+bool medMeshingWorkspace::registered()
+{
+    return medWorkspaceFactory::instance()->registerWorkspace <medMeshingWorkspace>();
+}

--- a/src/plugins/legacy/medMeshingWorkspace/medMeshingWorkspace.h
+++ b/src/plugins/legacy/medMeshingWorkspace/medMeshingWorkspace.h
@@ -1,0 +1,34 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medSelectorWorkspace.h>
+
+/**
+ * class medMeshingWorkspace
+ * Defines the meshing workspace.
+ */
+class medMeshingWorkspace : public medSelectorWorkspace
+{
+    Q_OBJECT
+    MED_WORKSPACE_INTERFACE("Meshing",
+                            "Providing tool for mesh processing.",
+                            "Methodology")
+
+public:
+    medMeshingWorkspace(QWidget *parent);
+
+    static bool isUsable();
+
+    static bool registered();
+};
+
+

--- a/src/plugins/legacy/medMeshingWorkspace/medMeshingWorkspacePlugin.cpp
+++ b/src/plugins/legacy/medMeshingWorkspace/medMeshingWorkspacePlugin.cpp
@@ -1,0 +1,43 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medMeshingWorkspace.h>
+#include <medMeshingWorkspacePlugin.h>
+
+medMeshingWorkspacePlugin::medMeshingWorkspacePlugin(QObject *parent) : medPluginLegacy(parent)
+{
+}
+
+bool medMeshingWorkspacePlugin::initialize()
+{
+    if(!medMeshingWorkspace::registered())
+    {
+        qWarning() << "Unable to register medMeshingWorkspace type";
+    }
+    
+    return true;
+}
+
+QString medMeshingWorkspacePlugin::name() const
+{
+    return "Meshing Workspace";
+}
+
+QString medMeshingWorkspacePlugin::version() const
+{
+    return MEDMESHINGWORKSPACEPLUGIN_VERSION;
+}
+
+QStringList medMeshingWorkspacePlugin::types() const
+{
+    return QStringList() << "medMeshingWorkspace";
+}

--- a/src/plugins/legacy/medMeshingWorkspace/medMeshingWorkspacePlugin.h
+++ b/src/plugins/legacy/medMeshingWorkspace/medMeshingWorkspacePlugin.h
@@ -1,0 +1,31 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medPluginLegacy.h>
+#include <medMeshingWorkspacePluginExport.h>
+
+class MEDMESHINGWORKSPACEPLUGIN_EXPORT medMeshingWorkspacePlugin : public medPluginLegacy
+{
+    Q_OBJECT
+    Q_INTERFACES(dtkPlugin)
+    Q_PLUGIN_METADATA(IID "fr.inria.medMeshingWorkspacePlugin" FILE "medMeshingWorkspacePlugin.json")
+    
+public:
+    medMeshingWorkspacePlugin(QObject *parent = nullptr);
+    virtual bool initialize();
+    
+    virtual QString name() const;
+    virtual QString version() const;
+    virtual QStringList types() const;
+};
+
+

--- a/src/plugins/legacy/medMeshingWorkspace/medMeshingWorkspacePlugin.json
+++ b/src/plugins/legacy/medMeshingWorkspace/medMeshingWorkspacePlugin.json
@@ -1,0 +1,5 @@
+{
+            "name" : "medMeshingWorkspacePlugin",
+         "version" : "0.0.1", 	
+    "dependencies" : []
+}

--- a/src/plugins/legacy/medMeshingWorkspace/medMeshingWorkspacePluginExport.h
+++ b/src/plugins/legacy/medMeshingWorkspace/medMeshingWorkspacePluginExport.h
@@ -1,0 +1,25 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#pragma once
+
+#ifdef WIN32
+    #ifdef medMeshingWorkspacePlugin_EXPORTS
+        #define MEDMESHINGWORKSPACEPLUGIN_EXPORT __declspec(dllexport) 
+    #else
+        #define MEDMESHINGWORKSPACEPLUGIN_EXPORT __declspec(dllimport) 
+    #endif
+#else
+    #define MEDMESHINGWORKSPACEPLUGIN_EXPORT
+#endif
+
+

--- a/src/plugins/legacy/medRemeshing/CMakeLists.txt
+++ b/src/plugins/legacy/medRemeshing/CMakeLists.txt
@@ -1,0 +1,86 @@
+################################################################################
+#
+# medInria
+#
+# Copyright (c) INRIA 2013 - 2019. All rights reserved.
+# See LICENSE.txt for details.
+# 
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.
+#
+################################################################################
+
+set(TARGET_NAME medRemeshingPlugin)
+
+## #############################################################################
+## Setup version numbering
+## #############################################################################
+
+set(${TARGET_NAME}_VERSION ${MEDINRIA_VERSION})
+
+string(TOUPPER ${TARGET_NAME} TARGET_NAME_UP)
+add_definitions(-D${TARGET_NAME_UP}_VERSION="${${TARGET_NAME}_VERSION}")
+
+set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
+
+## #############################################################################
+## Resolve dependencies
+## #############################################################################
+
+find_package(dtk REQUIRED)
+include_directories(${dtk_INCLUDE_DIRS})
+
+find_package(ITK REQUIRED)
+include(${ITK_USE_FILE})
+
+find_package(VTK REQUIRED)
+include(${VTK_USE_FILE})
+
+## #############################################################################
+## List Sources
+## #############################################################################
+
+list_source_files(${TARGET_NAME}
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+
+## #############################################################################
+## include directories
+## #############################################################################
+
+list_header_directories_to_include(${TARGET_NAME}
+  ${${TARGET_NAME}_HEADERS}
+  )
+
+include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
+  ${MEDINRIA_INCLUDE_DIRS}
+  )
+
+## #############################################################################
+## add library
+## #############################################################################
+
+add_library(${TARGET_NAME} SHARED
+  ${${TARGET_NAME}_CFILES}
+  ${${TARGET_NAME}_QRC}
+  )
+
+## #############################################################################
+## Link
+## #############################################################################
+
+target_link_libraries(${TARGET_NAME}
+  ${QT_LIBRARIES}
+  medCore
+  medVtkInria
+  medUtilities
+  )
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+## #############################################################################
+## Install rules
+## #############################################################################
+
+set_plugin_install_rules_legacy(${TARGET_NAME})

--- a/src/plugins/legacy/medRemeshing/medDecimateMeshProcess.cpp
+++ b/src/plugins/legacy/medRemeshing/medDecimateMeshProcess.cpp
@@ -1,0 +1,206 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+//dtk
+#include <dtkCoreSupport/dtkAbstractProcessFactory.h>
+#include <dtkCoreSupport/dtkSmartPointer.h>
+
+//medinria
+#include <medAbstractDataFactory.h>
+#include <medDecimateMeshProcess.h>
+#include <medUtilities.h>
+#include <vtkMetaDataSetSequence.h>
+#include <vtkMetaSurfaceMesh.h>
+
+//vtk
+#include <vtkDecimatePro.h>
+#include <vtkSmartPointer.h>
+#include <vtkTriangleFilter.h>
+
+// /////////////////////////////////////////////////////////////////
+// medDecimateMeshProcessPrivate
+// /////////////////////////////////////////////////////////////////
+
+class medDecimateMeshProcessPrivate
+{
+public:
+    dtkSmartPointer <medAbstractData> input;
+    dtkSmartPointer <medAbstractData> output;
+    double targetReduction;
+    bool preserveTopology;
+    bool changeMetaData;
+};
+
+// /////////////////////////////////////////////////////////////////
+// medDecimateMeshProcess
+// /////////////////////////////////////////////////////////////////
+
+medDecimateMeshProcess::medDecimateMeshProcess() : d(new medDecimateMeshProcessPrivate)
+{
+    d->input = nullptr;
+    d->output = nullptr;
+    d->targetReduction = 0.0;
+    d->preserveTopology = false;
+    d->changeMetaData = true;
+}
+
+medDecimateMeshProcess::~medDecimateMeshProcess()
+{
+    delete d;
+    d = nullptr;
+}
+
+bool medDecimateMeshProcess::registered()
+{
+    return dtkAbstractProcessFactory::instance()->registerProcessType("medDecimateMeshProcess", createmedDecimateMeshProcess);
+}
+
+QString medDecimateMeshProcess::description() const
+{
+    return "medDecimateMeshProcess";
+}
+
+void medDecimateMeshProcess::setInput(medAbstractData *data, int channel)
+{
+    d->input = data;
+}
+
+void medDecimateMeshProcess::setParameter(double data, int channel)
+{
+    if (channel == 0)
+    {
+        d->targetReduction = data;
+    }
+}
+
+void medDecimateMeshProcess::setParameter(int data, int channel)
+{
+    if (channel == 1)
+    {
+        d->preserveTopology = data;
+    }
+    else if(channel == 2)
+    {
+        d->changeMetaData = data;
+    }
+}
+
+vtkMetaDataSet* medDecimateMeshProcess::decimateOneMetaDataSet(vtkMetaDataSet *inputMetaDaset)
+{
+    vtkPolyData *polyData = dynamic_cast<vtkPolyData*>(inputMetaDaset->GetDataSet());
+
+    if(!polyData)
+    {
+        emit polyDataCastFailure();
+        return nullptr;
+    }
+    else
+    {
+        vtkSmartPointer<vtkTriangleFilter> triFilter = vtkSmartPointer<vtkTriangleFilter>::New();
+        triFilter->SetInputData(polyData);
+        triFilter->Update();
+
+        int originalNbOfPolygons = polyData->GetNumberOfPolys();
+        // nb of polygons expected after processing
+        int theoreticalFinalNbOfPolygons = ceil (originalNbOfPolygons * (1-d->targetReduction));
+
+        vtkDecimatePro* contourDecimated = vtkDecimatePro::New();
+        contourDecimated->SetInputConnection(triFilter->GetOutputPort());
+        contourDecimated->SetTargetReduction(d->targetReduction);
+        // Turn on/off whether to preserve the mesh topology.
+        // If on, splitting and hole elimination will not occur.
+        // Can limit the maximum reduction that may be achieved.
+        contourDecimated->SetPreserveTopology(d->preserveTopology);
+        contourDecimated->Update();
+
+        vtkMetaSurfaceMesh * smesh = vtkMetaSurfaceMesh::New();
+        smesh->SetDataSet(contourDecimated->GetOutput());
+        //If we can't reach the desired decimation
+        if (contourDecimated->GetOutput()->GetNumberOfPolys() > theoreticalFinalNbOfPolygons)
+        {
+            emit warning();
+        }
+        contourDecimated->Delete();
+
+        return smesh;
+    }
+}
+
+int medDecimateMeshProcess::update()
+{
+    progressed(0);
+
+    if (!d->input)
+    {
+        return medAbstractProcessLegacy::FAILURE;
+    }
+    if(!d->input->identifier().contains("vtkDataMesh"))
+    {
+        return medAbstractProcessLegacy::FAILURE;
+    }
+
+    d->output = medAbstractDataFactory::instance()->createSmartPointer(d->input->identifier());
+
+    if (d->input->identifier() == "vtkDataMesh4D")
+    {
+        vtkMetaDataSetSequence *inputSequence = static_cast<vtkMetaDataSetSequence*>(d->input->data());
+        vtkMetaDataSetSequence *outputSequence = vtkMetaDataSetSequence::New();
+
+        foreach(vtkMetaDataSet *inputMetaDataSet, inputSequence->GetMetaDataSetList())
+        {
+            vtkMetaDataSet *outputMetaDataSet = decimateOneMetaDataSet(inputMetaDataSet);
+            outputMetaDataSet->SetTime(inputMetaDataSet->GetTime());
+            if (outputMetaDataSet == nullptr)
+            {
+                return medAbstractProcessLegacy::FAILURE;
+            }
+            outputSequence->AddMetaDataSet(outputMetaDataSet);
+            outputMetaDataSet->Delete();
+        }
+        d->output->setData(outputSequence);
+        outputSequence->Delete();
+    }
+    else
+    {
+        vtkMetaDataSet *inputMetaDataSet = static_cast<vtkMetaDataSet*>(d->input->data());
+        vtkMetaDataSet *outputMetaDataSet = decimateOneMetaDataSet(inputMetaDataSet);
+        if (outputMetaDataSet == nullptr)
+        {
+            return medAbstractProcessLegacy::FAILURE;
+        }
+        d->output->setData(outputMetaDataSet);
+        outputMetaDataSet->Delete();
+    }
+
+    progressed(100);
+
+    if (d->changeMetaData)
+    {
+        medUtilities::setDerivedMetaData(d->output, d->input, "decimated");
+    }
+
+    return medAbstractProcessLegacy::SUCCESS;
+}
+
+medAbstractData * medDecimateMeshProcess::output()
+{
+    return d->output;
+}
+
+// /////////////////////////////////////////////////////////////////
+// Type instantiation
+// /////////////////////////////////////////////////////////////////
+
+dtkAbstractProcess *createmedDecimateMeshProcess()
+{
+    return new medDecimateMeshProcess;
+}

--- a/src/plugins/legacy/medRemeshing/medDecimateMeshProcess.h
+++ b/src/plugins/legacy/medRemeshing/medDecimateMeshProcess.h
@@ -1,0 +1,63 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#pragma once
+
+#include <medAbstractData.h>
+#include <medAbstractProcessLegacy.h>
+#include <medRemeshingPluginExport.h>
+
+#include <vtkMetaDataSet.h>
+
+class medDecimateMeshProcessPrivate;
+
+class MEDREMESHINGPLUGIN_EXPORT medDecimateMeshProcess : public medAbstractProcessLegacy
+{
+    Q_OBJECT
+    
+public:
+    medDecimateMeshProcess();
+    virtual ~medDecimateMeshProcess();
+    
+    virtual QString description() const;
+    
+    static bool registered();
+
+signals:
+    void warning();
+    void polyDataCastFailure();
+    
+public slots:
+    
+    //! Input data to the plugin is set through here
+    void setInput(medAbstractData *data, int channel = 0);
+    
+    //! Parameters are set through here, channel allows to handle multiple parameters
+    void setParameter(double data, int channel);
+    void setParameter(int data, int channel);
+
+    //! Method to actually start the filter
+    int update();
+    
+    //! The output will be available through here
+    medAbstractData *output();
+
+protected:
+    vtkMetaDataSet* decimateOneMetaDataSet(vtkMetaDataSet *inputMetaDataSet);
+
+private:
+    medDecimateMeshProcessPrivate *d;
+};
+
+dtkAbstractProcess *createmedDecimateMeshProcess();
+
+

--- a/src/plugins/legacy/medRemeshing/medRefineMeshProcess.cpp
+++ b/src/plugins/legacy/medRemeshing/medRefineMeshProcess.cpp
@@ -1,0 +1,185 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+//dtk
+#include <dtkCoreSupport/dtkAbstractProcessFactory.h>
+#include <dtkCoreSupport/dtkSmartPointer.h>
+
+//medinria
+#include <medAbstractDataFactory.h>
+#include <medRefineMeshProcess.h>
+#include <medUtilities.h>
+#include <vtkMetaDataSetSequence.h>
+#include <vtkMetaSurfaceMesh.h>
+
+//vtk
+#include <vtkButterflySubdivisionFilter.h>
+#include <vtkSmartPointer.h>
+#include <vtkTriangleFilter.h>
+
+// /////////////////////////////////////////////////////////////////
+// medRefineMeshProcessPrivate
+// /////////////////////////////////////////////////////////////////
+
+class medRefineMeshProcessPrivate
+{
+public:
+    dtkSmartPointer <medAbstractData> input;
+    dtkSmartPointer <medAbstractData> output;
+    double nbOfSubdivisions;
+    bool changeMetaData;
+};
+
+// /////////////////////////////////////////////////////////////////
+// medRefineMeshProcess
+// /////////////////////////////////////////////////////////////////
+
+medRefineMeshProcess::medRefineMeshProcess() : d(new medRefineMeshProcessPrivate)
+{
+    d->input = nullptr;
+    d->output = nullptr;
+    d->nbOfSubdivisions = 1.0;
+    d->changeMetaData = true;
+}
+
+medRefineMeshProcess::~medRefineMeshProcess()
+{
+    delete d;
+    d = nullptr;
+}
+
+bool medRefineMeshProcess::registered()
+{
+    return dtkAbstractProcessFactory::instance()->registerProcessType("medRefineMeshProcess", createmedRefineMeshProcess);
+}
+
+QString medRefineMeshProcess::description() const
+{
+    return "medRefineMeshProcess";
+}
+
+void medRefineMeshProcess::setInput(medAbstractData *data, int channel)
+{
+    d->input = data;
+}
+
+void medRefineMeshProcess::setParameter(double data, int channel)
+{
+    d->nbOfSubdivisions = data;
+}
+
+void medRefineMeshProcess::setParameter(int data, int channel)
+{
+    if(channel == 1)
+    {
+        d->changeMetaData = data;
+    }
+}
+
+vtkMetaDataSet* medRefineMeshProcess::refineOneMetaDataSet(vtkMetaDataSet *inputMetaDaset)
+{
+    vtkPolyData *polyData = dynamic_cast<vtkPolyData*>(inputMetaDaset->GetDataSet());
+
+    if(!polyData)
+    {
+        emit polyDataCastFailure();
+        return nullptr;
+    }
+    else
+    {
+        vtkSmartPointer<vtkTriangleFilter> triFilter = vtkSmartPointer<vtkTriangleFilter>::New();
+        triFilter->SetInputData(polyData);
+        triFilter->Update();
+
+        vtkButterflySubdivisionFilter *loopRefineFilter = vtkButterflySubdivisionFilter::New();
+        loopRefineFilter->SetInputConnection(triFilter->GetOutputPort());
+        loopRefineFilter->SetNumberOfSubdivisions(d->nbOfSubdivisions);
+        loopRefineFilter->SetGlobalWarningDisplay(true);
+        loopRefineFilter->Update();
+
+        vtkMetaSurfaceMesh *smesh = vtkMetaSurfaceMesh::New();
+        smesh->SetDataSet(loopRefineFilter->GetOutput());
+        loopRefineFilter->Delete();
+
+        return smesh;
+    }
+}
+
+int medRefineMeshProcess::update()
+{
+    progressed(0);
+
+    if (!d->input)
+    {
+        return medAbstractProcessLegacy::FAILURE;
+    }
+    if(!d->input->identifier().contains("vtkDataMesh"))
+    {
+        return medAbstractProcessLegacy::FAILURE;
+    }
+
+    d->output = medAbstractDataFactory::instance()->createSmartPointer(d->input->identifier());
+
+    if (d->input->identifier() == "vtkDataMesh4D")
+    {
+        vtkMetaDataSetSequence *inputSequence = static_cast<vtkMetaDataSetSequence*>(d->input->data());
+        vtkMetaDataSetSequence *outputSequence = vtkMetaDataSetSequence::New();
+
+        foreach(vtkMetaDataSet *inputMetaDataSet, inputSequence->GetMetaDataSetList())
+        {
+            vtkMetaDataSet *outputMetaDataSet = refineOneMetaDataSet(inputMetaDataSet);
+            outputMetaDataSet->SetTime(inputMetaDataSet->GetTime());
+            if (outputMetaDataSet == nullptr)
+            {
+                return medAbstractProcessLegacy::FAILURE;
+            }
+            outputSequence->AddMetaDataSet(outputMetaDataSet);
+            outputMetaDataSet->Delete();
+        }
+        d->output->setData(outputSequence);
+        outputSequence->Delete();
+    }
+    else
+    {
+        vtkMetaDataSet *inputMetaDataSet = static_cast<vtkMetaDataSet*>(d->input->data());
+        vtkMetaDataSet *outputMetaDataSet = refineOneMetaDataSet(inputMetaDataSet);
+        if (outputMetaDataSet == nullptr)
+        {
+            return medAbstractProcessLegacy::FAILURE;
+        }
+        d->output->setData(outputMetaDataSet);
+        outputMetaDataSet->Delete();
+    }
+
+    progressed(100);
+
+    if (d->changeMetaData)
+    {
+        medUtilities::setDerivedMetaData(d->output, d->input, "refined");
+    }
+
+    return medAbstractProcessLegacy::SUCCESS;
+}
+
+medAbstractData * medRefineMeshProcess::output()
+{
+    return d->output;
+}
+
+// /////////////////////////////////////////////////////////////////
+// Type instantiation
+// /////////////////////////////////////////////////////////////////
+
+dtkAbstractProcess *createmedRefineMeshProcess()
+{
+    return new medRefineMeshProcess;
+}

--- a/src/plugins/legacy/medRemeshing/medRefineMeshProcess.h
+++ b/src/plugins/legacy/medRemeshing/medRefineMeshProcess.h
@@ -1,0 +1,60 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medAbstractData.h>
+#include <medAbstractProcessLegacy.h>
+#include <medRemeshingPluginExport.h>
+
+#include <vtkMetaDataSet.h>
+
+class medRefineMeshProcessPrivate;
+
+class MEDREMESHINGPLUGIN_EXPORT medRefineMeshProcess : public medAbstractProcessLegacy
+{
+    Q_OBJECT
+    
+public:
+    medRefineMeshProcess();
+    virtual ~medRefineMeshProcess();
+    
+    virtual QString description() const;
+    
+    static bool registered();
+
+signals:
+    void polyDataCastFailure();
+    
+public slots:
+    
+    //! Input data to the plugin is set through here
+    void setInput(medAbstractData *data, int channel = 0);
+    
+    //! Parameters are set through here, channel allows to handle multiple parameters
+    void setParameter(double data, int channel = 0);
+    void setParameter(int data, int channel);
+
+    //! Method to actually start the filter
+    int update();
+    
+    //! The output will be available through here
+    medAbstractData *output();
+
+protected:
+    vtkMetaDataSet* refineOneMetaDataSet(vtkMetaDataSet *inputMetaDataSet);
+
+private:
+    medRefineMeshProcessPrivate *d;
+};
+
+dtkAbstractProcess *createmedRefineMeshProcess();
+
+

--- a/src/plugins/legacy/medRemeshing/medRemeshingPlugin.cpp
+++ b/src/plugins/legacy/medRemeshing/medRemeshingPlugin.cpp
@@ -1,0 +1,74 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medRemeshingPlugin.h>
+#include <medDecimateMeshProcess.h>
+#include <medRefineMeshProcess.h>
+#include <medSmoothMeshProcess.h>
+#include <medRemeshingToolBox.h>
+
+medRemeshingPlugin::medRemeshingPlugin(QObject *parent) : medPluginLegacy(parent)
+{
+}
+
+bool medRemeshingPlugin::initialize()
+{
+    if ( !medDecimateMeshProcess::registered() )
+    {
+        qWarning() << "Unable to register medDecimateMeshProcess";
+    }
+    if ( !medRefineMeshProcess::registered() )
+    {
+        qWarning() << "Unable to register medRefineMeshProcess";
+    }
+    if ( !medSmoothMeshProcess::registered() )
+    {
+        qWarning() << "Unable to register medSmoothMeshProcess";
+    }
+    if ( !medRemeshingToolBox::registered() )
+    {
+        qWarning() << "Unable to register medRemeshingToolBox";
+    }
+    return true;
+}
+
+QString medRemeshingPlugin::name() const
+{
+    return "Remeshing";
+}
+
+QString medRemeshingPlugin::description() const
+{
+    QString description = \
+            "Modify the number of polygons of a 3D mesh:<br><br> \
+            - <i>Refinement</i><br> \
+            Creates four new triangles for each triangle in the mesh using <a href=\"https://www.vtk.org/doc/nightly/html/classvtkButterflySubdivisionFilter.html\" style=\"color: #cc0000\" >vtkButterflySubdivisionFilter</a>.<br><br> \
+            - <i>Decimation</i><br> \
+            Divides by four the number of triangles using <a href=\"https://www.vtk.org/doc/nightly/html/classvtkDecimatePro.html\" style=\"color: #cc0000\" >vtkDecimatePro</a>.<br><br> \
+            - <i>Manual</i> modification of the number of triangles.<br><br> \
+            - <i>Smooth</i> the mesh using <a href=\"https://www.vtk.org/doc/nightly/html/classvtkSmoothPolyDataFilter.html\" style=\"color: #cc0000\" >vtkSmoothPolyDataFilter</a>. \
+            <br><br>This plugin uses the <a href=\"https://www.vtk.org/\" style=\"color: #cc0000\" >VTK library</a>.";
+
+    return description;
+}
+
+QString medRemeshingPlugin::version() const
+{
+    return MEDREMESHINGPLUGIN_VERSION;
+}
+
+QStringList medRemeshingPlugin::types() const
+{
+    return QStringList()    << "medDecimateMeshProcess"
+                            << "medRefineMeshProcess"
+                            << "medSmoothMeshProcess";
+}

--- a/src/plugins/legacy/medRemeshing/medRemeshingPlugin.h
+++ b/src/plugins/legacy/medRemeshing/medRemeshingPlugin.h
@@ -1,0 +1,32 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medPluginLegacy.h>
+#include <medRemeshingPluginExport.h>
+
+class MEDREMESHINGPLUGIN_EXPORT medRemeshingPlugin : public medPluginLegacy
+{
+    Q_OBJECT
+    Q_INTERFACES(dtkPlugin)
+    Q_PLUGIN_METADATA(IID "fr.inria.medRemeshingPlugin" FILE "medRemeshingPlugin.json")
+
+public:
+    medRemeshingPlugin(QObject *parent = nullptr);
+    virtual bool initialize();
+    
+    virtual QString name() const;
+    virtual QString description() const;
+    virtual QString version() const;
+    virtual QStringList types() const;
+};
+
+

--- a/src/plugins/legacy/medRemeshing/medRemeshingPlugin.json
+++ b/src/plugins/legacy/medRemeshing/medRemeshingPlugin.json
@@ -1,0 +1,5 @@
+{
+            "name" : "medRemeshingPlugin",
+         "version" : "0.0.1", 	
+    "dependencies" : []
+}

--- a/src/plugins/legacy/medRemeshing/medRemeshingPluginExport.h
+++ b/src/plugins/legacy/medRemeshing/medRemeshingPluginExport.h
@@ -1,0 +1,25 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#pragma once
+
+#ifdef WIN32
+    #ifdef medRemeshingPlugin_EXPORTS
+        #define MEDREMESHINGPLUGIN_EXPORT __declspec(dllexport)
+    #else
+        #define MEDREMESHINGPLUGIN_EXPORT __declspec(dllimport)
+    #endif
+#else
+    #define MEDREMESHINGPLUGIN_EXPORT
+#endif
+
+

--- a/src/plugins/legacy/medRemeshing/medRemeshingToolBox.cpp
+++ b/src/plugins/legacy/medRemeshing/medRemeshingToolBox.cpp
@@ -1,0 +1,613 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <dtkCoreSupport/dtkAbstractProcessFactory.h>
+
+#include <medAbstractLayeredView.h>
+#include <medDecimateMeshProcess.h>
+#include <medMessageController.h>
+#include <medPluginManager.h>
+#include <medRefineMeshProcess.h>
+#include <medRemeshingToolBox.h>
+#include <medRunnableProcess.h>
+#include <medSmoothMeshProcess.h>
+#include <medTabbedViewContainers.h>
+#include <medToolBoxFactory.h>
+#include <medUtilities.h>
+#include <medVtkViewBackend.h>
+
+#include <vtkDataSetCollection.h>
+#include <vtkImageView2D.h>
+#include <vtkPointSet.h>
+
+class medRemeshingToolBoxPrivate
+{
+public:
+    dtkSmartPointer <medDecimateMeshProcess> decimateProcess;
+    dtkSmartPointer <medRefineMeshProcess> refineProcess;
+    dtkSmartPointer <medSmoothMeshProcess> smoothProcess;
+
+    medRemeshingToolBox::ProcessName currentProcess;
+    medRemeshingToolBox::ProcessName lastManualProcess;
+
+    medAbstractLayeredView *view;
+    dtkSmartPointer<medAbstractData> input, refinedMesh;
+    QLabel *initialCellsLabel, *outputCellsLabel;
+    QSpinBox *trianglesSpinBox;
+    QPushButton *decimateButton, *refineButton, *runUserNumber, *resetButton;
+    QRadioButton *topologyRadioButton;
+    vtkSmartPointer<vtkDataSet> original_points;
+
+    // Smooth tool
+    QSpinBox *iterationsSpinBox;
+    QDoubleSpinBox *relaxationSpinBox;
+    QPushButton *smoothButton;
+};
+
+medRemeshingToolBox::medRemeshingToolBox(QWidget *parent)
+ : medAbstractSelectableToolBox(parent)
+ , d(new medRemeshingToolBoxPrivate)
+{
+    QVBoxLayout *displayLayout = new QVBoxLayout();
+
+    // Font used for warning, information, etc.
+    QFont font;
+    font.setItalic(true);
+
+    // Decimate and Refine buttons
+    QLabel* decimateRefineTitle = new QLabel("Decimate/Refine", this);
+    decimateRefineTitle->setStyleSheet("QLabel { color : #ED6639; }");
+    displayLayout->addWidget(decimateRefineTitle);
+
+    // Decimate
+    QLabel *explainDecimationTxt = new QLabel("divide by 4", this);
+
+    d->decimateButton = new QPushButton("Decimate", this);
+    d->decimateButton->setToolTip("Reduce the number of cells by 4");
+    connect (d->decimateButton, SIGNAL(clicked()), this, SLOT(launchDecimate()));
+
+    QHBoxLayout *layoutDecimate = new QHBoxLayout();
+    layoutDecimate->addWidget(explainDecimationTxt);
+    layoutDecimate->addWidget(d->decimateButton);
+    displayLayout->addLayout(layoutDecimate);
+
+    d->topologyRadioButton = new QRadioButton(tr("Preserve topology during decimation"));
+    d->topologyRadioButton->setToolTip("Turn on/off whether to preserve the mesh topology.\n If on, splitting and hole elimination will not occur.\n Can limit the maximum reduction that may be achieved.");
+    d->topologyRadioButton->setChecked(true);
+    d->topologyRadioButton->setObjectName("topologyRadioButton");
+    displayLayout->addWidget(d->topologyRadioButton);
+    connect (d->topologyRadioButton, SIGNAL(toggled(bool)), this, SLOT(allowDecimateIfTopologyButtonUnchecked(bool)));
+
+    // Refine
+    QLabel *explainRefineTxt = new QLabel("multiply by 4", this);
+    d->refineButton = new QPushButton("Refine", this);
+    d->refineButton->setToolTip("Increase the number of cells by 4");
+    connect (d->refineButton, SIGNAL(clicked()), this, SLOT(launchRefine()));
+
+    QHBoxLayout *layoutRefine = new QHBoxLayout();
+    layoutRefine->addWidget(explainRefineTxt);
+    layoutRefine->addWidget(d->refineButton);
+    displayLayout->addLayout(layoutRefine);
+
+    // Separator
+    QFrame *line1 = new QFrame(this);
+    line1->setFrameShape(QFrame::HLine);
+    line1->setFrameShadow(QFrame::Sunken);
+    displayLayout->addWidget(line1);
+
+    // User can choose a number of cells
+    QLabel *numberTitle = new QLabel("Choose the number of cells that you want", this);
+    numberTitle->setStyleSheet("QLabel { color : #ED6639; }");
+    displayLayout->addWidget(numberTitle);
+
+    QLabel *numberTxt = new QLabel("number of cells:", this);
+    d->trianglesSpinBox = new QSpinBox;
+    d->trianglesSpinBox->setMaximum(30000000);
+    d->trianglesSpinBox->setMinimum(0);
+    d->trianglesSpinBox->setValue(0);
+    d->runUserNumber = new QPushButton("Run", this);
+    connect(d->runUserNumber, SIGNAL(clicked()), this, SLOT(imposeNbOfTriangles()));
+
+    QHBoxLayout *numberLayout = new QHBoxLayout();
+    numberLayout->addWidget(numberTxt);
+    numberLayout->addWidget(d->trianglesSpinBox);
+    numberLayout->addWidget(d->runUserNumber);
+    displayLayout->addLayout(numberLayout);
+
+    // Separator
+    QFrame *line2 = new QFrame(this);
+    line2->setFrameShape(QFrame::HLine);
+    line2->setFrameShadow(QFrame::Sunken);
+    displayLayout->addWidget(line2);
+
+    // Smooth tool
+    QLabel *smoothTitle = new QLabel("Smooth", this);
+    smoothTitle->setStyleSheet("QLabel { color : #ED6639; }");
+    displayLayout->addWidget(smoothTitle);
+
+    QLabel *iterationsLabel = new QLabel("iterations: ", this);
+    d->iterationsSpinBox = new QSpinBox;
+    d->iterationsSpinBox->setRange(0, 100);
+    d->iterationsSpinBox->setSingleStep(1);
+    d->iterationsSpinBox->setValue(30);
+
+    QLabel *relaxationLabel = new QLabel("relaxation factor: ", this);
+    d->relaxationSpinBox = new QDoubleSpinBox;
+    d->relaxationSpinBox->setRange(0.0, 1.0);
+    d->relaxationSpinBox->setSingleStep(0.01);
+    d->relaxationSpinBox->setDecimals(2);
+    d->relaxationSpinBox->setValue(0.2);
+
+    d->smoothButton = new QPushButton(tr("Run"), this);
+    connect(d->smoothButton, SIGNAL(clicked()), this, SLOT(smoothMesh()));
+
+    QHBoxLayout *smoothLayout = new QHBoxLayout();
+    smoothLayout->addWidget(iterationsLabel);
+    smoothLayout->addStretch(1);
+    smoothLayout->addWidget(d->iterationsSpinBox);
+    smoothLayout->addStretch(1);
+    smoothLayout->addWidget(relaxationLabel);
+    smoothLayout->addStretch(1);
+    smoothLayout->addWidget(d->relaxationSpinBox);
+    smoothLayout->addStretch(1);
+    smoothLayout->addWidget(d->smoothButton);
+    smoothLayout->addStretch(1);
+    displayLayout->addLayout(smoothLayout);
+
+    // Separator
+    QFrame *line3 = new QFrame(this);
+    line3->setFrameShape(QFrame::HLine);
+    line3->setFrameShadow(QFrame::Sunken);
+    displayLayout->addWidget(line3);
+
+    // Number of cells labels
+    QVBoxLayout *numberOfCellsLayout = new QVBoxLayout();
+    d->initialCellsLabel = new QLabel(this);
+    d->initialCellsLabel->setFont(font);
+    d->outputCellsLabel = new QLabel(this);
+    d->outputCellsLabel->setFont(font);
+    d->outputCellsLabel->hide();
+    numberOfCellsLayout->addWidget(d->initialCellsLabel);
+    numberOfCellsLayout->addWidget(d->outputCellsLabel);
+    displayLayout->addLayout(numberOfCellsLayout);
+
+    // Reset button
+    d->resetButton = new QPushButton(tr("Reset"), this);
+    d->resetButton->setEnabled(false);
+    d->resetButton->setObjectName("resetButton");
+    connect(d->resetButton, SIGNAL(clicked()), this, SLOT(reset()));
+    displayLayout->addWidget(d->resetButton);
+
+    QWidget *widget = new QWidget(this);
+    widget->setLayout(displayLayout);
+
+    this->addWidget(widget);
+
+    disableButtons(true);
+    d->view = nullptr;
+    d->input = nullptr;
+    d->refinedMesh = nullptr;
+    d->original_points = nullptr;
+
+    this->hide();
+}
+
+medRemeshingToolBox::~medRemeshingToolBox()
+{
+    delete d;
+    d = nullptr;
+}
+
+medAbstractData *medRemeshingToolBox::processOutput()
+{
+    medAbstractData *res = nullptr;
+
+    switch (d->currentProcess)
+    {
+    case REFINE:
+    {
+        if(d->refineProcess)
+        {
+            res = d->refineProcess->output();
+        }
+
+        break;
+    }
+    case DECIMATE:
+    {
+        if(d->decimateProcess)
+        {
+            res = d->decimateProcess->output();
+        }
+
+        break;
+    }
+    case SMOOTH:
+    {
+        if(d->smoothProcess)
+        {
+            res = d->smoothProcess->output();
+        }
+
+        break;
+    }
+    case MANUAL:
+    {
+        if(d->lastManualProcess == REFINE)
+        {
+            medUtilities::setDerivedMetaData(d->refineProcess->output(), d->input, "manual");
+            res = d->refineProcess->output();
+        }
+        else if(d->lastManualProcess == DECIMATE)
+        {
+            medUtilities::setDerivedMetaData(d->decimateProcess->output(), d->input, "manual");
+            res = d->decimateProcess->output();
+        }
+
+        break;
+    }
+    }
+
+    return res;
+}
+
+bool medRemeshingToolBox::registered()
+{
+    return medToolBoxFactory::instance()->registerToolBox<medRemeshingToolBox>();
+}
+
+dtkPlugin* medRemeshingToolBox::plugin()
+{
+    medPluginManager *pm = medPluginManager::instance();
+    dtkPlugin *plugin = pm->plugin("Remeshing");
+    return plugin;
+}
+
+void medRemeshingToolBox::updateView()
+{
+    medAbstractView *view = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainerView();
+
+    if(!view)
+    {
+        clear();
+        return;
+    }
+
+    medAbstractLayeredView *medView = dynamic_cast<medAbstractLayeredView *> (view);
+
+    if ((d->view) && (d->view != medView) )
+    {
+        clear();
+    }
+
+    d->view = medView;
+
+    medAbstractData *data = d->view->layerData(d->view->currentLayer());
+
+    if (data && data->identifier().contains("vtkDataMesh"))
+    {
+        if(!d->input)
+        {
+            d->input       = d->view->layerData(d->view->currentLayer());
+            d->refinedMesh = d->view->layerData(d->view->currentLayer());
+            disableButtons(false);
+
+            vtkMetaDataSet *_dataset = static_cast<vtkMetaDataSet*>(d->input->data());
+
+            d->original_points = vtkSmartPointer<vtkDataSet>::Take(_dataset->GetDataSet()->NewInstance());
+            d->original_points->DeepCopy(_dataset->GetDataSet());
+
+            d->trianglesSpinBox->setValue(getNumberOfCells(d->input));
+            d->initialCellsLabel->setText("Original number of cells: " + QString::number(getNumberOfCells(d->input)));
+            QObject::connect(d->view, SIGNAL(currentLayerChanged()),
+                             this, SLOT(clearAndUpdate()),
+                             Qt::UniqueConnection);
+
+            medUtilities::switchTo3D(d->view, medUtilities::MSR);
+        }
+    }
+}
+
+void medRemeshingToolBox::clearAndUpdate()
+{
+    clear();
+    updateView();
+}
+
+void medRemeshingToolBox::clear()
+{
+    d->view = nullptr;
+    d->input = nullptr;
+    d->refinedMesh = nullptr;
+    d->original_points = nullptr;
+    d->resetButton->setEnabled(false);
+    d->outputCellsLabel->hide();
+    d->initialCellsLabel->setText("");
+    d->trianglesSpinBox->setValue(0);
+
+    // "Choose the number of cells", Decimate, Refine and Smooth are not allowed without data
+    disableButtons(true);
+}
+
+void medRemeshingToolBox::reset()
+{
+    if (d->input && d->input->data())
+    {
+        displayChanges(d->input);
+        allowDecimate();
+    }
+}
+
+void medRemeshingToolBox::launchDecimate()
+{
+    d->currentProcess = DECIMATE;
+    decimateMesh(0.75); // Divide the nb of triangles by 4 (reverse operation of refine)
+}
+
+void medRemeshingToolBox::decimateMesh(double factor, dtkSmartPointer<medAbstractData> data)
+{
+    if (d->refinedMesh)
+    {
+        this->setToolBoxOnWaitStatus();
+
+        if (!d->decimateProcess)
+        {
+            d->decimateProcess = dtkAbstractProcessFactory::instance()->createSmartPointer("medDecimateMeshProcess");
+        }
+
+        if (!data)
+        {
+            d->decimateProcess->setInput(d->refinedMesh, 0);
+        }
+        else
+        {
+            d->decimateProcess->setInput(data, 0);
+        }
+        d->decimateProcess->setParameter(factor, 0);
+        d->decimateProcess->setParameter(d->topologyRadioButton->isChecked(), 1);
+
+        connect(d->decimateProcess, SIGNAL(warning()), this, SLOT (cantDecimateMore()));
+        connect(d->decimateProcess, SIGNAL(polyDataCastFailure()), this, SLOT (displayCastFailure()));
+
+        medRunnableProcess *runProcess = new medRunnableProcess;
+        runProcess->setProcess (d->decimateProcess);
+        connect (runProcess, SIGNAL (success  (QObject*)),  this, SLOT(addMeshToView()));
+        this->addConnectionsAndStartJob(runProcess);
+    }
+}
+
+void medRemeshingToolBox::launchRefine()
+{
+    d->currentProcess = REFINE;
+    refineMesh(1.0); // Multiply the nb of triangles by 4 (due to loop algorithm)
+}
+
+void medRemeshingToolBox::refineMesh(double factor, dtkSmartPointer<medAbstractData> data)
+{
+    if (d->refinedMesh)
+    {
+        this->setToolBoxOnWaitStatus();
+
+        if (!d->refineProcess)
+        {
+            d->refineProcess = dtkAbstractProcessFactory::instance()->createSmartPointer("medRefineMeshProcess");
+        }
+
+        if (!data)
+        {
+            d->refineProcess->setInput(d->refinedMesh);
+        }
+        else
+        {
+            d->refineProcess->setInput(data);
+        }
+        d->refineProcess->setParameter(factor, 0);
+
+        connect(d->refineProcess, SIGNAL(polyDataCastFailure()), this, SLOT (displayCastFailure()));
+
+        medRunnableProcess *runProcess = new medRunnableProcess;
+        runProcess->setProcess (d->refineProcess);
+        connect (runProcess, SIGNAL (success  (QObject*)),  this, SLOT(addMeshToView()));
+        this->addConnectionsAndStartJob(runProcess);
+    }
+}
+
+void medRemeshingToolBox::imposeNbOfTriangles()
+{
+    this->setToolBoxOnWaitStatusForNonRunnableProcess();
+
+    d->currentProcess = MANUAL;
+    d->trianglesSpinBox->blockSignals(true);
+
+    d->decimateProcess = dtkAbstractProcessFactory::instance()->createSmartPointer("medDecimateMeshProcess");
+    d->decimateProcess->setParameter(false, 2); //do not change MetaData
+
+    d->refineProcess = dtkAbstractProcessFactory::instance()->createSmartPointer("medRefineMeshProcess");
+    d->refineProcess->setParameter(false, 2); //do not change MetaData
+
+    double askedNumber = static_cast<double>(d->trianglesSpinBox->value());
+    double actualNumber = getNumberOfCells(d->refinedMesh);
+    double decimateValue = 0.0;
+
+    if( askedNumber < actualNumber )
+    {
+        d->lastManualProcess = DECIMATE;
+        decimateValue = 1.0 - askedNumber/actualNumber;
+        decimateMesh(decimateValue);
+    }
+    else if( askedNumber > actualNumber )
+    {
+        // Refine only multiply the number of cells by x*4, so we need to
+        // multiply by x*4 in order to have a higher number of cells than the asked number,
+        // and decimate after.
+        double refineValue = ceil(log(askedNumber/actualNumber)/log(4.0));
+
+        d->refineProcess->setInput(d->refinedMesh);
+        d->refineProcess->setParameter(refineValue, 0);
+        connect(d->refineProcess, SIGNAL(polyDataCastFailure()), this, SLOT (displayCastFailure()));
+        d->lastManualProcess = REFINE;
+
+        if(d->refineProcess->update() == medAbstractProcessLegacy::SUCCESS)
+        {
+            allowDecimate();
+            d->lastManualProcess = DECIMATE;
+
+            decimateValue = 1.0 - askedNumber/getNumberOfCells(d->refineProcess->output());
+            decimateMesh(decimateValue, d->refineProcess->output());
+        }
+    }
+
+    d->decimateProcess->setParameter(true, 2); //change MetaData
+    d->refineProcess->setParameter(true, 1); //change MetaData
+    d->trianglesSpinBox->blockSignals(false);
+
+    this->setToolBoxOnReadyToUse();
+}
+
+double medRemeshingToolBox::getNumberOfCells(dtkSmartPointer<medAbstractData> data)
+{
+    vtkMetaDataSet *metaDataSet = static_cast<vtkMetaDataSet*>(data->data());
+    vtkDataSet *dataSet = dynamic_cast<vtkDataSet*>(metaDataSet->GetDataSet());
+    return dataSet->GetNumberOfCells();
+}
+
+void medRemeshingToolBox::addMeshToView()
+{
+    medRunnableProcess *process = static_cast<medRunnableProcess*>(sender());
+
+    QStringList options;
+    options << "medDecimateMeshProcess" << "medRefineMeshProcess" << "medSmoothMeshProcess";
+
+    switch (options.indexOf(process->getProcess()->description()))
+    {
+        case 0:
+        {
+            displayComputedMesh(d->decimateProcess->output());
+            break;
+        }
+        case 1:
+        {
+            displayComputedMesh(d->refineProcess->output());
+            allowDecimate();
+            break;
+        }
+        case 2:
+        {
+            displayComputedMesh(d->smoothProcess->output());
+            break;
+        }
+        default:
+        {
+            return;
+        }
+    }
+}
+
+void medRemeshingToolBox::displayComputedMesh(dtkSmartPointer<medAbstractData> output)
+{
+    if (output && output->data())
+    {
+        displayChanges(output);
+        d->resetButton->setEnabled(true);
+    }
+}
+
+void medRemeshingToolBox::displayChanges(dtkSmartPointer<medAbstractData> output)
+{
+    d->refinedMesh = output;
+
+    vtkImageView3D *view3D = static_cast<medVtkViewBackend*>(d->view->backend())->view3D;
+    vtkImageView2D *view2D = static_cast<medVtkViewBackend*>(d->view->backend())->view2D;
+    
+    vtkMetaDataSet *_dataset = static_cast<vtkMetaDataSet*>(output->data());
+    vtkPointSet *new_points = vtkPointSet::SafeDownCast(_dataset->GetDataSet());
+
+    vtkPointSet *pointsInView3d = vtkPointSet::SafeDownCast(view3D->GetDataSetCollection()->GetItem(d->view->currentLayer()));
+    vtkPointSet *pointsInView2d = vtkPointSet::SafeDownCast(view2D->GetDataSetCollection()->GetItem(d->view->currentLayer()));
+
+    pointsInView3d->ShallowCopy(new_points);
+    pointsInView2d->ShallowCopy(new_points);
+    
+    vtkMetaDataSet *inputDataSet = static_cast<vtkMetaDataSet*>(d->input->data());
+    inputDataSet->SetDataSet(d->original_points);
+
+    medAbstractView *view = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainerView();
+    view->render();
+
+    displayNewNumberOfCells(output);
+}
+
+void medRemeshingToolBox::displayNewNumberOfCells(dtkSmartPointer<medAbstractData> output)
+{
+    d->outputCellsLabel->setText("New number of cells: " + QString::number(static_cast<int>(getNumberOfCells(output))));
+    d->outputCellsLabel->show();
+
+    d->trianglesSpinBox->setValue(getNumberOfCells(output)); // Update in case of limit reached
+}
+
+void medRemeshingToolBox::cantDecimateMore()
+{
+    medMessageController::instance()->showError(tr("Not possible to decimate more without changing the mesh topology"), 5000);
+    d->decimateButton->setEnabled(false);
+}
+
+void medRemeshingToolBox::allowDecimate()
+{
+    d->decimateButton->setEnabled(true);
+}
+
+void medRemeshingToolBox::allowDecimateIfTopologyButtonUnchecked(bool checked)
+{
+    if (!checked && d->input)
+    {
+        allowDecimate();
+    }
+}
+
+void medRemeshingToolBox::disableButtons(bool val)
+{
+    d->runUserNumber->setDisabled(val);  // "choose the number of cells"
+    d->decimateButton->setDisabled(val); // Decimate
+    d->refineButton->setDisabled(val);   // Refine
+    d->smoothButton->setDisabled(val);   // Smooth
+}
+
+void medRemeshingToolBox::smoothMesh()
+{
+    d->currentProcess = SMOOTH;
+
+    if (d->refinedMesh)
+    {
+        this->setToolBoxOnWaitStatus();
+
+        if (!d->smoothProcess)
+        {
+            d->smoothProcess = dtkAbstractProcessFactory::instance()->createSmartPointer("medSmoothMeshProcess");
+        }
+        d->smoothProcess->setInput(d->refinedMesh);
+
+        d->smoothProcess->setParameter((double)d->iterationsSpinBox->value(), 0);
+        d->smoothProcess->setParameter(d->relaxationSpinBox->value(),         1);
+
+        connect(d->smoothProcess, SIGNAL(polyDataCastFailure()), this, SLOT(displayCastFailure()));
+
+        medRunnableProcess *runProcess = new medRunnableProcess;
+        runProcess->setProcess (d->smoothProcess);
+        connect (runProcess, SIGNAL (success  (QObject*)),  this, SLOT(addMeshToView()));
+        this->addConnectionsAndStartJob(runProcess);
+    }
+}
+
+void medRemeshingToolBox::displayCastFailure()
+{
+    displayMessageError("This toolbox is designed for vtkPolyData-based meshes");
+}

--- a/src/plugins/legacy/medRemeshing/medRemeshingToolBox.h
+++ b/src/plugins/legacy/medRemeshing/medRemeshingToolBox.h
@@ -1,0 +1,82 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <dtkCoreSupport/dtkSmartPointer.h>
+
+#include <medAbstractSelectableToolBox.h>
+#include <medRemeshingPluginExport.h>
+
+class medRemeshingToolBoxPrivate;
+
+/*! \brief Toolbox to refine, decimate, smooth, change the number of polygons in a mesh.
+ *
+ * This toolbox has several named widgets which can be accessed in python pipelines:\n\n
+ * "topologyRadioButton" : QRadioButton\n
+ * "resetButton" : QPushButton
+ */
+class MEDREMESHINGPLUGIN_EXPORT medRemeshingToolBox : public medAbstractSelectableToolBox
+{
+    Q_OBJECT
+    MED_TOOLBOX_INTERFACE("Remeshing",
+                          "Tools for refining/decimating meshes.",
+                          <<"Meshing")
+public:
+    enum ProcessName
+    {
+             REFINE,
+             DECIMATE,
+             SMOOTH,
+             MANUAL
+    };
+
+    medRemeshingToolBox(QWidget *parent = nullptr);
+    ~medRemeshingToolBox();
+
+    medAbstractData *processOutput();
+
+    static bool registered();
+    dtkPlugin *plugin();
+
+    void displayNewNumberOfCells(dtkSmartPointer<medAbstractData> output);
+    void displayChanges(dtkSmartPointer<medAbstractData> output);
+    double getNumberOfCells(dtkSmartPointer<medAbstractData> data);
+    void displayComputedMesh(dtkSmartPointer<medAbstractData> output);
+    void decimateMesh(double factor, dtkSmartPointer<medAbstractData> data = nullptr);
+    void refineMesh(double factor, dtkSmartPointer<medAbstractData> data = nullptr);
+
+signals:
+    void success();
+    void failure();
+
+public slots:
+    void reset();
+    void launchDecimate();
+    void launchRefine();
+    void imposeNbOfTriangles();
+    void updateView();
+    void clearAndUpdate();
+    void smoothMesh();
+
+protected slots :
+    void clear();
+    void addMeshToView();
+    void cantDecimateMore();
+    void allowDecimate();
+
+    //! Decimation is allowed if the topology button is uncheck
+    void allowDecimateIfTopologyButtonUnchecked(bool checked);
+    void disableButtons(bool val);
+    void displayCastFailure();
+
+private:
+    medRemeshingToolBoxPrivate *d;
+};

--- a/src/plugins/legacy/medRemeshing/medSmoothMeshProcess.cpp
+++ b/src/plugins/legacy/medRemeshing/medSmoothMeshProcess.cpp
@@ -1,0 +1,174 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <dtkCoreSupport/dtkAbstractProcessFactory.h>
+#include <dtkCoreSupport/dtkSmartPointer.h>
+
+#include <medAbstractDataFactory.h>
+#include <medSmoothMeshProcess.h>
+#include <medUtilities.h>
+
+#include <vtkMetaDataSetSequence.h>
+#include <vtkMetaSurfaceMesh.h>
+#include <vtkSmoothPolyDataFilter.h>
+
+// /////////////////////////////////////////////////////////////////
+// medSmoothMeshProcessPrivate
+// /////////////////////////////////////////////////////////////////
+
+class medSmoothMeshProcessPrivate
+{
+public:
+    dtkSmartPointer <medAbstractData> input;
+    dtkSmartPointer <medAbstractData> output;
+    int iterations;
+    double relaxationFactor;
+};
+
+// /////////////////////////////////////////////////////////////////
+// medSmoothMeshProcess
+// /////////////////////////////////////////////////////////////////
+
+medSmoothMeshProcess::medSmoothMeshProcess() : d(new medSmoothMeshProcessPrivate)
+{
+    d->output = nullptr;
+}
+
+medSmoothMeshProcess::~medSmoothMeshProcess()
+{
+    delete d;
+    d = nullptr;
+}
+
+bool medSmoothMeshProcess::registered()
+{
+    return dtkAbstractProcessFactory::instance()->registerProcessType("medSmoothMeshProcess", createmedSmoothMeshProcess);
+}
+
+QString medSmoothMeshProcess::description() const
+{
+    return "medSmoothMeshProcess";
+}
+
+void medSmoothMeshProcess::setInput(medAbstractData *data , int channel)
+{
+    if (data)
+    {
+        d->input = data;
+    }
+}    
+
+void medSmoothMeshProcess::setParameter(double data, int channel)
+{
+    if (channel > 1)
+    {
+        return;
+    }
+
+    switch (channel)
+    {
+        case 0:
+            d->iterations = data;
+            break;
+        case 1:
+            d->relaxationFactor = data;
+            break;
+    }
+}
+
+vtkMetaDataSet* medSmoothMeshProcess::smoothOneMetaDataSet(vtkMetaDataSet *inputMetaDaset)
+{
+    vtkPolyData *polyData = dynamic_cast<vtkPolyData*>(inputMetaDaset->GetDataSet());
+
+    if (!polyData)
+    {
+        emit polyDataCastFailure();
+        return nullptr;
+    }
+    else
+    {
+        vtkSmoothPolyDataFilter *contourSmoothed = vtkSmoothPolyDataFilter::New();
+        contourSmoothed->SetInputData(polyData);
+        contourSmoothed->SetNumberOfIterations(d->iterations);
+        contourSmoothed->SetRelaxationFactor(d->relaxationFactor);
+        contourSmoothed->Update();
+
+        vtkMetaSurfaceMesh *smesh = vtkMetaSurfaceMesh::New();
+        smesh->SetDataSet(contourSmoothed->GetOutput());
+        contourSmoothed->Delete();
+
+        return smesh;
+    }
+}
+
+int medSmoothMeshProcess::update()
+{
+    progressed(0);
+
+    if(!d->input->identifier().contains("vtkDataMesh"))
+    {
+        return medAbstractProcessLegacy::FAILURE;
+    }
+
+    d->output = medAbstractDataFactory::instance()->createSmartPointer(d->input->identifier());
+
+    if (d->input->identifier() == "vtkDataMesh4D")
+    {
+        vtkMetaDataSetSequence *inputSequence = static_cast<vtkMetaDataSetSequence*>(d->input->data());
+        vtkMetaDataSetSequence *outputSequence = vtkMetaDataSetSequence::New();
+
+        foreach(vtkMetaDataSet *inputMetaDataSet, inputSequence->GetMetaDataSetList())
+        {
+            vtkMetaDataSet *outputMetaDataSet = smoothOneMetaDataSet(inputMetaDataSet);
+            outputMetaDataSet->SetTime(inputMetaDataSet->GetTime());
+            if (outputMetaDataSet == nullptr)
+            {
+                return medAbstractProcessLegacy::FAILURE;
+            }
+            outputSequence->AddMetaDataSet(outputMetaDataSet);
+            outputMetaDataSet->Delete();
+        }
+        d->output->setData(outputSequence);
+        outputSequence->Delete();
+    }
+    else
+    {
+        vtkMetaDataSet *inputMetaDataSet = static_cast<vtkMetaDataSet*>(d->input->data());
+        vtkMetaDataSet *outputMetaDataSet = smoothOneMetaDataSet(inputMetaDataSet);
+        if (outputMetaDataSet == nullptr)
+        {
+            return medAbstractProcessLegacy::FAILURE;
+        }
+        d->output->setData(outputMetaDataSet);
+        outputMetaDataSet->Delete();
+    }
+
+    progressed(100);
+
+    medUtilities::setDerivedMetaData(d->output, d->input, "smoothed");
+
+    return medAbstractProcessLegacy::SUCCESS;
+}
+
+medAbstractData * medSmoothMeshProcess::output()
+{
+    return ( d->output );
+}
+
+// /////////////////////////////////////////////////////////////////
+// Type instantiation
+// /////////////////////////////////////////////////////////////////
+
+dtkAbstractProcess *createmedSmoothMeshProcess()
+{
+    return new medSmoothMeshProcess;
+}

--- a/src/plugins/legacy/medRemeshing/medSmoothMeshProcess.h
+++ b/src/plugins/legacy/medRemeshing/medSmoothMeshProcess.h
@@ -1,0 +1,59 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medAbstractData.h>
+#include <medAbstractProcessLegacy.h>
+#include <medRemeshingPluginExport.h>
+
+#include <vtkMetaDataSet.h>
+
+class medSmoothMeshProcessPrivate;
+
+class MEDREMESHINGPLUGIN_EXPORT medSmoothMeshProcess : public medAbstractProcessLegacy
+{
+    Q_OBJECT
+    
+public:
+    medSmoothMeshProcess();
+    virtual ~medSmoothMeshProcess();
+    
+    virtual QString description() const;
+    
+    static bool registered();
+
+signals:
+    void polyDataCastFailure();
+    
+public slots:
+    
+    //! Input data to the plugin is set through here
+    void setInput(medAbstractData *data, int channel = 0);
+    
+    //! Parameters are set through here, channel allows to handle multiple parameters
+    void setParameter(double data, int channel);
+    
+    //! Method to actually start the filter
+    int update();
+    
+    //! The output will be available through here
+    medAbstractData *output();
+
+protected:
+    vtkMetaDataSet* smoothOneMetaDataSet(vtkMetaDataSet *inputMetaDataSet);
+
+private:
+    medSmoothMeshProcessPrivate *d;
+};
+
+dtkAbstractProcess *createmedSmoothMeshProcess();
+
+

--- a/src/plugins/legacy/medVtkView/medVtkViewNavigator.cpp
+++ b/src/plugins/legacy/medVtkView/medVtkViewNavigator.cpp
@@ -385,12 +385,14 @@ QWidget* medVtkViewNavigator::buildToolBoxWidget()
     showOptionsLayout->addWidget(d->showRulerParameter->getCheckBox());
     showOptionsLayout->addWidget(d->showAnnotationParameter->getCheckBox());
     showOptionsLayout->addWidget(d->showScalarBarParameter->getCheckBox());
+    showOptionsLayout->setContentsMargins(0, 0, 0, 10);
 
     QVBoxLayout* layout = new QVBoxLayout(toolBoxWidget);
     layout->addWidget(d->orientationParameter->getLabel());
     layout->addWidget(d->orientationParameter->getPushButtonGroup());
     layout->addWidget(d->showOptionsWidget);
     layout->addWidget(this->timeLineParameter()->getWidget());
+    layout->setContentsMargins(0, 0, 0, 0);
 
     return toolBoxWidget;
 }
@@ -645,6 +647,7 @@ void medVtkViewNavigator::changeOrientation(medImageView::Orientation orientatio
     }
     d->currentView->SetRenderWindow(renWin);
     d->currentView->SetCurrentPoint(pos);
+    d->currentView->GlobalWarningDisplayOff();
     d->currentView->Render();
 
     d->orientation = orientation;

--- a/src/plugins/legacy/meshManipulation/CMakeLists.txt
+++ b/src/plugins/legacy/meshManipulation/CMakeLists.txt
@@ -1,0 +1,86 @@
+################################################################################
+#
+# medInria
+#
+# Copyright (c) INRIA 2013 - 2019. All rights reserved.
+# See LICENSE.txt for details.
+# 
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.
+#
+################################################################################
+
+set(TARGET_NAME meshManipulationPlugin)
+
+## #############################################################################
+## Setup version numbering
+## #############################################################################
+
+set(${TARGET_NAME}_VERSION ${MEDINRIA_VERSION})
+
+string(TOUPPER ${TARGET_NAME} TARGET_NAME_UP)
+add_definitions(-D${TARGET_NAME_UP}_VERSION="${${TARGET_NAME}_VERSION}")
+
+set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
+
+## #############################################################################
+## Resolve dependencies
+## #############################################################################
+
+find_package(dtk REQUIRED)
+include_directories(${dtk_INCLUDE_DIRS})
+
+find_package(ITK REQUIRED)
+include(${ITK_USE_FILE})
+
+find_package(VTK REQUIRED)
+include(${VTK_USE_FILE})
+
+## #############################################################################
+## List Sources
+## #############################################################################
+
+list_source_files(${TARGET_NAME}
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+
+## #############################################################################
+## include directories
+## #############################################################################
+
+list_header_directories_to_include(${TARGET_NAME}
+  ${${TARGET_NAME}_HEADERS}
+  )
+
+include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
+  ${MEDINRIA_INCLUDE_DIRS}
+  )
+
+## #############################################################################
+## add library
+## #############################################################################
+
+add_library(${TARGET_NAME} SHARED
+  ${${TARGET_NAME}_CFILES}
+  ${${TARGET_NAME}_QRC}
+  )
+
+## #############################################################################
+## Link
+## #############################################################################
+
+target_link_libraries(${TARGET_NAME}
+  ${QT_LIBRARIES}
+  medCore
+  medVtkInria
+  medUtilities
+  )
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+## #############################################################################
+## Install rules
+## #############################################################################
+
+set_plugin_install_rules_legacy(${TARGET_NAME})

--- a/src/plugins/legacy/meshManipulation/meshManipulationPlugin.cpp
+++ b/src/plugins/legacy/meshManipulation/meshManipulationPlugin.cpp
@@ -1,0 +1,47 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <meshManipulationPlugin.h>
+#include <meshManipulationToolBox.h>
+
+meshManipulationPlugin::meshManipulationPlugin(QObject *parent) : medPluginLegacy(parent)
+{
+}
+
+bool meshManipulationPlugin::initialize()
+{
+    if (!meshManipulationToolBox::registered())
+    {
+        qWarning() << "Unable to register meshManipulation toolbox";
+    }
+    return true;
+}
+
+QString meshManipulationPlugin::name() const
+{
+    return "Mesh Manipulation";
+}
+
+QString meshManipulationPlugin::description() const
+{
+    return tr("Plugin allowing to apply linear transformations.");
+}
+
+QString meshManipulationPlugin::version() const
+{
+    return MESHMANIPULATIONPLUGIN_VERSION;
+}
+
+QStringList meshManipulationPlugin::types() const
+{
+    return QStringList() << "medMeshTools";
+}

--- a/src/plugins/legacy/meshManipulation/meshManipulationPlugin.h
+++ b/src/plugins/legacy/meshManipulation/meshManipulationPlugin.h
@@ -1,0 +1,30 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medPluginLegacy.h>
+#include <meshManipulationPluginExport.h>
+
+class MESHMANIPULATIONPLUGIN_EXPORT meshManipulationPlugin : public medPluginLegacy
+{
+    Q_OBJECT
+    Q_INTERFACES(dtkPlugin)
+    Q_PLUGIN_METADATA(IID "fr.inria.meshManipulationPlugin" FILE "meshManipulationPlugin.json")
+    
+public:
+    meshManipulationPlugin(QObject *parent = nullptr);
+    virtual bool initialize();
+    
+    virtual QString name() const;
+    virtual QString description() const;
+    virtual QString version() const;
+    virtual QStringList types() const;
+};

--- a/src/plugins/legacy/meshManipulation/meshManipulationPlugin.json
+++ b/src/plugins/legacy/meshManipulation/meshManipulationPlugin.json
@@ -1,0 +1,5 @@
+{
+            "name" : "meshManipulationPlugin",
+         "version" : "0.0.1", 	
+    "dependencies" : []
+}

--- a/src/plugins/legacy/meshManipulation/meshManipulationPluginExport.h
+++ b/src/plugins/legacy/meshManipulation/meshManipulationPluginExport.h
@@ -1,0 +1,25 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#pragma once
+
+#ifdef WIN32
+    #ifdef meshManipulationPlugin_EXPORTS
+        #define MESHMANIPULATIONPLUGIN_EXPORT __declspec(dllexport)
+    #else
+        #define MESHMANIPULATIONPLUGIN_EXPORT __declspec(dllimport)
+    #endif
+#else
+    #define MESHMANIPULATIONPLUGIN_EXPORT
+#endif
+
+

--- a/src/plugins/legacy/meshManipulation/meshManipulationToolBox.cpp
+++ b/src/plugins/legacy/meshManipulation/meshManipulationToolBox.cpp
@@ -1,0 +1,488 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medAbstractDataFactory.h>
+#include <medDataManager.h>
+#include <meshManipulationToolBox.h>
+#include <medPluginManager.h>
+#include <medTabbedViewContainers.h>
+#include <medToolBoxBody.h>
+#include <medToolBoxFactory.h>
+#include <medUtilities.h>
+#include <medUtilitiesVTK.h>
+#include <medVtkViewBackend.h>
+
+#include <vtkActor.h>
+#include <vtkBoxWidget.h>
+#include <vtkCommand.h>
+#include <vtkTransform.h>
+#include <vtkMetaDataSet.h>
+#include <vtkMetaDataSetSequence.h>
+#include <vtkPointSet.h>
+#include <vtkTransformFilter.h>
+
+class ManipulationCallback : public vtkCommand
+{
+public:
+    static ManipulationCallback* New()
+    {
+        return new ManipulationCallback;
+    }
+
+    virtual void Execute(vtkObject *caller, unsigned long, void*)
+    {
+        vtkSmartPointer<vtkTransform> t = vtkSmartPointer<vtkTransform>::New();
+        vtkBoxWidget *widget = reinterpret_cast<vtkBoxWidget*>(caller);
+        widget->GetTransform(t);
+
+        foreach (vtkMetaDataSet *metadata, datasets)
+        {
+            for(unsigned int i = 0; i < metadata->GetNumberOfActors(); i++)
+            {
+                metadata->GetActor(i)->SetUserTransform(t);
+            }
+        }
+    }
+
+    void addDataSet(vtkMetaDataSet *dataset)
+    {
+        if (!datasets.contains(dataset))
+        {
+            datasets.append(dataset);
+        }
+    }
+
+    void clearDataSet()
+    {
+       datasets.clear();
+    }
+
+private:
+    QList<vtkMetaDataSet*> datasets;
+};
+
+meshManipulationToolBox::meshManipulationToolBox(QWidget *parent)
+    : medAbstractSelectableToolBox(parent)
+{
+    QWidget *w = new QWidget(this);
+    this->addWidget(w);
+    w->setLayout(new QVBoxLayout);
+    
+    QLabel *explanation = new QLabel("Drop one or multiple meshes in the view.\n\n"
+                                     "Scaling: hold <right-click> on the bounding box\n\n"
+                                     "Rotation: hold <left-click> on the sides of the bounding box\n\n"
+                                     "Translation: hold <mouse-wheel button>, or <left-click> on the central sphere of the bounding box", this);
+    explanation->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+    explanation->setWordWrap(true);
+    explanation->setStyleSheet("font: italic");
+    w->layout()->addWidget(explanation);
+
+    // scaling
+    _scalingCheckBox = new QCheckBox(tr("Enable scaling"));
+    _scalingCheckBox->setChecked(true);
+    w->layout()->addWidget(_scalingCheckBox);
+
+    // rotation
+    _rotationCheckBox = new QCheckBox(tr("Enable rotation"));
+    _rotationCheckBox->setChecked(true);
+    w->layout()->addWidget(_rotationCheckBox);
+
+    // translation
+    _translationCheckBox = new QCheckBox(tr("Enable translation"));
+    _translationCheckBox->setChecked(true);
+    w->layout()->addWidget(_translationCheckBox);
+
+    _saveButton = new QPushButton("Save");
+    _saveButton->setToolTip("Current transform will be applied to all selected layers.");
+    _saveButton->setEnabled(false);
+    w->layout()->addWidget(_saveButton);
+
+    _cancelButton = new QPushButton("Cancel");
+    _cancelButton->setEnabled(false);
+    w->layout()->addWidget(_cancelButton);
+
+    _exportButton = new QPushButton("Export matrix");
+    _exportButton->setEnabled(false);
+    w->layout()->addWidget(_exportButton);
+
+    _importButton = new QPushButton("Import matrix");
+    _importButton->setEnabled(false);
+    w->layout()->addWidget(_importButton);
+
+    connect(_scalingCheckBox,     SIGNAL(toggled(bool)), this, SLOT(enableScaling(bool)));
+    connect(_rotationCheckBox,    SIGNAL(toggled(bool)), this, SLOT(enableRotation(bool)));
+    connect(_translationCheckBox, SIGNAL(toggled(bool)), this, SLOT(enableTranslation(bool)));
+    connect(_saveButton,   SIGNAL(clicked()), this, SLOT(save()));
+    connect(_cancelButton, SIGNAL(clicked()), this, SLOT(cancel()));
+    connect(_exportButton, SIGNAL(clicked()), this, SLOT(exportTransform()));
+    connect(_importButton, SIGNAL(clicked()), this, SLOT(importTransform()));
+
+    _boxWidget = vtkSmartPointer<vtkBoxWidget>::New();
+    _callback = vtkSmartPointer<ManipulationCallback>::New();
+    _boxWidget->AddObserver(vtkCommand::InteractionEvent, _callback);
+}
+
+bool meshManipulationToolBox::registered()
+{
+    return medToolBoxFactory::instance()->registerToolBox<meshManipulationToolBox>();
+}
+
+void meshManipulationToolBox::updateView()
+{
+    if(body()->isVisible())
+    {
+        resetToolbox();
+
+        medAbstractView *view = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainerView();
+        medAbstractLayeredView *view3d = qobject_cast<medAbstractLayeredView*>(view);
+        if (!view3d)
+        {
+            _view = nullptr;
+        }
+        else
+        {
+            _view = view3d;
+
+            connect(this->getWorkspace(), SIGNAL(layerSelectionChanged(QList<int>)),
+                    this, SLOT(handleLayerChange()),
+                    Qt::UniqueConnection);
+
+            medUtilities::switchTo3D(_view, medUtilities::MSR);
+            handleLayerChange();
+        }
+    }
+}
+
+void meshManipulationToolBox::handleLayerChange()
+{
+    if (_callback)
+    {
+        _callback->clearDataSet();
+    }
+
+    // Check if current layer is a mesh
+    if (_view.isNull() || _view->layersCount() == 0)
+    {
+        return;
+    }
+
+    // Retrieve currently selected layers
+    QList<int> selectedLayerIndices = this->getWorkspace()->getSelectedLayerIndices();
+
+    _selectedData.clear();
+    foreach (int layerIndex, selectedLayerIndices)
+    {
+        medAbstractData *data = _view->layerData(layerIndex);
+
+        if ((data->identifier().contains("vtkDataMesh") ||
+             data->identifier().contains("EPMap")))
+        {
+            _selectedData.append(data);
+        }
+    }
+
+    setupModificationBox();
+}
+
+void meshManipulationToolBox::setupModificationBox()
+{
+    if (_selectedData.count() && !_view.isNull())
+    {
+        _boxWidget->Off();
+
+        _boxWidget->SetInteractor(static_cast<medVtkViewBackend*>(_view->backend())->view3D->GetInteractor());
+        _boxWidget->SetPlaceFactor(1.25);
+
+        // Give box size and position throught bounds
+        double bounds[6] = {}; // init to zero
+        medAbstractData *data = _selectedData.at(0);
+        vtkDataSet *dataset = (static_cast<vtkMetaDataSet*>(data->data()))->GetDataSet();
+        vtkPointSet *pointset = dynamic_cast<vtkPointSet*>(dataset);
+        pointset->GetBounds(bounds);
+        _boxWidget->PlaceWidget(bounds);
+
+        // Add datasets to the callback
+        for (int i = 0; i < _selectedData.count(); ++i)
+        {
+            vtkMetaDataSet *metaDataSet = static_cast<vtkMetaDataSet*>(_selectedData.at(i)->data());
+            _callback->addDataSet(metaDataSet);
+        }
+
+        _boxWidget->SetScalingEnabled(_scalingCheckBox->isChecked());
+        _boxWidget->SetRotationEnabled(_rotationCheckBox->isChecked());
+        _boxWidget->SetTranslationEnabled(_translationCheckBox->isChecked());
+        _boxWidget->On();
+
+        _saveButton->setEnabled(true);
+        _cancelButton->setEnabled(true);
+        _exportButton->setEnabled(true);
+        _importButton->setEnabled(true);
+    }
+}
+
+void meshManipulationToolBox::computeData()
+{
+    _outputs.clear();
+
+    vtkSmartPointer<vtkTransform> t = vtkSmartPointer<vtkTransform>::New();
+    _boxWidget->GetTransform(t);
+
+    for (int i = 0; i < _selectedData.count(); ++i)
+    {
+        medAbstractData *data = _selectedData.at(i);
+        vtkMetaDataSet *dataset   = static_cast<vtkMetaDataSet*>(data->data());
+
+        vtkTransformFilter *transformFilter = vtkTransformFilter::New();
+        dtkSmartPointer<medAbstractData> output = medAbstractDataFactory::instance()->createSmartPointer(data->identifier());
+        if (data->identifier() == "vtkDataMesh")
+        {
+            vtkPointSet *newPointSet = transformDataSet(dataset, transformFilter, t);
+            vtkMetaDataSet *metaDataset = dataset->NewInstance();
+            metaDataset->SetDataSet(newPointSet);
+            newPointSet->Delete();
+
+            output->setData(metaDataset);
+            metaDataset->Delete();
+        }
+        else if (data->identifier() == "vtkDataMesh4D")
+        {
+            vtkMetaDataSetSequence *seq = vtkMetaDataSetSequence::SafeDownCast(dataset);
+            const std::vector<vtkMetaDataSet*>& datasetList = seq->GetMetaDataSetList();
+
+            vtkMetaDataSetSequence *newSeq = vtkMetaDataSetSequence::New();
+            foreach(vtkMetaDataSet *metaDataset, datasetList)
+            {
+                vtkPointSet *newPointSet = transformDataSet(metaDataset, transformFilter, t);
+                vtkMetaDataSet *newDataset = metaDataset->NewInstance();
+                newDataset->SetDataSet(newPointSet);
+                newDataset->SetTime(metaDataset->GetTime());
+                newPointSet->Delete();
+
+                newSeq->AddMetaDataSet(newDataset);
+                newDataset->Delete();
+            }
+
+            output->setData(newSeq);
+            newSeq->Delete();
+        }
+        else if (data->identifier().contains("EPMap"))
+        {
+            vtkPointSet *newPointSet = transformDataSet(dataset, transformFilter, t);
+            vtkMetaDataSet *metaDataset = dataset->NewInstance();
+            metaDataset->SetDataSet(newPointSet);
+            newPointSet->Delete();
+     
+            output->setData(metaDataset);
+            metaDataset->Delete();
+
+            // Manually transform catheter coordinates;
+            QStringList arrayNames;
+            arrayNames << "KT_Coordinates" << "_catheter_electrode_positions";
+            medUtilitiesVTK::transformCoordinates(output, arrayNames, t);
+        }
+        transformFilter->Delete();
+     
+        medUtilities::setDerivedMetaData(output, data, "manually modified");
+        medDataManager::instance()->importData(output, false);
+        _outputs.append(output.data());
+    }
+}
+
+vtkPointSet* meshManipulationToolBox::transformDataSet(vtkMetaDataSet *dataset,
+                                                       vtkTransformFilter *transformFilter,
+                                                       vtkTransform *t)
+{
+    vtkPointSet *pointset = vtkPointSet::SafeDownCast(dataset->GetDataSet());
+    transformFilter->SetInputData(pointset);
+    transformFilter->SetTransform(t);
+    transformFilter->Update();
+
+    vtkPointSet *newPointset = pointset->NewInstance();
+    newPointset->DeepCopy(transformFilter->GetOutput());
+
+    return newPointset;
+}
+
+void meshManipulationToolBox::save()
+{
+    computeData();
+}
+
+medAbstractData *meshManipulationToolBox::processOutput()
+{
+    if (_outputs.count())
+    {
+        return _outputs.at(0);
+    }
+    return nullptr;
+}
+
+void meshManipulationToolBox::cancel()
+{
+    reset();
+    setupModificationBox();
+}
+
+void meshManipulationToolBox::clear()
+{
+    medToolBox::clear();
+
+    reset();
+    if (this->getWorkspace())
+    {
+        disconnect(this->getWorkspace(), SIGNAL(layerSelectionChanged(QList<int>)),
+                   this, SLOT(handleLayerChange()));
+    }
+}
+
+void meshManipulationToolBox::reset()
+{
+    _outputs.clear();
+    if (_callback)
+    {
+        _callback->clearDataSet();
+    }
+
+    // iterate on all layers and reset the transform
+    if (!_view.isNull() && _view->layersCount())
+    {
+        vtkSmartPointer<vtkTransform> t_id = vtkSmartPointer<vtkTransform>::New();
+        for (unsigned int i = 0; i < _view->layersCount(); ++i)
+        {
+            medAbstractData *data = _view->layerData(i);
+            if ((data->identifier().contains("vtkDataMesh") ||
+                 data->identifier().contains("EPMap")))
+            {
+                vtkMetaDataSet *dataset = static_cast<vtkMetaDataSet*>(data->data());
+                for(unsigned int j = 0; j < dataset->GetNumberOfActors(); j++)
+                {
+                    dataset->GetActor(j)->SetUserTransform(t_id);
+                }
+            }
+        }
+        if (_boxWidget && _boxWidget->GetInteractor())
+        {
+            _boxWidget->Off();
+        }
+    }
+}
+
+void meshManipulationToolBox::resetToolbox()
+{
+    reset();
+
+    _cancelButton->setEnabled(false);
+    _saveButton->setEnabled(false);
+    _exportButton->setEnabled(false);
+    _importButton->setEnabled(false);
+}
+
+void meshManipulationToolBox::exportTransform()
+{
+    if (_boxWidget && _boxWidget->GetEnabled())
+    {
+        vtkSmartPointer<vtkTransform> t = vtkSmartPointer<vtkTransform>::New();
+        _boxWidget->GetTransform(t);
+
+        vtkSmartPointer<vtkMatrix4x4> m = vtkSmartPointer<vtkMatrix4x4>::New();
+        m->DeepCopy(t->GetMatrix());
+
+        QByteArray matrixStr;
+        for(int i = 0; i < 4; i++)
+        {
+            for(int j = 0; j < 4; j++)
+            {
+                matrixStr += QByteArray::number(m->GetElement(i, j)) + "\t";
+            }
+            matrixStr += "\n";
+        }
+
+        QString filePath = QFileDialog::getSaveFileName(this, tr("Export the transformation matrix in txt"),
+                                                        "/home/transformation.txt",
+                                                        tr("Text files (*.txt)"));
+        if (!filePath.isEmpty())
+        {
+            QFile f(filePath);
+            if (!f.open(QIODevice::WriteOnly))
+            {
+                qDebug() << "Can't open file" << filePath;
+                return;
+            }
+
+            f.write(matrixStr);
+            f.close();
+
+            qDebug() << "Done exporting tranform!";
+        }
+    }
+}
+
+void meshManipulationToolBox::importTransform()
+{
+    QString filePath = QFileDialog::getOpenFileName(0, "Import the matrix file");
+    if (!filePath.isEmpty())
+    {
+        QFile f(filePath);
+        if (!f.open(QIODevice::ReadOnly))
+        {
+            qDebug() << "Can't open file" << filePath;
+        }
+        else
+        {
+            QByteArray matrixStr = f.readAll();
+            f.close();
+
+            vtkSmartPointer<vtkMatrix4x4> m = vtkSmartPointer<vtkMatrix4x4>::New();
+            int i = 0, j = 0;
+            foreach(QByteArray line, matrixStr.split('\n'))
+            {
+                foreach(QByteArray num, line.split('\t'))
+                {
+                    m->SetElement(i, j, num.toDouble());
+                    j++;
+                }
+                i++;j = 0;
+            }
+
+            vtkSmartPointer<vtkTransform> t = vtkSmartPointer<vtkTransform>::New();
+            t->SetMatrix(m);
+
+            _boxWidget->SetTransform(t);
+            _boxWidget->InvokeEvent(vtkCommand::InteractionEvent);
+
+            medAbstractView *view = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainerView();
+            view->render();
+        }
+    }
+}
+
+dtkPlugin* meshManipulationToolBox::plugin()
+{
+    medPluginManager *pm = medPluginManager::instance();
+    dtkPlugin *plugin = pm->plugin("Mesh Manipulation");
+    return plugin;
+}
+
+void meshManipulationToolBox::enableScaling(bool state)
+{
+    _boxWidget->SetScalingEnabled(static_cast<int>(state));
+}
+
+void meshManipulationToolBox::enableRotation(bool state)
+{
+    _boxWidget->SetRotationEnabled(static_cast<int>(state));
+}
+
+void meshManipulationToolBox::enableTranslation(bool state)
+{
+    _boxWidget->SetTranslationEnabled(static_cast<int>(state));
+}

--- a/src/plugins/legacy/meshManipulation/meshManipulationToolBox.h
+++ b/src/plugins/legacy/meshManipulation/meshManipulationToolBox.h
@@ -1,0 +1,85 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medAbstractLayeredView.h>
+#include <medAbstractSelectableToolBox.h>
+#include <meshManipulationPluginExport.h>
+
+#include <vtkSmartPointer.h>
+
+class vtkBoxWidget;
+class ManipulationCallback;
+class vtkMetaDataSet;
+class vtkTransformFilter;
+class vtkTransform;
+class vtkPointSet;
+
+/*!
+ * \brief Toolbox to translate, rotate, manipulate meshes.
+ */
+class MESHMANIPULATIONPLUGIN_EXPORT meshManipulationToolBox : public medAbstractSelectableToolBox
+{
+    Q_OBJECT
+    MED_TOOLBOX_INTERFACE("Mesh Manipulation",
+                          "Toolbox to translate/rotate/manipulate meshes.",
+                          <<"Meshing")
+    
+public:
+    meshManipulationToolBox(QWidget *parent = nullptr);
+    
+    medAbstractData *processOutput();
+
+    static bool registered();
+    dtkPlugin * plugin();
+
+public slots:
+    void setupModificationBox();
+    void cancel();
+    void computeData();
+    void save();
+    void exportTransform();
+    void importTransform();
+    void updateView();
+    void resetToolbox();
+
+protected:
+    virtual void clear();
+    void reset();
+
+protected slots:
+    void handleLayerChange();
+    void enableScaling(bool state);
+    void enableRotation(bool state);
+    void enableTranslation(bool state);
+
+private:
+    vtkPointSet* transformDataSet(vtkMetaDataSet *dataset,
+                                  vtkTransformFilter *transformFilter,
+                                  vtkTransform *t);
+
+private:
+    QPointer<medAbstractLayeredView> _view;
+    QList<medAbstractData*> _outputs;
+    QList<medAbstractData*> _selectedData;
+
+    QCheckBox *_scalingCheckBox;
+    QCheckBox *_rotationCheckBox;
+    QCheckBox *_translationCheckBox;
+    QCheckBox *_modifyAllCheckBox;
+
+    QPushButton *_saveButton;
+    QPushButton *_cancelButton;
+    QPushButton *_exportButton;
+    QPushButton *_importButton;
+    vtkSmartPointer<vtkBoxWidget> _boxWidget;
+    vtkSmartPointer<ManipulationCallback> _callback;
+};

--- a/src/plugins/legacy/meshMapping/CMakeLists.txt
+++ b/src/plugins/legacy/meshMapping/CMakeLists.txt
@@ -1,0 +1,86 @@
+################################################################################
+#
+# medInria
+#
+# Copyright (c) INRIA 2013 - 2019. All rights reserved.
+# See LICENSE.txt for details.
+# 
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.
+#
+################################################################################
+
+set(TARGET_NAME meshMappingPlugin)
+
+## #############################################################################
+## Setup version numbering
+## #############################################################################
+
+set(${TARGET_NAME}_VERSION ${MEDINRIA_VERSION})
+
+string(TOUPPER ${TARGET_NAME} TARGET_NAME_UP)
+add_definitions(-D${TARGET_NAME_UP}_VERSION="${${TARGET_NAME}_VERSION}")
+
+set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
+
+## #############################################################################
+## Resolve dependencies
+## #############################################################################
+
+find_package(dtk REQUIRED)
+include_directories(${dtk_INCLUDE_DIRS})
+
+find_package(ITK REQUIRED)
+include(${ITK_USE_FILE})
+
+find_package(VTK REQUIRED)
+include(${VTK_USE_FILE})
+
+## #############################################################################
+## List Sources
+## #############################################################################
+
+list_source_files(${TARGET_NAME}
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+
+## #############################################################################
+## include directories
+## #############################################################################
+
+list_header_directories_to_include(${TARGET_NAME}
+  ${${TARGET_NAME}_HEADERS}
+  )
+
+include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
+  ${MEDINRIA_INCLUDE_DIRS}
+  )
+
+## #############################################################################
+## add library
+## #############################################################################
+
+add_library(${TARGET_NAME} SHARED
+  ${${TARGET_NAME}_CFILES}
+  ${${TARGET_NAME}_QRC}
+  )
+
+## #############################################################################
+## Link
+## #############################################################################
+
+target_link_libraries(${TARGET_NAME}
+  ${QT_LIBRARIES}
+  medCore
+  medVtkInria
+  medUtilities
+  )
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+## #############################################################################
+## Install rules
+## #############################################################################
+
+set_plugin_install_rules_legacy(${TARGET_NAME})

--- a/src/plugins/legacy/meshMapping/meshMapping.cpp
+++ b/src/plugins/legacy/meshMapping/meshMapping.cpp
@@ -1,0 +1,302 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <meshMapping.h>
+
+#include <dtkCoreSupport/dtkAbstractProcess.h>
+#include <dtkCoreSupport/dtkAbstractProcessFactory.h>
+#include <dtkCoreSupport/dtkSmartPointer.h>
+
+#include <medAbstractDataFactory.h>
+#include <medMetaDataKeys.h>
+#include <medUtilities.h>
+
+#include <vtkImageCast.h>
+#include <vtkImageData.h>
+#include <vtkImageGradientMagnitude.h>
+#include <vtkMatrix4x4.h>
+#include <vtkMetaDataSet.h>
+#include <vtkMetaSurfaceMesh.h>
+#include <vtkMetaVolumeMesh.h>
+#include <vtkPolyData.h>
+#include <vtkProbeFilter.h>
+#include <vtkSmartPointer.h>
+#include <vtkTransform.h>
+#include <vtkTransformFilter.h>
+
+#include <itkImageToVTKImageFilter.h>
+
+// /////////////////////////////////////////////////////////////////
+// meshMappingPrivate
+// /////////////////////////////////////////////////////////////////
+
+class meshMappingPrivate
+{
+public:
+    dtkSmartPointer <medAbstractData> structure;
+    dtkSmartPointer <medAbstractData> data;
+    dtkSmartPointer <medAbstractData> output;
+
+    template <class PixelType> int mapImageOnMesh()
+    {
+        typedef itk::Image<PixelType, 3> ImageType;
+
+        if ( !data ||!data->data() || !structure ||!structure->data())
+        {
+            return medAbstractProcessLegacy::FAILURE;
+        }
+
+        //Converting the mesh
+        if(!structure->identifier().contains("vtkDataMesh"))
+        {
+            return medAbstractProcessLegacy::MESH_TYPE;
+        }
+
+        vtkMetaDataSet *structureDataset = static_cast<vtkMetaDataSet*>(structure->data());
+        vtkPolyData *structurePolydata = static_cast<vtkPolyData*>(structureDataset->GetDataSet());
+
+        // Converting the image
+        typedef itk::ImageToVTKImageFilter<ImageType> FilterType;
+        typename FilterType::Pointer filter = FilterType::New();
+        typename ImageType::Pointer img = static_cast<ImageType *>(data->data());
+        filter->SetInput(img);
+        filter->Update();
+
+        // ----- Hack to keep the itkImages info (origin and orientation)
+        vtkMatrix4x4 *matrix = vtkMatrix4x4::New();
+        matrix->Identity();
+        for (unsigned int x=0; x<3; x++)
+        {
+            for (unsigned int y=0; y<3; y++)
+            {
+                matrix->SetElement(x, y, img->GetDirection()[x][y]);
+            }
+        }
+        typename itk::ImageBase<3>::PointType origin = img->GetOrigin();
+        double v_origin[4], v_origin2[4];
+        for (int i=0; i<3; i++)
+        {
+            v_origin[i] = origin[i];
+        }
+        v_origin[3] = 1.0;
+        matrix->MultiplyPoint (v_origin, v_origin2);
+        for (int i=0; i<3; i++)
+        {
+            matrix->SetElement (i, 3, v_origin[i]-v_origin2[i]);
+        }
+        //------------------------------------------------------
+
+        vtkImageData *vtkImage = filter->GetOutput();
+
+        vtkImageCast *cast = vtkImageCast::New();
+        cast->SetInputData(vtkImage);
+        cast->SetOutputScalarTypeToFloat();
+
+        //To get the itkImage infos back
+        vtkSmartPointer<vtkTransform> t = vtkSmartPointer<vtkTransform>::New();
+        t->SetMatrix(matrix);
+
+        vtkSmartPointer<vtkTransformFilter> transformFilter = vtkSmartPointer<vtkTransformFilter>::New();
+        transformFilter->SetInputConnection(cast->GetOutputPort());
+        transformFilter->SetTransform(t);
+
+        // Probe magnitude with iso-surface.
+        vtkProbeFilter *probe = vtkProbeFilter::New();
+        probe->SetInputData(structurePolydata);
+        probe->SetSourceConnection(transformFilter->GetOutputPort());
+        probe->SpatialMatchOn();
+        probe->Update();
+        vtkPolyData *polydata = probe->GetPolyDataOutput();
+
+        vtkMetaSurfaceMesh *smesh = vtkMetaSurfaceMesh::New();
+        smesh->SetDataSet(polydata);
+
+        output = medAbstractDataFactory::instance()->createSmartPointer("vtkDataMesh");
+        output->setData(smesh);
+        medUtilities::setDerivedMetaData(output, structure, "meshMapping");
+
+        return medAbstractProcessLegacy::SUCCESS;
+    }
+
+    int mapMeshOnMesh()
+    {
+        if ( !data ||!data->data() || !structure ||!structure->data())
+        {
+            return medAbstractProcessLegacy::FAILURE;
+        }
+
+        //Converting the meshes
+        if(!structure->identifier().contains("vtkDataMesh"))
+        {
+            return medAbstractProcessLegacy::MESH_TYPE;
+        }
+
+        vtkMetaDataSet *structureMetaDataSet = static_cast<vtkMetaDataSet*>(structure->data());
+        vtkDataSet *structureDataSet = static_cast<vtkDataSet*>(structureMetaDataSet->GetDataSet());
+
+        vtkMetaDataSet *dataMetaDataSet = static_cast<vtkMetaDataSet*>(data->data());
+        vtkDataSet *dataDataSet = static_cast<vtkDataSet*>(dataMetaDataSet->GetDataSet());
+
+        // Probe magnitude with iso-surface.
+        vtkProbeFilter *probe = vtkProbeFilter::New();
+        probe->SetInputData(structureDataSet);
+        probe->SetSourceData(dataDataSet);
+        probe->SpatialMatchOn();
+        probe->Update();
+
+        // create the output.
+        output = medAbstractDataFactory::instance()->createSmartPointer("vtkDataMesh");
+        medUtilities::setDerivedMetaData(output, structure, "meshMapping");
+
+        vtkMetaDataSet *outputDataSet = nullptr;
+        if (structureMetaDataSet->GetType() == vtkMetaDataSet::VTK_META_VOLUME_MESH)
+        {
+            outputDataSet = vtkMetaVolumeMesh::New();
+        }
+        else
+        {
+            outputDataSet = vtkMetaSurfaceMesh::New();
+        }
+        outputDataSet->SetDataSet(probe->GetOutput());
+        output->setData(outputDataSet);
+
+        probe->Delete();
+        outputDataSet->Delete();
+
+        return medAbstractProcessLegacy::SUCCESS;
+    }
+};
+
+// /////////////////////////////////////////////////////////////////
+// meshMapping
+// /////////////////////////////////////////////////////////////////
+
+meshMapping::meshMapping() : medAbstractProcessLegacy(), d(new meshMappingPrivate)
+{
+    d->data = nullptr;
+    d->structure = nullptr;
+    d->output = nullptr;
+}
+
+meshMapping::~meshMapping()
+{
+    delete d;
+    d = nullptr;
+}
+
+bool meshMapping::registered()
+{
+    return dtkAbstractProcessFactory::instance()->registerProcessType("meshMapping", createMeshMapping);
+}
+
+QString meshMapping::description() const
+{
+    return "meshMapping";
+}
+
+void meshMapping::setInput(medAbstractData *data, int channel)
+{
+    if (!data)
+    {
+        return;
+    }
+
+    if (channel == 0)
+    {
+        d->structure = data;
+    }
+
+    if (channel == 1)
+    {
+        d->data = data;
+    }
+}
+
+void meshMapping::setParameter(double  data, int channel)
+{
+    // Here comes a switch over channel to handle parameters
+}
+
+int meshMapping::update()
+{
+    int res = medAbstractProcessLegacy::FAILURE;
+
+    if (d->data)
+    {
+        QString id = d->data->identifier();
+
+        if ( id == "itkDataImageChar3" )
+        {
+            res = d->mapImageOnMesh<char>();
+        }
+        else if ( id == "itkDataImageUChar3" )
+        {
+            res = d->mapImageOnMesh<unsigned char>();
+        }
+        else if ( id == "itkDataImageShort3" )
+        {
+            res = d->mapImageOnMesh<short>();
+        }
+        else if ( id == "itkDataImageUShort3" )
+        {
+            res = d->mapImageOnMesh<unsigned short>();
+        }
+        else if ( id == "itkDataImageInt3" )
+        {
+            res = d->mapImageOnMesh<int>();
+        }
+        else if ( id == "itkDataImageUInt3" )
+        {
+            res = d->mapImageOnMesh<unsigned int>();
+        }
+        else if ( id == "itkDataImageLong3" )
+        {
+            res = d->mapImageOnMesh<long>();
+        }
+        else if ( id== "itkDataImageULong3" )
+        {
+            res = d->mapImageOnMesh<unsigned long>();
+        }
+        else if ( id == "itkDataImageFloat3" )
+        {
+            res = d->mapImageOnMesh<float>();
+        }
+        else if ( id == "itkDataImageDouble3" )
+        {
+            res = d->mapImageOnMesh<double>();
+        }
+        else if ( id == "vtkDataMesh" )
+        {
+            res = d->mapMeshOnMesh();
+        }
+        else
+        {
+            res = medAbstractProcessLegacy::PIXEL_TYPE;
+        }
+    }
+
+    return res;
+}        
+
+medAbstractData * meshMapping::output()
+{
+    return d->output;
+}
+
+// /////////////////////////////////////////////////////////////////
+// Type instantiation
+// /////////////////////////////////////////////////////////////////
+
+dtkAbstractProcess *createMeshMapping()
+{
+    return new meshMapping;
+}

--- a/src/plugins/legacy/meshMapping/meshMapping.h
+++ b/src/plugins/legacy/meshMapping/meshMapping.h
@@ -1,0 +1,56 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medAbstractData.h>
+#include <medAbstractProcessLegacy.h>
+#include <meshMappingPluginExport.h>
+
+#include <itkImage.h>
+
+class meshMappingPrivate;
+
+typedef itk::Image<unsigned char, 3>  MaskType;
+
+class MESHMAPPINGPLUGIN_EXPORT meshMapping : public medAbstractProcessLegacy
+{
+    Q_OBJECT
+    
+public:
+    meshMapping();
+    virtual ~meshMapping();
+    
+    virtual QString description() const;
+    
+    static bool registered();
+    
+public slots:
+    
+    //! Input data to the plugin is set through here
+    void setInput(medAbstractData *data, int channel);
+
+    //! Parameters are set through here, channel allows to handle multiple parameters
+    void setParameter(double data, int channel);
+    
+    //! Method to actually start the filter
+    int update();
+    
+    //! The output will be available through here
+    medAbstractData *output();
+    
+    
+private:
+    meshMappingPrivate *d;
+};
+
+dtkAbstractProcess *createMeshMapping();
+
+

--- a/src/plugins/legacy/meshMapping/meshMappingPlugin.cpp
+++ b/src/plugins/legacy/meshMapping/meshMappingPlugin.cpp
@@ -1,0 +1,57 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <meshMapping.h>
+#include <meshMappingPlugin.h>
+#include <meshMappingToolBox.h>
+
+meshMappingPlugin::meshMappingPlugin(QObject *parent) : medPluginLegacy(parent)
+{
+}
+
+bool meshMappingPlugin::initialize()
+{
+    if(!meshMapping::registered())
+    {
+        qWarning() << "Unable to register meshMapping type";
+    }
+    
+    if ( !meshMappingToolBox::registered() )
+    {
+        qWarning() << "Unable to register meshMapping toolbox";
+    }
+    
+    return true;
+}
+
+QString meshMappingPlugin::name() const
+{
+    return "Mesh Mapping";
+}
+
+QString meshMappingPlugin::description() const
+{
+    QString description = \
+            tr("Sample data values at specified point locations on a mesh.\
+               <br><br>This plugin uses the <a href=\"https://www.vtk.org/\" style=\"color: #cc0000\" >VTK library</a>.");
+    return description;
+}
+
+QString meshMappingPlugin::version() const
+{
+    return MESHMAPPINGPLUGIN_VERSION;
+}
+
+QStringList meshMappingPlugin::types() const
+{
+    return QStringList() << "meshMapping";
+}

--- a/src/plugins/legacy/meshMapping/meshMappingPlugin.h
+++ b/src/plugins/legacy/meshMapping/meshMappingPlugin.h
@@ -1,0 +1,32 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medPluginLegacy.h>
+#include <meshMappingPluginExport.h>
+
+class MESHMAPPINGPLUGIN_EXPORT meshMappingPlugin : public medPluginLegacy
+{
+    Q_OBJECT
+    Q_INTERFACES(dtkPlugin)
+    Q_PLUGIN_METADATA(IID "fr.inria.meshMappingPlugin" FILE "meshMappingPlugin.json")
+
+public:
+    meshMappingPlugin(QObject *parent = nullptr);
+    virtual bool initialize();
+    
+    virtual QString name() const;
+    virtual QString description() const;
+    virtual QString version() const;
+    virtual QStringList types() const;
+};
+
+

--- a/src/plugins/legacy/meshMapping/meshMappingPlugin.json
+++ b/src/plugins/legacy/meshMapping/meshMappingPlugin.json
@@ -1,0 +1,5 @@
+{
+            "name" : "meshMappingPlugin",
+         "version" : "0.0.1", 	
+    "dependencies" : []
+}

--- a/src/plugins/legacy/meshMapping/meshMappingPluginExport.h
+++ b/src/plugins/legacy/meshMapping/meshMappingPluginExport.h
@@ -1,0 +1,25 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#pragma once
+
+#ifdef WIN32
+    #ifdef meshMappingPlugin_EXPORTS
+        #define MESHMAPPINGPLUGIN_EXPORT __declspec(dllexport) 
+    #else
+        #define MESHMAPPINGPLUGIN_EXPORT __declspec(dllimport) 
+    #endif
+#else
+    #define MESHMAPPINGPLUGIN_EXPORT
+#endif
+
+

--- a/src/plugins/legacy/meshMapping/meshMappingToolBox.cpp
+++ b/src/plugins/legacy/meshMapping/meshMappingToolBox.cpp
@@ -1,0 +1,186 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medAbstractLayeredView.h>
+#include <medDataIndex.h>
+#include <medPluginManager.h>
+#include <medMetaDataKeys.h>
+#include <medRunnableProcess.h>
+#include <medTabbedViewContainers.h>
+#include <medToolBoxFactory.h>
+
+#include <meshMapping.h>
+#include <meshMappingToolBox.h>
+
+class meshMappingToolBoxPrivate
+{
+public:
+    dtkSmartPointer <meshMapping> process;
+
+    dtkAbstractView *view;
+    dtkSmartPointer<medAbstractData> data;
+    dtkSmartPointer<medAbstractData> structure;
+
+    QComboBox *layersForStructure;
+    QComboBox *layersForData;
+
+    // Need to re-implement the counting of layers because pb with meshes in the current counting
+    int nbOfImageLayers, nbOfMeshLayers;
+};
+
+meshMappingToolBox::meshMappingToolBox(QWidget *parent)
+    :medAbstractSelectableToolBox(parent),
+    d(new meshMappingToolBoxPrivate)
+{
+    QWidget *widget = new QWidget(this);
+
+    QLabel *dataLabel = new QLabel("Select the data to map ", this);
+    dataLabel->setToolTip(tr("Select the dataset from which to obtain\n probe values (image or mesh)."));
+    d->layersForData = new QComboBox;
+    d->layersForData->addItem("Select the layer", 0);
+
+    QLabel *structureLabel = new QLabel("Select the structure", this);
+    structureLabel->setToolTip(tr("Select the dataset whose geometry will be used\n \
+                                  in determining positions to probe (typically a mesh)."));
+    d->layersForStructure = new QComboBox;
+    d->layersForStructure->addItem("Select the layer", 0);
+    
+    QPushButton *runButton = new QPushButton(tr("Run"), this);
+    connect(runButton, SIGNAL(clicked()), this, SLOT(run()));
+
+    QVBoxLayout *layout = new QVBoxLayout(widget);
+    layout->addWidget(dataLabel);
+    layout->addWidget(d->layersForData);
+    layout->addWidget(structureLabel);
+    layout->addWidget(d->layersForStructure);
+    layout->addWidget(runButton);
+
+    widget->setLayout(layout);
+    this->addWidget(widget);
+
+    d->nbOfMeshLayers = 0;
+    d->nbOfImageLayers = 0;
+}
+
+meshMappingToolBox::~meshMappingToolBox()
+{
+    delete d;
+    d = nullptr;
+}
+
+bool meshMappingToolBox::registered()
+{
+    return medToolBoxFactory::instance()->registerToolBox<meshMappingToolBox>();
+}
+
+dtkPlugin* meshMappingToolBox::plugin()
+{
+    medPluginManager *pm = medPluginManager::instance();
+    dtkPlugin *plugin = pm->plugin("Mesh Mapping");
+    return plugin;
+}
+
+medAbstractData* meshMappingToolBox::processOutput()
+{
+    if(!d->process)
+    {
+        return nullptr;
+    }
+
+    return d->process->output();
+}
+
+void meshMappingToolBox::run()
+{ 
+    if (!d->process)
+    {
+        d->process =  new meshMapping();
+    }
+
+    medAbstractLayeredView *medView = static_cast<medAbstractLayeredView *> (d->view);
+    if (medView)
+    {
+        int structureLayer = d->layersForStructure->currentIndex() - 1;
+
+        if ((structureLayer >= 0) && (medView->layersCount() >= 0))
+        {
+            this->setToolBoxOnWaitStatus();
+
+            d->process->setInput(medView->layerData(structureLayer), 0);
+
+            int dataLayer = d->layersForData->currentIndex() -1;
+            d->process->setInput(medView->layerData(dataLayer), 1);
+
+            medRunnableProcess *runProcess = new medRunnableProcess;
+            runProcess->setProcess (d->process);
+            connect (runProcess, SIGNAL (failure  (int)),  this, SLOT (handleDisplayError(int)));
+            this->addConnectionsAndStartJob(runProcess);
+        }
+    }
+}
+
+void meshMappingToolBox::updateView()
+{
+    resetComboBoxes();
+
+    medAbstractView *view = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainerView();
+
+    medAbstractLayeredView *medView = dynamic_cast<medAbstractLayeredView *> (view);
+    if (medView)
+    {
+        d->view = medView;
+
+        QList<medDataIndex> layerList = medView->dataList();
+        for (int i=0; i<layerList.size(); i++)
+        {
+            addLayer(i);
+        }
+
+        QObject::connect(d->view, SIGNAL(closed()),
+                         this, SLOT(resetComboBoxes()),
+                         Qt::UniqueConnection);
+    }
+}
+
+void meshMappingToolBox::resetComboBoxes()
+{
+    d->layersForStructure->clear();
+    d->layersForData->clear();
+    d->layersForStructure->addItem("Select a layer");
+    d->layersForData->addItem("Select a layer");
+    d->nbOfMeshLayers = 0;
+    d->nbOfImageLayers = 0;
+}
+
+void meshMappingToolBox::addLayer(unsigned int layer)
+{
+    medAbstractLayeredView *medView = static_cast<medAbstractLayeredView *> (d->view);
+    if (medView)
+    {
+        medAbstractData *data = medView->layerData(layer);
+
+        QString name = medMetaDataKeys::SeriesDescription.getFirstValue(data,"<i>no name</i>");
+
+        if(data && !data->identifier().contains("vtkDataMesh"))
+        {
+            d->nbOfImageLayers += 1;
+            d->layersForStructure->addItem(name);
+            d->layersForData->addItem(name);
+        }
+        else
+        {
+            d->nbOfMeshLayers += 1;
+            d->layersForStructure->addItem(name);
+            d->layersForData->addItem(name);
+        }
+    }
+}

--- a/src/plugins/legacy/meshMapping/meshMappingToolBox.h
+++ b/src/plugins/legacy/meshMapping/meshMappingToolBox.h
@@ -1,0 +1,53 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include <medAbstractSelectableToolBox.h>
+#include <meshMappingPluginExport.h>
+
+class meshMappingToolBoxPrivate;
+
+/*!
+ * \brief Toolbox to map data on a mesh: keep the intersection of the mesh and data, and set these values to the mesh.
+ */
+class MESHMAPPINGPLUGIN_EXPORT meshMappingToolBox : public medAbstractSelectableToolBox
+{
+    Q_OBJECT
+    MED_TOOLBOX_INTERFACE("Mesh Mapping",
+                          "Map data on a mesh: keep the intersection of the mesh and data, and set these values to the mesh.",
+                          <<"Meshing")
+    
+public:
+    meshMappingToolBox(QWidget *parent = nullptr);
+    ~meshMappingToolBox();
+    
+    medAbstractData *processOutput();
+    
+    static bool registered();
+    dtkPlugin *plugin();
+    
+signals:
+    void success();
+    void failure();
+    
+public slots:
+    void run();
+    void updateView();
+
+protected slots:
+    void addLayer(unsigned int layer);
+    void resetComboBoxes();
+
+private:
+    meshMappingToolBoxPrivate *d;
+};
+
+

--- a/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
+++ b/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
@@ -499,6 +499,9 @@ void vtkDataMeshInteractor::updatePipeline ()
             d->actor2d = d->view2d->AddDataSet(pointSet);
             d->actor3d = d->view3d->AddDataSet(pointSet);
 
+            d->metaDataSet->AddActor(d->actor2d);
+            d->metaDataSet->AddActor(d->actor3d);
+
             d->actorProperty2D = vtkDataMeshInteractorPrivate::PropertySmartPointer::New();
             d->actorProperty3D = vtkDataMeshInteractorPrivate::PropertySmartPointer::New();
 


### PR DESCRIPTION
This Pull Request adds:
 * the _Meshing_ workspace
 * the _Create Mesh from Mask_ toolbox to convert a mask to a mesh
 * the _Mesh Manipulation_ toolbox to manually scale/rotate a mesh
 * the _Mesh Mapping_ toolbox to map a data to a mesh
 * the _Remeshing_ toolbox to refine/decimate/smooth/choose the triangles number of a mesh

Small comments: 
 * medComboBox.h handle the way the selector combobox in workspaces behaves. It's from https://github.com/LoicCadour/medInria-public/pull/82 but the wheel event is removed. Indeed, the user can loose his/her work if the wheel event in a toolbox is caught by the selector.
 * the change from dtkDebug to qDebug in medDatabaseView.cpp  is a debug: the soft freezed sometimes saving data in the db.

:m:
