### PR TITLE
[PolygonROI] crash delete roi and switch to other tlbx

### DIFF
--- a/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
@@ -1160,11 +1160,13 @@ void polygonRoiToolBox::clear()
             list = listSeries->at(0)->getListOfRois();
             DeleteSeveralRoisCommand * deleteCommand = new DeleteSeveralRoisCommand(currentView,*list,"Polygon rois","deleteSeveralRois");
             medRoiManager::instance()->addToUndoRedoStack(deleteCommand);
-
-            m_maskData = nullptr;
-            disableButtons();
         }
+
+        currentView = nullptr;
     }
+
+    m_maskData = nullptr;
+    disableButtons();
 }
 
 void polygonRoiToolBox::buttonsStateAtDataOpeningBeforeROI()

--- a/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
@@ -1152,7 +1152,9 @@ void polygonRoiToolBox::clear()
         ListRois *list;
         QList<medSeriesOfRoi*> *listSeries = medRoiManager::instance()->getSeriesOfRoi()->value(currentView);
 
-        if(listSeries != nullptr && listSeries->at(0)->getListOfRois()->size() != 0)
+        if(listSeries != nullptr
+                && listSeries->count() > 0
+                && listSeries->at(0)->getListOfRois()->size() != 0)
         {
             // Get list of Rois
             list = listSeries->at(0)->getListOfRois();


### PR DESCRIPTION
Fix the crash:
 * Drop a data in a view, open PolygonROI
 * Draw a ROI, delete it (with the "D" button in medRoiManagementToolbox)
 * Switch to an other toolbox (Paint for instance) -> crash

:m: