### PR TITLE
[Maximize] rebase error maximize action disappear

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.cpp
@@ -197,6 +197,8 @@ medViewContainer::medViewContainer(medViewContainerSplitter *parent): QFrame(par
     d->toolBarMenu->addActions(QList<QAction*>() << d->vSplitAction << d->hSplitAction << d->fourSplitAction);
     d->toolBarMenu->addMenu(d->presetMenu);
     d->toolBarMenu->addSeparator();
+    d->toolBarMenu->addActions(QList<QAction*>() << d->maximizedAction);
+    d->toolBarMenu->addSeparator();
     d->toolBarMenu->addActions(QList<QAction*>() << d->histogramAction);
 
     d->poolIndicator = new medPoolIndicatorL;


### PR DESCRIPTION
Because of a rebase error during the mix of Histogram, Four-split and Maximize changes in the Tools button of views, the maximize action was missing.

:m: