### PR TITLE
[DataInteractor] min/max intensities steps

### DIFF
--- a/src/layers/legacy/medCoreLegacy/parameters/medDoubleParameterL.cpp
+++ b/src/layers/legacy/medCoreLegacy/parameters/medDoubleParameterL.cpp
@@ -16,10 +16,10 @@
 #include <QDoubleSpinBox>
 #include <QSlider>
 #include <QLabel>
+
 #include <dtkLog>
 
 #include <cmath>
-
 #include <iomanip>
 #include <sstream>
 
@@ -40,7 +40,6 @@ public:
     double max;
     double step;
     int decimals;
-
     medDoubleSpinBox *spinBox;
     QSlider *slider;
     QLabel *valueLabel;
@@ -58,9 +57,9 @@ medDoubleParameterL::medDoubleParameterL(QString name, QObject *parent):
     d->min = 0;
     d->max = 0;
     m_value = 0;
-    d->spinBox = NULL;
-    d->slider = NULL;
-    d->valueLabel = NULL;
+    d->spinBox = nullptr;
+    d->slider = nullptr;
+    d->valueLabel = nullptr;
     d->step = 0.1;
     d->decimals = -1;
 }
@@ -72,33 +71,48 @@ medDoubleParameterL::~medDoubleParameterL()
 
 void medDoubleParameterL::setValue(double value)
 {
-    if(m_value == value)
-        return;
+    if(m_value != value)
+    {
+        if(d->min == d->max)
+        {
+            m_value = value;
+        }
+        else if(value < d->min)
+        {
+            m_value = d->min;
+        }
+        else if(value > d->max)
+        {
+            m_value = d->max;
+        }
+        else
+        {
+            m_value = value;
+        }
 
-    if(d->min == d->max)
-       m_value = value;
-    else if(value < d->min)
-        m_value = d->min;
-    else if(value > d->max)
-        m_value = d->max;
-    else m_value = value;
+        //  update intern widget
+        this->blockInternWidgetsSignals(true);
+        this->updateInternWigets();
+        this->blockInternWidgetsSignals(false);
 
-    //  update intern widget
-    this->blockInternWidgetsSignals(true);
-    this->updateInternWigets();
-    this->blockInternWidgetsSignals(false);
-
-    emit valueChanged(m_value);
+        emit valueChanged(m_value);
+    }
 }
 
 void medDoubleParameterL::updateInternWigets()
 {
     if(d->spinBox)
+    {
         d->spinBox->setValue(m_value);
+    }
     if(d->slider)
+    {
         d->slider->setValue(convertToInt(m_value));
+    }
     if(d->valueLabel)
+    {
         d->valueLabel->setText(QString::number(m_value, 'f', 2));
+    }
 }
 
 void medDoubleParameterL::setRange(double min, double max)
@@ -172,7 +186,9 @@ QDoubleSpinBox* medDoubleParameterL::getSpinBox()
                 multipliedStep *= 10;
                 int testNumber = floor(multipliedStep);
                 if (testNumber > 0)
+                {
                     nullDecimal = false;
+                }
             }
         }
 
@@ -196,8 +212,8 @@ QSlider* medDoubleParameterL::getSlider()
         d->slider->setStyleSheet("QSlider::handle:horizontal {width: 15px;}");
 
         this->addToInternWidgets(d->slider);
-        connect(d->slider, SIGNAL(destroyed()), this, SLOT(removeInternSlider()));
-        connect(d->slider, SIGNAL(valueChanged(int)), this, SLOT(setIntValue(int)));
+        connect(d->slider, SIGNAL(destroyed()),       this, SLOT(removeInternSlider()));
+        connect(d->slider, SIGNAL(valueChanged(int)), this, SLOT(setSliderIntValue(int)));
     }
     return d->slider;
 }
@@ -238,8 +254,10 @@ int medDoubleParameterL::convertToInt(double value)
     return (value-d->min)/d->step;
 }
 
-void medDoubleParameterL::setIntValue(int value)
+void medDoubleParameterL::setSliderIntValue(int value)
 {
-    double dValue = static_cast<double>(value)*d->step + d->min;
+    double currentDoubleValue = static_cast<double>(value);
+    double dValue = currentDoubleValue * d->step + d->min;
     setValue(dValue);
 }
+

--- a/src/layers/legacy/medCoreLegacy/parameters/medDoubleParameterL.cpp
+++ b/src/layers/legacy/medCoreLegacy/parameters/medDoubleParameterL.cpp
@@ -110,9 +110,13 @@ void medDoubleParameterL::setRange(double min, double max)
         return;
 
     if(d->spinBox)
+    {
         d->spinBox->setRange(min, max);
+    }
     if(d->slider)
+    {
         d->slider->setRange(0,convertToInt(max));
+    }
     updateInternWigets();
 }
 
@@ -120,16 +124,20 @@ void medDoubleParameterL::setSingleStep(double step)
 {
     if(step <= 0)
     {
-        dtkWarn() << "Attempt to set a step <= 0 to medDoubleParameterL";
+        qWarning() << "Attempt to set a step <= 0 to medDoubleParameterL";
         return;
     }
 
     d->step = step;
 
     if(d->spinBox)
+    {
         d->spinBox->setSingleStep(step);
+    }
     if(d->slider)
+    {
         d->slider->setSingleStep(convertToInt(step));
+    }
 }
 
 void medDoubleParameterL::setDecimals(unsigned int decimals)
@@ -137,7 +145,9 @@ void medDoubleParameterL::setDecimals(unsigned int decimals)
     d->decimals = decimals;
 
     if(d->spinBox)
+    {
         d->spinBox->setDecimals(decimals);
+    }
 }
 
 QDoubleSpinBox* medDoubleParameterL::getSpinBox()
@@ -214,13 +224,13 @@ QWidget* medDoubleParameterL::getWidget()
 void medDoubleParameterL::removeInternSpinBox()
 {
     this->removeFromInternWidgets(d->spinBox);
-    d->spinBox = NULL;
+    d->spinBox = nullptr;
 }
 
 void medDoubleParameterL::removeInternSlider()
 {
     this->removeFromInternWidgets(d->slider);
-    d->slider = NULL;
+    d->slider = nullptr;
 }
 
 int medDoubleParameterL::convertToInt(double value)
@@ -230,6 +240,6 @@ int medDoubleParameterL::convertToInt(double value)
 
 void medDoubleParameterL::setIntValue(int value)
 {
-    double dValue = (double)value*d->step + d->min;
+    double dValue = static_cast<double>(value)*d->step + d->min;
     setValue(dValue);
 }

--- a/src/layers/legacy/medCoreLegacy/parameters/medDoubleParameterL.h
+++ b/src/layers/legacy/medCoreLegacy/parameters/medDoubleParameterL.h
@@ -51,7 +51,7 @@ private slots:
     void removeInternSpinBox();
     void removeInternSlider();
 
-    void setIntValue(int);
+    void setSliderIntValue(int value);
 
 private:
     int convertToInt(double value);

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
@@ -930,7 +930,7 @@ void vtkImageView::SetColorWindow(double s,int layer)
     this->StoreColorWindow(s,layer);
     this->SetTransferFunctionRangeFromWindowSettings(layer);
 
-    this->InvokeEvent (vtkImageView::WindowLevelChangedEvent, NULL);
+    this->InvokeEvent (vtkImageView::WindowLevelChangedEvent, nullptr);
 }
 
 //----------------------------------------------------------------------------
@@ -942,7 +942,7 @@ void vtkImageView::SetColorLevel(double s,int layer)
     this->StoreColorLevel (s, layer);
     this->SetTransferFunctionRangeFromWindowSettings(layer);
 
-    this->InvokeEvent (vtkImageView::WindowLevelChangedEvent, NULL);
+    this->InvokeEvent (vtkImageView::WindowLevelChangedEvent, nullptr);
 }
 
 void vtkImageView::SetColorWindowLevel(double w, double l)
@@ -954,14 +954,14 @@ void vtkImageView::SetColorWindowLevel(double w, double l)
 void vtkImageView::SetColorWindowLevel(double w, double l, int layer)
 {
     if (w == this->GetColorWindow(layer) && l == this->GetColorLevel(layer))
+    {
         return;
-
+    }
     this->StoreColorWindow(w,layer);
     this->StoreColorLevel (l, layer);
     this->SetTransferFunctionRangeFromWindowSettings(layer);
 
-    this->InvokeEvent (vtkImageView::WindowLevelChangedEvent, NULL);
-
+    this->InvokeEvent (vtkImageView::WindowLevelChangedEvent, nullptr);
 }
 
 /**

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
@@ -324,20 +324,18 @@ void medVtkViewItkDataImageInteractor::initWindowLevelParameters(double *range)
     d->maxIntensityParameter = new medDoubleParameterL("Max Intensity", this);
     connect(d->maxIntensityParameter, SIGNAL(valueChanged(double)), this, SLOT(setWindowLevelFromMinMax()));
 
+    d->intensityStep = (levelMax - levelMin) / 100;
+    d->minIntensityParameter->setSingleStep(d->intensityStep);
+    d->maxIntensityParameter->setSingleStep(d->intensityStep);
+
     if(d->isFloatImage)
     {
-        d->intensityStep = qMin(0.1,(levelMax-levelMin) / 1000);
-        d->minIntensityParameter->setSingleStep(d->intensityStep);
-        d->minIntensityParameter->setDecimals(6);
-        d->maxIntensityParameter->setSingleStep(d->intensityStep);
-        d->maxIntensityParameter->setDecimals(6);
+        d->minIntensityParameter->setDecimals(2);
+        d->maxIntensityParameter->setDecimals(2);
     }
     else
     {
-        d->intensityStep= 1;
-        d->minIntensityParameter->setSingleStep(d->intensityStep);
         d->minIntensityParameter->setDecimals(0);
-        d->maxIntensityParameter->setSingleStep(d->intensityStep);
         d->maxIntensityParameter->setDecimals(0);
     }
 
@@ -531,14 +529,21 @@ void medVtkViewItkDataImageInteractor::setWindowLevelFromMinMax()
     this->windowLevelParameter()->blockSignals(true);
 
     if(d->view2d->GetColorWindow(d->view->layer(d->imageData)) != window)
+    {
         d->view2d->SetColorWindow(window, d->view->layer(d->imageData));
+    }
     if(d->view3d->GetColorWindow(d->view->layer(d->imageData)) != window)
+    {
         d->view3d->SetColorWindow(window, d->view->layer(d->imageData));
+    }
     if(d->view2d->GetColorLevel(d->view->layer(d->imageData)) != level)
+    {
         d->view2d->SetColorLevel(level, d->view->layer(d->imageData));
+    }
     if(d->view3d->GetColorLevel(d->view->layer(d->imageData)) != level)
+    {
         d->view3d->SetColorLevel(level, d->view->layer(d->imageData));
-
+    }
     this->windowLevelParameter()->blockSignals(false);
 }
 

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
@@ -510,40 +510,35 @@ void medVtkViewItkDataImageInteractor::setWindowLevelFromMinMax()
     if(!sender)
         return;
 
-    if( sender == d->minIntensityParameter && d->minIntensityParameter->value() >= d->maxIntensityParameter->value() )
+    double minIntensityValue = d->minIntensityParameter->value();
+    double maxIntensityValue = d->maxIntensityParameter->value();
+
+    if( sender == d->minIntensityParameter && minIntensityValue >= maxIntensityValue )
     {
         d->maxIntensityParameter->blockSignals(true);
-        d->maxIntensityParameter->setValue(d->minIntensityParameter->value() + d->intensityStep);
+        d->maxIntensityParameter->setValue(minIntensityValue + d->intensityStep);
         d->maxIntensityParameter->blockSignals(false);
     }
-    else if( sender == d->maxIntensityParameter && d->maxIntensityParameter->value() <= d->minIntensityParameter->value() )
+    else if( sender == d->maxIntensityParameter && maxIntensityValue <= minIntensityValue )
     {
         d->minIntensityParameter->blockSignals(true);
-        d->minIntensityParameter->setValue(d->maxIntensityParameter->value() - d->intensityStep);
+        d->minIntensityParameter->setValue(maxIntensityValue - d->intensityStep);
         d->minIntensityParameter->blockSignals(false);
     }
 
-    double level = 0.5 * (d->maxIntensityParameter->value() - d->minIntensityParameter->value()) + d->minIntensityParameter->value();
-    double window = d->maxIntensityParameter->value() - d->minIntensityParameter->value();
+    double minIntensityValueUpdated = d->minIntensityParameter->value();
+    double maxIntensityValueUpdated = d->maxIntensityParameter->value();
+
+    double level = 0.5 * (maxIntensityValueUpdated - minIntensityValueUpdated) + minIntensityValueUpdated;
+    double window = maxIntensityValueUpdated - minIntensityValueUpdated;
 
     this->windowLevelParameter()->blockSignals(true);
 
-    if(d->view2d->GetColorWindow(d->view->layer(d->imageData)) != window)
-    {
-        d->view2d->SetColorWindow(window, d->view->layer(d->imageData));
-    }
-    if(d->view3d->GetColorWindow(d->view->layer(d->imageData)) != window)
-    {
-        d->view3d->SetColorWindow(window, d->view->layer(d->imageData));
-    }
-    if(d->view2d->GetColorLevel(d->view->layer(d->imageData)) != level)
-    {
-        d->view2d->SetColorLevel(level, d->view->layer(d->imageData));
-    }
-    if(d->view3d->GetColorLevel(d->view->layer(d->imageData)) != level)
-    {
-        d->view3d->SetColorLevel(level, d->view->layer(d->imageData));
-    }
+    unsigned int layer = d->view->layer(d->imageData);
+
+    d->view2d->SetColorWindowLevel(window, level, layer);
+    d->view3d->SetColorWindowLevel(window, level, layer);
+
     this->windowLevelParameter()->blockSignals(false);
 }
 


### PR DESCRIPTION
Working on https://github.com/medInria/medInria-public/issues/492 i enhanced the way the steps are computed for min and max intensities sliders.

Edit: this PR helps solving https://github.com/medInria/medInria-public/issues/492. It needs to be tested on an other PC however i think. On mine, this is really quicker, especially because of `d->view2d->SetColorWindowLevel(window, level, layer);` in `medVtkViewItkDataImageInteractor::setWindowLevelFromMinMax()`.

:m: