### PR TITLE
[DB] avoid not-found saved data in a new database after restart

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
@@ -96,12 +96,12 @@ medAbstractData* medDatabaseReader::run()
     studyUid = query.value ( 1 ).toString();
     studyId = query.value ( 2 ).toString();
 
-    query.prepare ( "SELECT name, uid, orientation, seriesNumber, sequenceName, sliceThickness, rows, columns, \
-                     description, protocol, comments, status, acquisitiondate, importationdate, referee,       \
-                     institution, report, modality, seriesId, \
-                     origin, flipAngle, echoTime, repetitionTime, acquisitionTime, \
-                     path, thumbnail, isIndexed \
-                     FROM series WHERE id = :id" );
+    query.prepare ( "SELECT name, uid, orientation, seriesNumber, sequenceName, sliceThickness, rows, columns, "
+                    "description, protocol, comments, status, acquisitiondate, importationdate, referee, "
+                    "institution, report, modality, seriesId, "
+                    "origin, flipAngle, echoTime, repetitionTime, acquisitionTime, "
+                    "path, thumbnail, isIndexed "
+                    "FROM series WHERE id = :id" );
     query.bindValue ( ":id", seriesDbId );
 
     if ( !query.exec() )


### PR DESCRIPTION
In order to see the bug:
 * Open medInria -> Settings -> Database -> change the database path to a completely new one -> Save -> Close medInria
 * Open medInria -> Workspace/Browser -> open a data -> permanent saving of the data -> Close medInria
 * Open medInria -> Visualization -> open the data: it does not open.

This PR solves this problem. New databases were not opened well, since the image column does not exist in them, but user_version is not set.

:m: