### PR TITLE
[RELEASE_NOTES] update the release notes with 3.1 changes

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,4 +1,6 @@
 medInria v3.1:
+- Switch ITK to version 5.0.0
+- Switch VTK to version 8.1.2
 - Create Meshing workspace with 4 toolboxes: Create Mesh from Mask, Mesh Manipulation, Mesh Mapping and Remeshing
 - Create Reformat workspace with 2 toolboxes: Cropping and Reslice
 - Create Filtering Legacy workspace with 2 toolboxes: Binary Operation and Mask Application

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -4,7 +4,7 @@ medInria v3.1:
 - Create Meshing workspace with 5 toolboxes: Create Mesh from Mask, Mesh Manipulation, Mesh Mapping, Remeshing and Iterative Closest Point
 - Create Reformat workspace with 2 toolboxes: Cropping and Reslice
 - Filtering workspace becomes Filtering dtk2
-- Create Filtering workspace with 2 toolboxes: Binary Operation and Mask Application
+- Create Filtering workspace with 5 toolboxes: Binary Operation, ITK Basic Filters, Mask Application, Morphological Filters and N4 Bias Correction
 - Segmentation workspace, add new toolboxes: VOI Cutter, Variational Segmentation and Polygon ROI
 - Registration workspace, add a new toolbox: Manual Registration
 - Paint toolbox in Segmentation is updated, can do region growing algorithm

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,9 +1,10 @@
 medInria v3.1:
 - Switch ITK to version 5.0.0
 - Switch VTK to version 8.1.2
-- Create Meshing workspace with 4 toolboxes: Create Mesh from Mask, Mesh Manipulation, Mesh Mapping and Remeshing
+- Create Meshing workspace with 5 toolboxes: Create Mesh from Mask, Mesh Manipulation, Mesh Mapping, Remeshing and Iterative Closest Point
 - Create Reformat workspace with 2 toolboxes: Cropping and Reslice
-- Create Filtering Legacy workspace with 2 toolboxes: Binary Operation and Mask Application
+- Filtering workspace becomes Filtering dtk2
+- Create Filtering workspace with 2 toolboxes: Binary Operation and Mask Application
 - Segmentation workspace, add new toolboxes: VOI Cutter, Variational Segmentation and Polygon ROI
 - Registration workspace, add a new toolbox: Manual Registration
 - Paint toolbox in Segmentation is updated, can do region growing algorithm
@@ -23,7 +24,9 @@ medInria v3.1:
 - Clarify the use of Load/Import data which become Temporary Import/Import
 - Remove homepage animation
 - Improve Mouse Interaction/View settings/Layer settings ergonomy
+- Fix Dicom import with non axial acquisition
 - Fix a synchronisation bug between views
+- Fix a 4-split bug with the slicing
 - Fix a 4-split views bug with scrolling, button in view Tools button
 - Fix command-line bugs
 - Fix import errors of DICOM and mha

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,3 +1,37 @@
+medInria v3.1:
+- Create Meshing workspace with 4 toolboxes: Create Mesh from Mask, Mesh Manipulation, Mesh Mapping and Remeshing
+- Create Reformat workspace with 2 toolboxes: Cropping and Reslice
+- Create Filtering Legacy workspace with 2 toolboxes: Binary Operation and Mask Application
+- Segmentation workspace, add new toolboxes: VOI Cutter, Variational Segmentation and Polygon ROI
+- Registration workspace, add a new toolbox: Manual Registration
+- Paint toolbox in Segmentation is updated, can do region growing algorithm
+- A log system has been added, you can find the log file on homepage -> Logs
+- Histogram in views Tools button
+- Possibility to open a study, dropping it in a view
+- Reset camera on layer double click
+- 3D orientation, change the color of the background
+- Browser -> File System, path saved each time you open a directory
+- Improve visibility of 2D meshes
+- Pop-up to validate application exit: avoid misclicks
+- Search toolbox tool in the quick access menu to find toolboxes
+- Standardize Selector workspaces (with a selector combobox of toolboxes)
+- Filter tool added on the top on database column in workspaces
+- Right-click on a data in the database: Metadata tool lists the data metadata
+- Possibility to rename data in database column with the OS shortcut (ex. F2 on Linux)
+- Clarify the use of Load/Import data which become Temporary Import/Import
+- Remove homepage animation
+- Improve Mouse Interaction/View settings/Layer settings ergonomy
+- Fix a synchronisation bug between views
+- Fix a 4-split views bug with scrolling, button in view Tools button
+- Fix command-line bugs
+- Fix import errors of DICOM and mha
+- Fix hidden layer visibility when add a new data in a view
+- Fix Composer button, and Diffusion toolboxes sizes
+- Fix memory leak with meshes after view closing
+- Fix thumbnail size
+- Fix the slice number and location on the view when the orientation changes
+- Improve packaging
+
 medInria v3.0:
 - Switch Qt backend to Qt 5.x
 - Switch VTK to version 8.1, including a switch to OpenGL2 backend

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -22,14 +22,18 @@ medInria v3.1:
 - Right-click on a data in the database: Metadata tool lists the data metadata
 - Possibility to rename data in database column with the OS shortcut (ex. F2 on Linux)
 - Clarify the use of Load/Import data which become Temporary Import/Import
-- Remove homepage animation
+- Remove homepage animation, and update minimum size of the application
+- Splash screen design updated, and fix transparency problem on some computers
 - Improve Mouse Interaction/View settings/Layer settings ergonomy
+- Fix Tensor view crash, and mesh + data display in view
+- Fix save and load settings for PACS system
 - Fix Dicom import with non axial acquisition
 - Fix a synchronisation bug between views
 - Fix a 4-split bug with the slicing
 - Fix a 4-split views bug with scrolling, button in view Tools button
 - Fix command-line bugs
 - Fix import errors of DICOM and mha
+- Fix default database path
 - Fix hidden layer visibility when add a new data in a view
 - Fix Composer button, and Diffusion toolboxes sizes
 - Fix memory leak with meshes after view closing

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@
 cmake_minimum_required(VERSION 3.3)
 
 if(NOT DEFINED ${medInria_VERSION})
-    set(medInria_VERSION 3.0.1)
+    set(medInria_VERSION 3.1.0)
 endif()
 
 project(medInria VERSION ${medInria_VERSION})


### PR DESCRIPTION
Fixes https://github.com/medInria/medInria-public/issues/433

This PR updates the release notes file with the changes in the future 3.1 version of medInria. It can be updated until the release, if we had or remove tools/toolboxes/plugins/fix, etc. Specially for the Filtering Legacy workspace.

