### PR TITLE
[CMake] CMAKE_BUILD_TYPE(s) cleaning

### DIFF
--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -86,8 +86,8 @@ endif()
 
 unset(CMAKE_BUILD_TYPE CACHE)
 
-set(CMAKE_BUILD_TYPE_medInria  Release CACHE STRING "Build type configuration specific to medInria.")
-set(CMAKE_BUILD_TYPE_externals Debug   CACHE STRING "Build type configuration for externals projects libraries.")
+set(CMAKE_BUILD_TYPE_medInria  Debug   CACHE STRING "Build type configuration specific to medInria.")
+set(CMAKE_BUILD_TYPE_externals Release CACHE STRING "Build type configuration for externals projects libraries.")
 
 ## #############################################################################
 ## medInria dirs

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -86,8 +86,8 @@ endif()
 
 unset(CMAKE_BUILD_TYPE CACHE)
 
-set(CMAKE_BUILD_TYPE_medInria  Debug   CACHE STRING "Build type configuration specific to medInria.")
-set(CMAKE_BUILD_TYPE_externals Release CACHE STRING "Build type configuration for externals projects libraries.")
+set(CMAKE_BUILD_TYPE_medInria  Debug  CACHE STRING "Build type configuration specific to medInria.")
+set(CMAKE_BUILD_TYPE_ExtProjs Release CACHE STRING "Build type configuration for externals projects libraries.")
 
 ## #############################################################################
 ## medInria dirs

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -86,12 +86,11 @@ endif()
 
 unset(CMAKE_BUILD_TYPE CACHE)
 
-set(CMAKE_BUILD_TYPE_medInria  RelWithDebInfo CACHE STRING "Build type configuration specific to medInria.")
-
-set(CMAKE_BUILD_TYPE_externals RelWithDebInfo CACHE STRING "Build type configuration for externals projects libraries.")
+set(CMAKE_BUILD_TYPE_medInria  Release CACHE STRING "Build type configuration specific to medInria.")
+set(CMAKE_BUILD_TYPE_externals Debug   CACHE STRING "Build type configuration for externals projects libraries.")
 
 ## #############################################################################
-## medInria dirs.
+## medInria dirs
 ## #############################################################################
 
 set(medInria_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src)

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -85,16 +85,18 @@ endif()
 ## #############################################################################
 
 unset(CMAKE_BUILD_TYPE CACHE)
-set(CMAKE_BUILD_TYPE_externals_projects Release CACHE STRING "Build type configuration for externals projects libraries.")
-set(CMAKE_BUILD_TYPE_medInria Debug CACHE STRING "Build type configuration specific to medInria.")
+
+set(CMAKE_BUILD_TYPE_medInria  RelWithDebInfo CACHE STRING "Build type configuration specific to medInria.")
+
+set(CMAKE_BUILD_TYPE_externals RelWithDebInfo CACHE STRING "Build type configuration for externals projects libraries.")
 
 ## #############################################################################
 ## medInria dirs.
 ## #############################################################################
+
 set(medInria_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src)
 set(medInria_BINARY_DIR ${CMAKE_BINARY_DIR}/medInria-build)
 set(medInria_STAMP_DIR ${CMAKE_BINARY_DIR}/medInria-stamp)
-
 
 ## #############################################################################
 ## Add modules

--- a/superbuild/projects_modules/DCMTK.cmake
+++ b/superbuild/projects_modules/DCMTK.cmake
@@ -68,7 +68,7 @@ endif()
 
 set(cmake_args
   ${ep_common_cache_args}
-  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_ExtProjs}
   -DCMAKE_C_FLAGS=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS=${${ep}_cxx_flags}
   -DCMAKE_SHARED_LINKER_FLAGS:=${${ep}_shared_linker_flags}  

--- a/superbuild/projects_modules/DCMTK.cmake
+++ b/superbuild/projects_modules/DCMTK.cmake
@@ -68,7 +68,7 @@ endif()
 
 set(cmake_args
   ${ep_common_cache_args}
-  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals_projects}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals}
   -DCMAKE_C_FLAGS=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS=${${ep}_cxx_flags}
   -DCMAKE_SHARED_LINKER_FLAGS:=${${ep}_shared_linker_flags}  

--- a/superbuild/projects_modules/ITK.cmake
+++ b/superbuild/projects_modules/ITK.cmake
@@ -53,7 +53,7 @@ endif()
 
 set(cmake_args
   ${ep_common_cache_args}
-  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals_projects}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals}
   -DCMAKE_C_FLAGS=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS=${${ep}_cxx_flags}
   -DCMAKE_MACOSX_RPATH:BOOL=OFF

--- a/superbuild/projects_modules/ITK.cmake
+++ b/superbuild/projects_modules/ITK.cmake
@@ -53,7 +53,7 @@ endif()
 
 set(cmake_args
   ${ep_common_cache_args}
-  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_ExtProjs}
   -DCMAKE_C_FLAGS=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS=${${ep}_cxx_flags}
   -DCMAKE_MACOSX_RPATH:BOOL=OFF

--- a/superbuild/projects_modules/QtDCM.cmake
+++ b/superbuild/projects_modules/QtDCM.cmake
@@ -66,7 +66,7 @@ endif()
 
 set(cmake_args
   ${ep_common_cache_args}
-  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_ExtProjs}
   -DCMAKE_C_FLAGS=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS=${${ep}_cxx_flags}
   -DCMAKE_SHARED_LINKER_FLAGS=${${ep}_shared_linker_flags}  

--- a/superbuild/projects_modules/QtDCM.cmake
+++ b/superbuild/projects_modules/QtDCM.cmake
@@ -66,7 +66,7 @@ endif()
 
 set(cmake_args
   ${ep_common_cache_args}
-  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals_projects}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals}
   -DCMAKE_C_FLAGS=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS=${${ep}_cxx_flags}
   -DCMAKE_SHARED_LINKER_FLAGS=${${ep}_shared_linker_flags}  

--- a/superbuild/projects_modules/RPI.cmake
+++ b/superbuild/projects_modules/RPI.cmake
@@ -58,7 +58,7 @@ endif()
 
 set(cmake_args
   ${ep_common_cache_args}
-  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_ExtProjs}
   -DCMAKE_C_FLAGS=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS=${${ep}_cxx_flags}
   -DCMAKE_SHARED_LINKER_FLAGS=${${ep}_shared_linker_flags}  

--- a/superbuild/projects_modules/RPI.cmake
+++ b/superbuild/projects_modules/RPI.cmake
@@ -58,7 +58,7 @@ endif()
 
 set(cmake_args
   ${ep_common_cache_args}
-  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals_projects}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals}
   -DCMAKE_C_FLAGS=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS=${${ep}_cxx_flags}
   -DCMAKE_SHARED_LINKER_FLAGS=${${ep}_shared_linker_flags}  

--- a/superbuild/projects_modules/TTK.cmake
+++ b/superbuild/projects_modules/TTK.cmake
@@ -59,7 +59,7 @@ endif()
 
 set(cmake_args
   ${ep_common_cache_args}
-  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals_projects}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals}
   -DCMAKE_C_FLAGS:STRING=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS:STRING=${${ep}_cxx_flags}
   -DCMAKE_SHARED_LINKER_FLAGS:STRING=${${ep}_shared_linker_flags}  

--- a/superbuild/projects_modules/TTK.cmake
+++ b/superbuild/projects_modules/TTK.cmake
@@ -59,7 +59,7 @@ endif()
 
 set(cmake_args
   ${ep_common_cache_args}
-  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_ExtProjs}
   -DCMAKE_C_FLAGS:STRING=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS:STRING=${${ep}_cxx_flags}
   -DCMAKE_SHARED_LINKER_FLAGS:STRING=${${ep}_shared_linker_flags}  

--- a/superbuild/projects_modules/VTK.cmake
+++ b/superbuild/projects_modules/VTK.cmake
@@ -60,7 +60,7 @@ endif() # no WIN32 use of FFmpeg
 
 set(cmake_args
   ${ep_common_cache_args}
-  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_ExtProjs}
   -DCMAKE_C_FLAGS=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS=${${ep}_cxx_flags}
   -DCMAKE_MACOSX_RPATH:BOOL=OFF

--- a/superbuild/projects_modules/VTK.cmake
+++ b/superbuild/projects_modules/VTK.cmake
@@ -60,7 +60,7 @@ endif() # no WIN32 use of FFmpeg
 
 set(cmake_args
   ${ep_common_cache_args}
-  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals_projects}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals}
   -DCMAKE_C_FLAGS=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS=${${ep}_cxx_flags}
   -DCMAKE_MACOSX_RPATH:BOOL=OFF

--- a/superbuild/projects_modules/dtk.cmake
+++ b/superbuild/projects_modules/dtk.cmake
@@ -60,7 +60,7 @@ endif()
 
 set(cmake_args
   ${ep_common_cache_args}
-  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_ExtProjs}
   -DCMAKE_C_FLAGS:STRING=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS:STRING=${${ep}_cxx_flags}   
   -DCMAKE_SHARED_LINKER_FLAGS:STRING=${${ep}_shared_linker_flags}  

--- a/superbuild/projects_modules/dtk.cmake
+++ b/superbuild/projects_modules/dtk.cmake
@@ -60,7 +60,7 @@ endif()
 
 set(cmake_args
   ${ep_common_cache_args}
-  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals_projects}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals}
   -DCMAKE_C_FLAGS:STRING=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS:STRING=${${ep}_cxx_flags}   
   -DCMAKE_SHARED_LINKER_FLAGS:STRING=${${ep}_shared_linker_flags}  

--- a/superbuild/projects_modules/dtkImaging.cmake
+++ b/superbuild/projects_modules/dtkImaging.cmake
@@ -59,7 +59,7 @@ endif()
 
 set(cmake_args
   ${ep_common_cache_args}
-  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals_projects}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals}
   -DCMAKE_C_FLAGS:STRING=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS:STRING=${${ep}_cxx_flags}   
   -DCMAKE_SHARED_LINKER_FLAGS:STRING=${${ep}_shared_linker_flags}  

--- a/superbuild/projects_modules/dtkImaging.cmake
+++ b/superbuild/projects_modules/dtkImaging.cmake
@@ -59,7 +59,7 @@ endif()
 
 set(cmake_args
   ${ep_common_cache_args}
-  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_externals}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_ExtProjs}
   -DCMAKE_C_FLAGS:STRING=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS:STRING=${${ep}_cxx_flags}   
   -DCMAKE_SHARED_LINKER_FLAGS:STRING=${${ep}_shared_linker_flags}  

--- a/superbuild/projects_modules/medInria.cmake
+++ b/superbuild/projects_modules/medInria.cmake
@@ -66,11 +66,9 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   set(${ep}_cxx_flags "${${ep}_cxx_flags} -fpermissive")
 endif()
 
-set(${ep}_BUILD_TYPE Debug CACHE STRING "Build type configuration specific to medInria.")
-
 set(cmake_args
    ${ep_common_cache_args}
-  -DCMAKE_BUILD_TYPE=${${ep}_BUILD_TYPE}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE_medInria}
   -DCMAKE_C_FLAGS=${${ep}_c_flags}
   -DCMAKE_CXX_FLAGS=${${ep}_cxx_flags}
   -DCMAKE_SHARED_LINKER_FLAGS=${${ep}_shared_linker_flags}  


### PR DESCRIPTION
This PR fixes https://github.com/medInria/medInria-public/issues/439.

 * CMAKE_BUILD_TYPE_medInria was never used, only medInria _BUILD_TYPE in medInria.cmake
 * CMAKE_BUILD_TYPE_externals_projects was too long

:m: