### PR TITLE
[VariationalSeg] interactors cleaning

### DIFF
--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImage4DInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImage4DInteractor.cpp
@@ -22,6 +22,7 @@
 #include <medVtkViewBackend.h>
 #include <medViewFactory.h>
 #include <medAbstractImageData.h>
+#include <medIntParameterL.h>
 #include <medDoubleParameterL.h>
 
 #include <QVBoxLayout>
@@ -40,6 +41,7 @@ public:
     vtkImageView3D *view3d;
     medAbstractImageData *imageData;
 
+    medIntParameterL *slicingParameter;
 };
 
 
@@ -51,6 +53,8 @@ medVtkViewItkDataImage4DInteractor::medVtkViewItkDataImage4DInteractor(medAbstra
     medVtkViewBackend* backend = static_cast<medVtkViewBackend*>(parent->backend());
     d->view2d = backend->view2D;
     d->view3d = backend->view3D;
+
+    d->slicingParameter = nullptr;
 }
 
 medVtkViewItkDataImage4DInteractor::~medVtkViewItkDataImage4DInteractor()
@@ -122,6 +126,8 @@ void medVtkViewItkDataImage4DInteractor::setInputData(medAbstractData *data)
             double* range = m_poConv->getCurrentScalarRange();
             d->view2d->SetColorRange(range);
             this->initWindowLevelParameters(range);
+
+            createSlicingParam();
 
             if(d->view->layer(d->imageData) == 0)
             {

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.h
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.h
@@ -45,6 +45,8 @@ public:
     virtual QString preset() const;
     virtual QStringList handled() const;
 
+    void createSlicingParam();
+
 public slots:
     virtual void setOpacity (double opacity);
     void moveToSlice(int slice);

--- a/src/plugins/legacy/variationalSegmentation/varSegToolBox.cpp
+++ b/src/plugins/legacy/variationalSegmentation/varSegToolBox.cpp
@@ -219,6 +219,8 @@ void VarSegToolBox::applyMaskToImage()
 {
     if (d->currentView)
     {
+        addBinaryImage();
+
         this->setToolBoxOnWaitStatus();
 
         d->process = qobject_cast<medAbstractProcessLegacy*>(dtkAbstractProcessFactory::instance()->create("medMaskApplication"));
@@ -481,7 +483,7 @@ void VarSegToolBox::endSegmentation()
         enableButtons(false);
 
         medAbstractView *view = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainerView();
-        if (view)
+        if (view && (view->count()>0))
         {
             view->render();
         }


### PR DESCRIPTION
This PR aims to clean/solve remaining problems seen in Variational Segmentation from the interactors system.

 * No crash closing the last layer of the view in the toolbox
 * Slicing Parameter standardize in interactors

And something weird in varSegToolBox.cpp:
if you do not save the output data in the db (with `VarSegToolBox::addBinaryImage`) before adding the output in the view, it crashes. During this crash, `medVtkViewItkDataImageInteractor::setInputData` is called, but does not succeed to do `SetViewInput (data, d->view->layer(data)`.
I have got a `"Unable to add data:  \"itkDataImageUChar3\"  to view  \"medVtkViewItkDataImageInteractor\""` warning.
Thus, the data is not really created, including parameters which create the crash. 
In this PR, since we want to do an alpha release soon, i choose to save the data (non-permanently) in the database before adding the output on the view. However, it could be an underlying problem. The `SetViewInput` function is a new function which was different from the [previous one](https://github.com/Inria-Asclepios/medInria-public/blob/2.4.0/src-plugins/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp#L158) so i don't know how to solve this. I checked and this behavior was not bugged on our version.
I think this is the only toolbox for now trying to add data like that, that's why it has not been seen before.

:m:
