### PR TITLE
[DB] save-on-quit save temporary data: no duplicated names

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
@@ -431,10 +431,15 @@ void medAbstractDatabaseImporter::importData()
         return;
     }
 
-    populateMissingMetadata(d->data, "EmptySeries");
+    // Update name of the series if a permanent data has this name already
+    QString seriesDescription = d->data->metadata(medMetaDataKeys::SeriesDescription.key());
+    QString newSeriesDescription = ensureUniqueSeriesName(seriesDescription);
+    d->data->setMetaData(medMetaDataKeys::SeriesDescription.key(), QStringList() << newSeriesDescription );
 
     if ( !d->data->hasMetaData ( medMetaDataKeys::FilePaths.key() ) )
+    {
          d->data->addMetaData ( medMetaDataKeys::FilePaths.key(), QStringList() << "data created internally" );
+    }
 
     // Information about the app and version of the application
     QString attachedInfoApp = QString("generated with " +
@@ -533,7 +538,6 @@ void medAbstractDatabaseImporter::populateMissingMetadata ( medAbstractData* med
         qWarning() << "data invalid";
         return;
     }
-
 
     QString newSeriesDescription;
     // check if image have basic information like patient, study, etc.


### PR DESCRIPTION
Fixes https://github.com/medInria/medInria-public/issues/230

On close, if you want to save temporary data, the code checks if there is already a data with the same name in the database, and add a suffix on the name.

(it was an issue for 4.0 but it was a quick fix, and i worked a lot of these code since few week, so i was not lost)

:m: