### PR TITLE
[qRegisterMetaType] clean qt metatype register at app opening

### DIFF
--- a/src/app/medInria/main.cpp
+++ b/src/app/medInria/main.cpp
@@ -68,8 +68,6 @@ void forceShow(medMainWindow& mainwindow )
 
 int main(int argc,char* argv[])
 {
-    qRegisterMetaType<medDataIndex>("medDataIndex");
-
     // Setup openGL surface compatible with QVTKOpenGLWidget,
     // required by medVtkView
     QSurfaceFormat fmt;

--- a/src/app/medInria/medApplication.cpp
+++ b/src/app/medInria/medApplication.cpp
@@ -117,13 +117,12 @@ void medApplication::open(QString path)
 
 void medApplication::initialize()
 {
-    qRegisterMetaType<QUuid>("QUuid");
-    //    qRegisterMetaType<medAbstractImageData>("medAbstractImageData");
+    qRegisterMetaType<medDataIndex>("medDataIndex");
 
     //  Setting up database connection
     if ( ! medDatabaseController::instance()->createConnection())
     {
-        dtkDebug() << "Unable to create a connection to the database";
+        qDebug() << "Unable to create a connection to the database";
     }
 
     medDataManager::initialize();
@@ -143,8 +142,6 @@ void medApplication::initialize()
     settingsWidgetFactory->registerSettingsWidget<medDatabaseSettingsWidget>();
 
     //Register annotations
-    //TODO there is obviously something that have to be done here. - RDE
-    //TODO I did something... was it enough ? - Flo
     medAbstractDataFactory * datafactory = medAbstractDataFactory::instance();
     datafactory->registerDataType<medSeedPointAnnotationData>();
 


### PR DESCRIPTION
From work with @Florent2305. No need to register already registered QVariant type (Quuid). Move medDataIndex register in medApplication.

:m: