### PR TITLE
[Reslice] solve crash using reslice toolbox

### DIFF
--- a/src/plugins/legacy/reformat/medResliceViewer.h
+++ b/src/plugins/legacy/reformat/medResliceViewer.h
@@ -88,6 +88,7 @@ protected:
     double *outputSpacing;
     unsigned char selectedView;
     vtkImageView3D *view3d;
+    vtkSmartPointer<vtkImageData> vtkViewData;
     dtkSmartPointer<medAbstractData> outputData;
     int fromSlice, toSlice;
     resliceToolBox *reformaTlbx;

--- a/src/plugins/legacy/reformat/resliceToolBox.cpp
+++ b/src/plugins/legacy/reformat/resliceToolBox.cpp
@@ -196,9 +196,9 @@ void resliceToolBox::startReformat()
                 container->setDefaultWidget(d->resliceViewer->viewWidget());
                 connect(container, SIGNAL(viewRemoved()),this, SLOT(stopReformat()), Qt::UniqueConnection);
 
-                connect(d->spacingX, SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));
-                connect(d->spacingY, SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));
-                connect(d->spacingZ, SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));
+                connect(d->spacingX->getSpinBox(), SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));
+                connect(d->spacingY->getSpinBox(), SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));
+                connect(d->spacingZ->getSpinBox(), SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));
                 connect(d->b_saveImage, SIGNAL(clicked()), d->resliceViewer, SLOT(saveImage()));
 
                 d->reformatedImage = nullptr;


### PR DESCRIPTION
Based on https://github.com/medInria/medInria-public/pull/512, will be rebased.

Fixes https://github.com/medInria/medInria-public/issues/509

Remove the crash using the reslice toolbox. This was from an incorrect input, and a wrong connection.

COMMIT:  https://github.com/medInria/medInria-public/commit/0ae6260f552631ef19e311f87007cf824f6581a4

:m: