### PR TITLE
[SearchToolbox] open at app start on some pc

### DIFF
--- a/src/app/medInria/medQuickAccessMenu.cpp
+++ b/src/app/medInria/medQuickAccessMenu.cpp
@@ -23,7 +23,8 @@ Qt::Key OSIndependentControlKey = Qt::Key_Control;
 
 int retrieveDefaultWorkSpace()
 {
-    int iRes = 0;
+    int homepageDefaultWorkspaceNumber = 1;
+    int iRes = homepageDefaultWorkspaceNumber;
 
     bool bMatch = false;
     medWorkspaceFactory::Details *poDetail = nullptr;
@@ -32,11 +33,11 @@ int retrieveDefaultWorkSpace()
 
     if (oStartupWorkspace.toString() == "Search")
     {
-        iRes = 1; // "Search" should not be the startup area. Default is Homepage.
+        iRes = homepageDefaultWorkspaceNumber; // "Search" should not be the startup area. Default is Homepage.
     }
     if (oStartupWorkspace.toString() == "Homepage")
     {
-        iRes = 1;
+        iRes = homepageDefaultWorkspaceNumber;
     }
     else if (oStartupWorkspace.toString() == "Browser")
     {


### PR DESCRIPTION
Should fixes https://github.com/medInria/medInria-public/issues/515

The default workspace number is not 0, it's 1 (homepage).

Is it possible to test it @Florent2305 on the computer on which you had the bug? If you want to test quickly, you just need to change `int iRes = 0;` to `int iRes = 1;` in `medQuickAccessMenu` function `retrieveDefaultWorkSpace`. @mjuhoor had only once this bug. At the second opening of medInria, the search toolbox was not displayed at start.

:m: