### PR TITLE
[FIX] - [OSX] - default db path

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medStorage.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medStorage.cpp
@@ -60,8 +60,8 @@ QString medStorage::dataLocation(void)
         {
 #ifdef Q_OS_MAC
             vDbLoc = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
-                .remove(QCoreApplication::applicationName())
-                .append(QCoreApplication::applicationName());
+                    + "/" + QCoreApplication::organizationName()
+                    + "/" + QCoreApplication::applicationName();
 #else
             vDbLoc = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
                     + "/data/" + QCoreApplication::organizationName()


### PR DESCRIPTION
On OSX, Replace the default DB path below  : 
- `/Users/account_name/Library/Application SupportmedInria`

with
- `/Users/account_name/Library/Application Support/inria/medInria/`

**CAUTION**, 
If you have already launch medInria on your laptop, 
the wrong db path is defined in your plist 
cf. key `database.actual_database_location` in file `/Users/account_name/Library/Preferences/com.fr.medInria.plist`
and the fix does not work.

**First, You have to delete the key from your plist**
1. Open a terminal
2. `defaults delete com.fr.medInria database.actual_database_location`