### PR TITLE
[Splash] center on previous current screen

### DIFF
--- a/src/app/medInria/medMainWindow.cpp
+++ b/src/app/medInria/medMainWindow.cpp
@@ -302,6 +302,9 @@ void medMainWindow::saveSettings()
         medSettingsManager * mnger = medSettingsManager::instance();
         mnger->setValue("medMainWindow", "state", this->saveState());
         mnger->setValue("medMainWindow", "geometry", this->saveGeometry());
+
+        // Keep the current screen for multiple-screens display
+        mnger->setValue("medMainWindow", "currentScreen", QApplication::desktop()->screenNumber(this));
     }
 }
 

--- a/src/app/medInria/medSplashScreen.cpp
+++ b/src/app/medInria/medSplashScreen.cpp
@@ -55,7 +55,7 @@ medSplashScreen::medSplashScreen(const QPixmap& thePixmap)
         }
     }
 
-    // Move the Spla
+    // Move the Splash screen at the center of the chosen screen
     move(QApplication::desktop()->screenGeometry(currentScreen).center() - r.center());
 }
 

--- a/src/app/medInria/medSplashScreen.cpp
+++ b/src/app/medInria/medSplashScreen.cpp
@@ -14,8 +14,10 @@
 #include <medSplashScreen.h>
 #include <dtkCoreSupport/dtkPlugin.h>
 #include <medPluginManager.h>
+#include <medSettingsManager.h>
 
-class medSplashScreenPrivate {
+class medSplashScreenPrivate
+{
 public:
     QPixmap  pixmap;
     QString  message;
@@ -34,10 +36,28 @@ medSplashScreen::medSplashScreen(const QPixmap& thePixmap)
     d->alignment = Qt::AlignBottom|Qt::AlignLeft;
     setAttribute(Qt::WA_TranslucentBackground);
     setFixedSize(d->pixmap.size());
-    QRect r(0, 0, d->pixmap.size().width(), d->pixmap.size().height());
-    move(QApplication::desktop()->screenGeometry().center() - r.center());
-}
 
+    QRect r(0, 0, d->pixmap.size().width(), d->pixmap.size().height());
+
+    // Get back the previous screen used to display the application
+    medSettingsManager *manager = medSettingsManager::instance();
+    int currentScreen = 0;
+
+    QVariant currentScreenQV = manager->value("medMainWindow", "currentScreen");
+    if (!currentScreenQV.isNull())
+    {
+        currentScreen = currentScreenQV.toInt();
+
+        // If the previous used screen has been removed, initialization
+        if (currentScreen >= QApplication::desktop()->screenCount())
+        {
+            currentScreen = 0;
+        }
+    }
+
+    // Move the Spla
+    move(QApplication::desktop()->screenGeometry(currentScreen).center() - r.center());
+}
 
 medSplashScreen::~medSplashScreen()
 {


### PR DESCRIPTION
On multiple screen display, if you close the application on screen 2 for instance, at the next opening, medInria will open on screen 2. But not the splash screen.

This PR solves the problem, and open the splash screen on the current screen.

:m: