### PR TITLE
[diffeo] standardize export file for windows

### DIFF
--- a/src/plugins/legacy/diffeomorphicDemons/diffeomorphicDemonsPlugin.h
+++ b/src/plugins/legacy/diffeomorphicDemons/diffeomorphicDemonsPlugin.h
@@ -39,5 +39,3 @@ public:
     virtual QStringList contributors() const;
     virtual QStringList types() const;
 };
-
-

--- a/src/plugins/legacy/diffeomorphicDemons/diffeomorphicDemonsPluginExport.h
+++ b/src/plugins/legacy/diffeomorphicDemons/diffeomorphicDemonsPluginExport.h
@@ -14,7 +14,7 @@
 #pragma once
 
 #ifdef WIN32
-    #ifdef DiffeomorphicDemonsPlugin_EXPORTS
+    #ifdef diffeomorphicDemonsPlugin_EXPORTS
         #define DIFFEOMORPHICDEMONSPLUGIN_EXPORT __declspec(dllexport)
     #else
         #define DIFFEOMORPHICDEMONSPLUGIN_EXPORT __declspec(dllimport)


### PR DESCRIPTION
Standardize the export file for Windows compilation. It could prevent also compilation errors.

:m: