### PR TITLE
[MACOSX - FIX] - medN4BiasCorrection - build and link errors

### DIFF
--- a/src/plugins/legacy/medN4BiasCorrection/CMakeLists.txt
+++ b/src/plugins/legacy/medN4BiasCorrection/CMakeLists.txt
@@ -70,6 +70,7 @@ add_library(${TARGET_NAME} SHARED
 
 target_link_libraries(${TARGET_NAME}
   ${QT_LIBRARIES}
+  ${ITK_LIBRARIES}
   medCore
   medUtilities
   )

--- a/src/plugins/legacy/medN4BiasCorrection/medN4BiasCorrectionToolBox.cpp
+++ b/src/plugins/legacy/medN4BiasCorrection/medN4BiasCorrectionToolBox.cpp
@@ -20,6 +20,10 @@
 #include <medSelectorToolBox.h>
 #include <medToolBoxFactory.h>
 
+#include <string>
+#include <sstream>
+#include <iostream>
+
 class medN4BiasCorrectionToolBoxPrivate
 {
 public:    


### PR DESCRIPTION
Fix compilation and link error when building on macosx.

__medN4BiasCorrection Plugin__  

- Add missing std include in file. 
- Add ITK_LIBRARIES in CMakelists.txt => target_link_libraries