### PR TITLE
[Splash] solve corner transparency pb, change logo

### DIFF
--- a/src/app/medInria/main.cpp
+++ b/src/app/medInria/main.cpp
@@ -92,7 +92,7 @@ int main(int argc,char* argv[])
     // Qt doc, otherwise there are some edge cases where the style is not fully applied
     //QApplication::setStyle("plastique");
     medApplication application(argc,argv);
-    medSplashScreen splash(QPixmap(":/pixmaps/medInria-splash.png"));
+    medSplashScreen splash(QPixmap(":/pixmaps/medInria-logo-homepage.png"));
 
     setlocale(LC_NUMERIC, "C");
     QLocale::setDefault(QLocale("C"));

--- a/src/app/medInria/medSplashScreen.cpp
+++ b/src/app/medInria/medSplashScreen.cpp
@@ -31,10 +31,12 @@ medSplashScreen::medSplashScreen(const QPixmap& thePixmap)
     : QWidget(0, Qt::SplashScreen |Qt::FramelessWindowHint|Qt::WindowStaysOnTopHint)
     , d(new medSplashScreenPrivate)
 {
+    // Graphic
     d->pixmap = thePixmap;
-    d->color = Qt::white; // TODO get from QSS
+    d->color = Qt::white;
+
+    // Geometry
     d->alignment = Qt::AlignBottom|Qt::AlignLeft;
-    setAttribute(Qt::WA_TranslucentBackground);
     setFixedSize(d->pixmap.size());
 
     QRect r(0, 0, d->pixmap.size().width(), d->pixmap.size().height());
@@ -78,11 +80,11 @@ void medSplashScreen::showMessage(const QString& message)
     const dtkPlugin* plugin = medPluginManager::instance()->plugin(message);
     if (plugin)
     {
-        d->message = plugin->name();
+        d->message = QString("Loading: ") + plugin->name();
     }
     else
     {
-        d->message = message;
+        d->message = QString("Loading: ") + message;
     }
 
     repaint();
@@ -98,7 +100,8 @@ void medSplashScreen::repaint()
 void medSplashScreen::finish(QWidget *mainWin)
 
 {
-    if (mainWin) {
+    if (mainWin)
+    {
 #if defined(Q_OS_X11)
         extern void qt_x11_wait_for_window_manager(QWidget *mainWin);
         qt_x11_wait_for_window_manager(mainWin);
@@ -111,7 +114,10 @@ void medSplashScreen::finish(QWidget *mainWin)
 void medSplashScreen::paintEvent(QPaintEvent* pe)
 {
     QRect aTextRect(rect());
-    aTextRect.setRect(aTextRect.x() + 5, aTextRect.y() + 5, aTextRect.width() - 10, aTextRect.height() - 10);
+    aTextRect.setRect(aTextRect.x() + 120,
+                      aTextRect.y() + 5,
+                      aTextRect.width() - 10,
+                      aTextRect.height() - 10);
 
     QPainter aPainter(this);
     aPainter.drawPixmap(rect(), d->pixmap);


### PR DESCRIPTION
Based on https://github.com/medInria/medInria-public/pull/441 (will be rebased)

COMMIT https://github.com/medInria/medInria-public/commit/578dcf8bbd50edb585b471ca34b55ebb45887014

Change the splash screen logo to the medInria homepage logo, which is... less.. orange? (:D) 
We would have a better readability of the text, and the logo is a rectangle, so, no transparency problems anymore. I think this "homepage" logo has more style than the orange original splash screen.

Example of this new splash screen:

![NewLogo](https://user-images.githubusercontent.com/3910352/67192801-8591b780-f3f4-11e9-90ef-30a9205802cc.png)

:m:
