### PR TITLE
[vtk] write/read metadata in vtk mesh files at export/import

### DIFF
--- a/src/plugins/legacy/vtkDataMesh/readers/vtkDataMesh4DReader.cpp
+++ b/src/plugins/legacy/vtkDataMesh/readers/vtkDataMesh4DReader.cpp
@@ -11,52 +11,57 @@
 
 =========================================================================*/
 
-#include <vtkDataMesh4DReader.h>
-#include <vtkDataManagerReader.h>
-#include <vtkDataManager.h>
-#include <vtkMetaDataSetSequence.h>
-#include <vtkSmartPointer.h>
+#include "vtkDataMesh4DReader.h"
+#include "vtkDataManagerReader.h"
 
 #include <medAbstractData.h>
 #include <medAbstractDataFactory.h>
 
+#include <vtkDataManager.h>
+#include <vtkFieldData.h>
+#include <vtkMetaDataSetSequence.h>
+#include <vtkSmartPointer.h>
+
 const char vtkDataMesh4DReader::ID[] = "vtkDataMesh4DReader";
 
-vtkDataMesh4DReader::vtkDataMesh4DReader(): dtkAbstractDataReader() {
+vtkDataMesh4DReader::vtkDataMesh4DReader(): vtkDataMeshReaderBase()
+{
     this->reader = vtkDataManagerReader::New();
 }
 
-vtkDataMesh4DReader::~vtkDataMesh4DReader() {
+vtkDataMesh4DReader::~vtkDataMesh4DReader()
+{
     this->reader->Delete();
 }
 
-QStringList vtkDataMesh4DReader::handled() const {
+QStringList vtkDataMesh4DReader::handled() const
+{
     return QStringList() << "vtkDataMesh4D";
 }
 
-QStringList vtkDataMesh4DReader::s_handled() {
+QStringList vtkDataMesh4DReader::s_handled()
+{
     return QStringList() << "vtkDataMesh4D";
 }
 
-bool vtkDataMesh4DReader::canRead (const QString& path) {
+bool vtkDataMesh4DReader::canRead (const QString& path)
+{
     return this->reader->CanReadFile (path.toLatin1().constData());
 }
 
-bool vtkDataMesh4DReader::canRead (const QStringList& paths) {
-    if (!paths.count())
-        return false;
-    return this->canRead ( paths[0].toLatin1().constData() );
-}
-
-bool vtkDataMesh4DReader::readInformation (const QString& path) {
+bool vtkDataMesh4DReader::readInformation (const QString& path)
+{
   
     medAbstractData *medData = dynamic_cast<medAbstractData*>(this->data());
     this->reader->SetFileName (path.toLatin1().constData());
   
-    if (!medData) {
+    if (!medData)
+    {
         medData = medAbstractDataFactory::instance()->create("vtkDataMesh4D");
         if (medData)
+        {
             this->setData ( medData );
+        }
     }
 
     medData->addMetaData ("FilePath", QStringList() << path);
@@ -65,59 +70,77 @@ bool vtkDataMesh4DReader::readInformation (const QString& path) {
     return true;
 }
 
-bool vtkDataMesh4DReader::readInformation (const QStringList& paths) {
-    if (!paths.count())
-        return false;
-    return this->readInformation ( paths[0].toLatin1().constData() );
-}
-
-bool vtkDataMesh4DReader::read (const QString& path) {
+bool vtkDataMesh4DReader::read (const QString& path)
+{
     this->setProgress (0);
 
     this->readInformation ( path );
 
     this->setProgress (50);
 
-    dtkDebug() << "Can read with: " << this->identifier();
+    qDebug() << "Can read with: " << this->identifier();
 
-    if (medAbstractData *medData = dynamic_cast<medAbstractData*>(this->data()) ) {
-
+    if (medAbstractData *medData = dynamic_cast<medAbstractData*>(this->data()) )
+    {
         if (!(medData->identifier()=="vtkDataMesh4D"))
+        {
             return false;
+        }
 
         this->reader->SetFileName (path.toLatin1().constData());
         this->reader->Update();
+
         vtkMetaDataSetSequence* sequence = vtkMetaDataSetSequence::SafeDownCast (this->reader->GetOutput()->GetMetaDataSet ((unsigned int)0));
-        if (sequence)
-            medData->setData (sequence );
+        if (sequence && sequence->GetNumberOfMetaDataSets() > 0)
+        {
+            if (!extractMetaData(sequence->GetMetaDataSet(0)))
+            {
+                qDebug() << metaObject()->className() << ": no metadata found in " << path;
+            }
+
+            // Remove field from top container of the sequence
+            vtkSmartPointer<vtkFieldData> newFieldData = vtkSmartPointer<vtkFieldData>::New();
+            sequence->GetDataSet()->SetFieldData(newFieldData);
+
+            medData->setData (sequence);
+        }
+        else
+        {
+            return false;
+        }
     }
 
     this->setProgress (100);
     return true;
 }
 
-bool vtkDataMesh4DReader::read (const QStringList& paths) {
-    if (!paths.count())
+bool vtkDataMesh4DReader::extractMetaData(vtkMetaDataSet* dataSet)
+{
+    if (extractMetaDataFromFieldData(dataSet))
+    {
+        return true;
+    }
+    else
+    {
         return false;
-    return this->read ( paths[0].toLatin1().constData() );
+    }
 }
 
-void vtkDataMesh4DReader::setProgress (int value) {
-    emit progressed (value);
-}
-
-bool vtkDataMesh4DReader::registered() {
+bool vtkDataMesh4DReader::registered()
+{
     return medAbstractDataFactory::instance()->registerDataReaderType(
           "vtkDataMesh4DReader",
           vtkDataMesh4DReader::s_handled(),
           createVtkDataMesh4DReader);
 }
 
-QString vtkDataMesh4DReader::identifier() const {
+QString vtkDataMesh4DReader::identifier() const
+{
     return ID;
 }
 
-QString vtkDataMesh4DReader::description() const {
+QString vtkDataMesh4DReader::description() const
+{
     return "Reader for vtk 4D meshes";
 }
 
@@ -125,6 +148,7 @@ QString vtkDataMesh4DReader::description() const {
 // Type instantiation
 // /////////////////////////////////////////////////////////////////
 
-dtkAbstractDataReader *createVtkDataMesh4DReader() {
+dtkAbstractDataReader *createVtkDataMesh4DReader()
+{
     return new vtkDataMesh4DReader;
 }

--- a/src/plugins/legacy/vtkDataMesh/readers/vtkDataMesh4DReader.cpp
+++ b/src/plugins/legacy/vtkDataMesh/readers/vtkDataMesh4DReader.cpp
@@ -78,7 +78,7 @@ bool vtkDataMesh4DReader::read (const QString& path)
 
     this->setProgress (50);
 
-    qDebug() << "Can read with: " << this->identifier();
+    qDebug().noquote() << "Can read with: " << this->identifier();
 
     if (medAbstractData *medData = dynamic_cast<medAbstractData*>(this->data()) )
     {

--- a/src/plugins/legacy/vtkDataMesh/readers/vtkDataMesh4DReader.cpp
+++ b/src/plugins/legacy/vtkDataMesh/readers/vtkDataMesh4DReader.cpp
@@ -2,9 +2,9 @@
 
  medInria
 
- Copyright (c) INRIA 2013 - 2018. All rights reserved.
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.

--- a/src/plugins/legacy/vtkDataMesh/readers/vtkDataMesh4DReader.h
+++ b/src/plugins/legacy/vtkDataMesh/readers/vtkDataMesh4DReader.h
@@ -14,10 +14,10 @@
 #pragma once
 
 #include "vtkDataMeshPluginExport.h"
+#include "vtkDataMeshReaderBase.h"
 
-#include <dtkCoreSupport/dtkAbstractDataReader.h>
+#include <vtkMetaDataSet.h>
 
-class vtkDataSetReader;
 class vtkDataManagerReader;
 
 /**
@@ -37,7 +37,8 @@ class vtkDataManagerReader;
     \author Nicolas Toussaint
 */
 
-class VTKDATAMESHPLUGIN_EXPORT vtkDataMesh4DReader: public dtkAbstractDataReader {
+class VTKDATAMESHPLUGIN_EXPORT vtkDataMesh4DReader: public vtkDataMeshReaderBase
+{
     Q_OBJECT
 
 public:
@@ -50,20 +51,13 @@ public:
 
 public slots:
     virtual bool canRead(const QString& path);
-    virtual bool canRead(const QStringList& paths);
-
     virtual bool readInformation(const QString& path);
-    virtual bool readInformation(const QStringList& paths);
-
     virtual bool read(const QString& path);
-    virtual bool read(const QStringList& paths);
-
-    virtual void setProgress(int value);
 
     virtual QString identifier()  const;
     virtual QString description() const;
 
-    static bool registered();	
+    static bool registered();
 
 protected:
 
@@ -72,9 +66,7 @@ protected:
 private:
 
     static const char ID[];
+    bool extractMetaData(vtkMetaDataSet *dataSet);
 };
 
 dtkAbstractDataReader *createVtkDataMesh4DReader();
-
-
-

--- a/src/plugins/legacy/vtkDataMesh/readers/vtkDataMesh4DReader.h
+++ b/src/plugins/legacy/vtkDataMesh/readers/vtkDataMesh4DReader.h
@@ -2,9 +2,9 @@
 
  medInria
 
- Copyright (c) INRIA 2013 - 2018. All rights reserved.
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.

--- a/src/plugins/legacy/vtkDataMesh/readers/vtkDataMeshReader.cpp
+++ b/src/plugins/legacy/vtkDataMesh/readers/vtkDataMeshReader.cpp
@@ -11,67 +11,62 @@
 
 =========================================================================*/
 
-#include <vtkDataMeshReader.h>
+#include "vtkDataMeshReader.h"
 
 #include <medAbstractData.h>
 #include <medAbstractDataFactory.h>
+#include <medMetaDataKeys.h>
 
+#include <vtkErrorCode.h>
 #include <vtkMetaVolumeMesh.h>
 #include <vtkMetaSurfaceMesh.h>
+#include <vtkPolyDataReader.h>
 #include <vtkSmartPointer.h>
 
 const char vtkDataMeshReader::ID[] = "vtkDataMeshReader";
 
-vtkDataMeshReader::vtkDataMeshReader() : dtkAbstractDataReader() {
+vtkDataMeshReader::vtkDataMeshReader() : vtkDataMeshReaderBase()
+{
 }
 
-vtkDataMeshReader::~vtkDataMeshReader() {
-}
-
-QStringList vtkDataMeshReader::handled() const {
+QStringList vtkDataMeshReader::handled() const
+{
     return QStringList() << "vtkDataMesh";
 }
 
-QStringList vtkDataMeshReader::s_handled() {
+QStringList vtkDataMeshReader::s_handled()
+{
     return QStringList() << "vtkDataMesh";
 }
 
-bool vtkDataMeshReader::canRead(const QString& path) {
+bool vtkDataMeshReader::canRead(const QString& path)
+{
     return (vtkMetaVolumeMesh::CanReadFile(path.toLocal8Bit().constData()) != 0) ||
            (vtkMetaSurfaceMesh::CanReadFile(path.toLocal8Bit().constData()) != 0);
 }
 
-bool vtkDataMeshReader::canRead(const QStringList& paths){
-    if (paths.empty())
-        return false;
-    return canRead(paths.first().toLocal8Bit().constData());
-}
-
-bool vtkDataMeshReader::readInformation(const QString& path) {
+bool vtkDataMeshReader::readInformation(const QString& path)
+{
     medAbstractData *medData = medAbstractDataFactory::instance()->create("vtkDataMesh");
     this->setData(medData);
-    medData->addMetaData("FilePath", QStringList() << path); // useful ?
     
     return true;
 }
 
-bool vtkDataMeshReader::readInformation(const QStringList& paths) {
-    if (paths.empty())
-        return false;
-    return readInformation(paths.first().toLocal8Bit().constData());
-}
-
-bool vtkDataMeshReader::read(const QString& path) {
+bool vtkDataMeshReader::read(const QString& path)
+{
     setProgress(0);
     readInformation(path);
     setProgress(50);
 
-    qDebug() << "Can read with: " << identifier();
+    qDebug() << "Can read with: " << this->identifier();
 
     if (medAbstractData * medData = dynamic_cast<medAbstractData*>(data()))
     {
         if (!(medData->identifier() == "vtkDataMesh"))
+        {
             return false;
+        }
 
         vtkSmartPointer<vtkMetaDataSet> dataSet = nullptr;
         if (vtkMetaVolumeMesh::CanReadFile(path.toLocal8Bit().constData()) != 0)
@@ -84,47 +79,108 @@ bool vtkDataMeshReader::read(const QString& path) {
         }
         else
         {
-            qDebug() << "Loading the vtkDataMesh failed, it's neither a surface nor a volume mesh!";
+            qDebug() << metaObject()->className() << ": loading " << path << " failed, not a surface or volume mesh";
             return false;
         }
 
         try
         {
             dataSet->Read(path.toLocal8Bit().constData());
-        } catch (...)
+            medData->setData(dataSet);
+
+            if (!extractMetaData(path, dataSet))
+            {
+                qDebug() << metaObject()->className() << ": no metadata found in " << path;
+            }
+        }
+        catch (vtkErrorCode::ErrorIds error)
         {
-            qDebug() << "Loading the vtkDataMesh failed, error while parsing!";
+            qDebug() << metaObject()->className() << ": " << vtkErrorCode::GetStringFromErrorCode(error);
+            return false;
+        }
+        catch (...)
+        {
+            qDebug() << metaObject()->className() << ": error reading " << path;;
             return false;
         }
 
-        medData->setData(dataSet);
+        // Use filename as series description if no meta data could be found
+        if (medData->metadata(medMetaDataKeys::SeriesDescription.key()).isEmpty())
+        {
+            QFileInfo file(path);
+            medData->setMetaData(medMetaDataKeys::SeriesDescription.key(), file.baseName());
+        }
+
+        setProgress(100);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+bool vtkDataMeshReader::extractMetaData(QString path, vtkMetaDataSet* dataSet)
+{
+    if (extractMetaDataFromFieldData(dataSet) || extractMetaDataFromHeader(path, dataSet) || extractCartoMetaData(dataSet))
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+// A previous version of vtkDataMeshWriter stored metadata in the header
+bool vtkDataMeshReader::extractMetaDataFromHeader(QString path, vtkMetaDataSet* dataSet)
+{
+    QString header;
+    vtkSmartPointer<vtkPolyDataReader> reader = vtkPolyDataReader::New();
+    reader->SetFileName(path.toLocal8Bit().constData());
+    reader->Update();
+    header = reader->GetHeader();
+    QStringList headerElements = header.split("\t");
+
+    for (int i = 0; i < headerElements.count() - 1; i += 2)
+    {
+        data()->setMetaData(headerElements.at(i), headerElements.at(i + 1));
     }
 
-    setProgress(100);
-    return true;
+    return headerElements.count() >= 2;
 }
 
-bool vtkDataMeshReader::read(const QStringList& paths) {
-    if (paths.empty())
+// For CARTO files the patient name and ID is stored in the header and retrieved by vtkMetaSurfaceMesh::ReadVtkFile
+bool vtkDataMeshReader::extractCartoMetaData(vtkMetaDataSet* dataSet)
+{
+    std::string patientName, patientID;
+
+    if (dataSet->GetMetaData("PatientName", patientName) && dataSet->GetMetaData("PatientID", patientID))
+    {
+        data()->setMetaData(medMetaDataKeys::PatientName.key(), QString::fromStdString(patientName));
+        data()->setMetaData(medMetaDataKeys::PatientID.key(), QString::fromStdString(patientID));
+        return true;
+    }
+    else
+    {
         return false;
-    return read(paths.first().toLocal8Bit().constData());
+    }
 }
 
-void vtkDataMeshReader::setProgress(int value) {
-    emit progressed(value);
-}
-
-bool vtkDataMeshReader::registered() {
+bool vtkDataMeshReader::registered()
+{
     return medAbstractDataFactory::instance()->registerDataReaderType(ID,
                                     vtkDataMeshReader::s_handled(),
                                     createVtkDataMeshReader);
 }
 
-QString vtkDataMeshReader::identifier() const {
+QString vtkDataMeshReader::identifier() const
+{
     return ID;
 }
 
-QString vtkDataMeshReader::description() const {
+QString vtkDataMeshReader::description() const
+{
     return "Reader for vtk meshes";
 }
 
@@ -132,7 +188,8 @@ QString vtkDataMeshReader::description() const {
 // Type instantiation
 // /////////////////////////////////////////////////////////////////
 
-dtkAbstractDataReader *createVtkDataMeshReader() {
+dtkAbstractDataReader *createVtkDataMeshReader()
+{
     return new vtkDataMeshReader;
 }
 

--- a/src/plugins/legacy/vtkDataMesh/readers/vtkDataMeshReader.cpp
+++ b/src/plugins/legacy/vtkDataMesh/readers/vtkDataMeshReader.cpp
@@ -59,7 +59,7 @@ bool vtkDataMeshReader::read(const QString& path)
     readInformation(path);
     setProgress(50);
 
-    qDebug() << "Can read with: " << this->identifier();
+    qDebug().noquote() << "Can read with: " << this->identifier();
 
     if (medAbstractData * medData = dynamic_cast<medAbstractData*>(data()))
     {

--- a/src/plugins/legacy/vtkDataMesh/readers/vtkDataMeshReader.cpp
+++ b/src/plugins/legacy/vtkDataMesh/readers/vtkDataMeshReader.cpp
@@ -2,9 +2,9 @@
 
  medInria
 
- Copyright (c) INRIA 2013 - 2018. All rights reserved.
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.

--- a/src/plugins/legacy/vtkDataMesh/readers/vtkDataMeshReader.h
+++ b/src/plugins/legacy/vtkDataMesh/readers/vtkDataMeshReader.h
@@ -14,17 +14,16 @@
 #pragma once
 
 #include "vtkDataMeshPluginExport.h"
+#include "vtkDataMeshReaderBase.h"
 
-#include <dtkCoreSupport/dtkAbstractDataReader.h>
+class vtkMetaDataSet;
 
-class vtkDataSetReader;
-
-class VTKDATAMESHPLUGIN_EXPORT vtkDataMeshReader: public dtkAbstractDataReader {
+class VTKDATAMESHPLUGIN_EXPORT vtkDataMeshReader: public vtkDataMeshReaderBase
+{
     Q_OBJECT
 
 public:
     vtkDataMeshReader();
-    virtual ~vtkDataMeshReader();
 
     virtual QStringList handled() const;
 
@@ -33,28 +32,20 @@ public:
 public slots:
 
     virtual bool canRead(const QString& path);
-    virtual bool canRead(const QStringList& paths);
-
     virtual bool readInformation(const QString& path);
-    virtual bool readInformation(const QStringList& paths);
-
     virtual bool read(const QString& path);
-    virtual bool read(const QStringList& paths);
-
-    virtual void setProgress(int value);
 
     virtual QString identifier()  const;
     virtual QString description() const;
 
-    static bool registered();	
+    static bool registered();
 
 private:
 
     static const char ID[];
+    bool extractMetaData(QString path, vtkMetaDataSet* dataSet);
+    bool extractMetaDataFromHeader(QString path, vtkMetaDataSet* dataSet);
+    bool extractCartoMetaData(vtkMetaDataSet* dataSet);
 };
 
-
 dtkAbstractDataReader *createVtkDataMeshReader();
-
-
-

--- a/src/plugins/legacy/vtkDataMesh/readers/vtkDataMeshReader.h
+++ b/src/plugins/legacy/vtkDataMesh/readers/vtkDataMeshReader.h
@@ -2,9 +2,9 @@
 
  medInria
 
- Copyright (c) INRIA 2013 - 2018. All rights reserved.
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
  See LICENSE.txt for details.
- 
+
   This software is distributed WITHOUT ANY WARRANTY; without even
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE.

--- a/src/plugins/legacy/vtkDataMesh/readers/vtkDataMeshReaderBase.cpp
+++ b/src/plugins/legacy/vtkDataMesh/readers/vtkDataMeshReaderBase.cpp
@@ -1,3 +1,16 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
 #include "vtkDataMeshReaderBase.h"
 #include "vtkDataMeshWriterBase.h"
 

--- a/src/plugins/legacy/vtkDataMesh/readers/vtkDataMeshReaderBase.cpp
+++ b/src/plugins/legacy/vtkDataMesh/readers/vtkDataMeshReaderBase.cpp
@@ -1,0 +1,77 @@
+#include "vtkDataMeshReaderBase.h"
+#include "vtkDataMeshWriterBase.h"
+
+#include <dtkCoreSupport/dtkAbstractData>
+
+#include <vtkFieldData.h>
+#include <vtkMetaDataSet.h>
+#include <vtkStringArray.h>
+#include <vtkSmartPointer.h>
+
+vtkDataMeshReaderBase::vtkDataMeshReaderBase() : dtkAbstractDataReader()
+{
+}
+
+bool vtkDataMeshReaderBase::canRead(const QStringList& paths)
+{
+    if (paths.empty())
+    {
+        return false;
+    }
+    return canRead(paths.first().toLocal8Bit().constData());
+}
+
+bool vtkDataMeshReaderBase::readInformation(const QStringList& paths)
+{
+    if (paths.empty())
+    {
+        return false;
+    }
+    return readInformation(paths.first().toLocal8Bit().constData());
+}
+
+bool vtkDataMeshReaderBase::read(const QStringList& paths)
+{
+    if (paths.empty())
+    {
+        return false;
+    }
+    return read(paths.first().toLocal8Bit().constData());
+}
+
+bool vtkDataMeshReaderBase::extractMetaDataFromFieldData(vtkMetaDataSet* dataSet)
+{
+    bool foundMetaData = false;
+    vtkFieldData* fieldData = dataSet->GetDataSet()->GetFieldData();
+    vtkSmartPointer<vtkFieldData> newFieldData = vtkSmartPointer<vtkFieldData>::New();
+
+    for (int i = 0; i < fieldData->GetNumberOfArrays(); i++)
+    {
+        QString arrayName = fieldData->GetArrayName(i);
+
+        if (arrayName.startsWith(vtkDataMeshWriterBase::metaDataFieldPrefix))
+        {
+            foundMetaData = true;
+            vtkStringArray* array = static_cast<vtkStringArray*>(fieldData->GetAbstractArray(i));
+            QString metaDataKey = arrayName.remove(0, vtkDataMeshWriterBase::metaDataFieldPrefix.length());
+
+            for (int j = 0; j < array->GetSize(); j++)
+            {
+                data()->addMetaData(metaDataKey, QString(array->GetValue(j)));
+            }
+        }
+        else
+        {
+            newFieldData->AddArray(fieldData->GetAbstractArray(i));
+        }
+    }
+
+    dataSet->GetDataSet()->SetFieldData(newFieldData);
+
+    return foundMetaData;
+}
+
+void vtkDataMeshReaderBase::setProgress(int value)
+{
+    emit progressed(value);
+}

--- a/src/plugins/legacy/vtkDataMesh/readers/vtkDataMeshReaderBase.h
+++ b/src/plugins/legacy/vtkDataMesh/readers/vtkDataMeshReaderBase.h
@@ -1,3 +1,15 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
 #pragma once
 
 #include "vtkDataMeshPluginExport.h"

--- a/src/plugins/legacy/vtkDataMesh/readers/vtkDataMeshReaderBase.h
+++ b/src/plugins/legacy/vtkDataMesh/readers/vtkDataMeshReaderBase.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "vtkDataMeshPluginExport.h"
+
+#include <dtkCoreSupport/dtkAbstractDataReader.h>
+
+class vtkMetaDataSet;
+
+class VTKDATAMESHPLUGIN_EXPORT vtkDataMeshReaderBase: public dtkAbstractDataReader
+{
+    Q_OBJECT
+
+public:
+    vtkDataMeshReaderBase();
+
+public slots:
+
+    virtual bool canRead        (const QStringList& paths);
+    virtual bool readInformation(const QStringList& paths);
+    virtual bool read           (const QStringList& paths);
+
+    virtual void setProgress(int value);
+
+    bool extractMetaDataFromFieldData(vtkMetaDataSet* dataSet);
+
+    // Functions needed to be declared in child classes
+    virtual bool canRead        (const QString& path){return false;}
+    virtual bool readInformation(const QString& path){return false;}
+    virtual bool read           (const QString& path){return false;}
+};

--- a/src/plugins/legacy/vtkDataMesh/writers/vtkDataMesh4DWriter.cpp
+++ b/src/plugins/legacy/vtkDataMesh/writers/vtkDataMesh4DWriter.cpp
@@ -2,7 +2,7 @@
 
  medInria
 
- Copyright (c) INRIA 2013 - 2018. All rights reserved.
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
  See LICENSE.txt for details.
  
   This software is distributed WITHOUT ANY WARRANTY; without even

--- a/src/plugins/legacy/vtkDataMesh/writers/vtkDataMesh4DWriter.cpp
+++ b/src/plugins/legacy/vtkDataMesh/writers/vtkDataMesh4DWriter.cpp
@@ -24,12 +24,12 @@ const char vtkDataMesh4DWriter::ID[] = "vtkDataMesh4DWriter";
 
 vtkDataMesh4DWriter::vtkDataMesh4DWriter() : vtkDataMeshWriterBase()
 {
-  this->writer = vtkDataManagerWriter::New();
+    this->writer = vtkDataManagerWriter::New();
 }
 
 vtkDataMesh4DWriter::~vtkDataMesh4DWriter()
 {
-  this->writer->Delete();
+    this->writer->Delete();
 }
 
 QStringList vtkDataMesh4DWriter::handled() const
@@ -60,7 +60,9 @@ bool vtkDataMesh4DWriter::write(const QString& path)
 
     vtkMetaDataSetSequence* sequence = dynamic_cast< vtkMetaDataSetSequence* >( (vtkObject*)(this->data()->output()));
     if (!sequence)
+    {
         return false;
+    }
 
     foreach (vtkMetaDataSet* dataSet, sequence->GetMetaDataSetList())
     {
@@ -87,7 +89,7 @@ bool vtkDataMesh4DWriter::write(const QString& path)
 
 QString vtkDataMesh4DWriter::description() const
 {
-    return tr( "VTK 4D Mesh Writer" );
+    return tr( "VTK with metadata 4D Mesh Writer" );
 }
 
 QString vtkDataMesh4DWriter::identifier() const
@@ -111,7 +113,5 @@ QStringList vtkDataMesh4DWriter::supportedFileExtensions() const
 
 dtkAbstractDataWriter *createVtkDataMesh4DWriter()
 {
-  return new vtkDataMesh4DWriter;
+    return new vtkDataMesh4DWriter;
 }
-
-

--- a/src/plugins/legacy/vtkDataMesh/writers/vtkDataMesh4DWriter.h
+++ b/src/plugins/legacy/vtkDataMesh/writers/vtkDataMesh4DWriter.h
@@ -2,7 +2,7 @@
 
  medInria
 
- Copyright (c) INRIA 2013 - 2018. All rights reserved.
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
  See LICENSE.txt for details.
  
   This software is distributed WITHOUT ANY WARRANTY; without even

--- a/src/plugins/legacy/vtkDataMesh/writers/vtkDataMesh4DWriter.h
+++ b/src/plugins/legacy/vtkDataMesh/writers/vtkDataMesh4DWriter.h
@@ -14,8 +14,7 @@
 #pragma once
 
 #include "vtkDataMeshPluginExport.h"
-
-#include <dtkCoreSupport/dtkAbstractDataWriter.h>
+#include "vtkDataMeshWriterBase.h"
 
 class vtkDataManagerWriter;
 
@@ -38,12 +37,12 @@ class vtkDataManagerWriter;
 */
 
 
-class VTKDATAMESHPLUGIN_EXPORT vtkDataMesh4DWriter : public dtkAbstractDataWriter
+class VTKDATAMESHPLUGIN_EXPORT vtkDataMesh4DWriter : public vtkDataMeshWriterBase
 {
     Q_OBJECT
 
 public:
-             vtkDataMesh4DWriter();
+    vtkDataMesh4DWriter();
     virtual ~vtkDataMesh4DWriter();
 
     virtual QStringList handled() const;
@@ -59,13 +58,12 @@ public:
 
 public slots:
     bool write    (const QString& path);
-    bool canWrite (const QString& path);
 
  protected:
     vtkDataManagerWriter* writer;
 
 private:
-        static const char ID[];
+    static const char ID[];
 };
 
 

--- a/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriter.cpp
+++ b/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriter.cpp
@@ -2,7 +2,7 @@
 
  medInria
 
- Copyright (c) INRIA 2013 - 2018. All rights reserved.
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
  See LICENSE.txt for details.
  
   This software is distributed WITHOUT ANY WARRANTY; without even

--- a/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriter.cpp
+++ b/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriter.cpp
@@ -11,22 +11,14 @@
 
 =========================================================================*/
 
-#include <vtkDataMeshWriter.h>
+#include "vtkDataMeshWriter.h"
 
-#include <medAbstractDataFactory.h>
 #include <medAbstractData.h>
-#include <dtkLog/dtkLog.h>
-
-#include <vtkMetaDataSet.h>
-
+#include <medAbstractDataFactory.h>
 
 const char vtkDataMeshWriter::ID[] = "vtkDataMeshWriter";
 
-vtkDataMeshWriter::vtkDataMeshWriter()
-{
-}
-
-vtkDataMeshWriter::~vtkDataMeshWriter()
+vtkDataMeshWriter::vtkDataMeshWriter() : vtkDataMeshWriterBase()
 {
 }
 
@@ -40,35 +32,45 @@ QStringList vtkDataMeshWriter::s_handled()
     return QStringList() << "vtkDataMesh";
 }
 
-bool vtkDataMeshWriter::canWrite(const QString& /*path*/)
-{
-    if ( ! this->data())
-        return false;
-
-    return dynamic_cast<vtkMetaDataSet*>((vtkObject*)(this->data()->data()));
-}
-
 bool vtkDataMeshWriter::write(const QString& path)
 {
-  if (!this->data())
-    return false;
+    if (!this->data())
+    {
+        return false;
+    }
 
-  dtkDebug() << "Can write with: " << this->identifier();
+    qDebug() << "Can write with: " << this->identifier();
 
-  medAbstractData * medData = dynamic_cast<medAbstractData*>(this->data());
+    medAbstractData * medData = dynamic_cast<medAbstractData*>(this->data());
 
-  if(medData->identifier() != "vtkDataMesh")
-  {
-    return false;
-  }
+    if(medData->identifier() != "vtkDataMesh")
+    {
+        return false;
+    }
 
-  vtkMetaDataSet * mesh = dynamic_cast< vtkMetaDataSet*>( (vtkObject*)(this->data()->data()));
-  if (!mesh)
-    return false;
+    vtkMetaDataSet * mesh = dynamic_cast< vtkMetaDataSet*>( (vtkObject*)(this->data()->data()));
+    if (!mesh)
+    {
+        return false;
+    }
+    addMetaDataAsFieldData(mesh);
 
-  mesh->Write(path.toLocal8Bit().constData());
+    try
+    {
+        setlocale(LC_NUMERIC, "C");
+        QLocale::setDefault(QLocale("C"));
 
-  return true;
+        mesh->Write(path.toLocal8Bit().constData());
+        clearMetaDataFieldData(mesh);
+    }
+    catch (...)
+    {
+        qDebug() << metaObject()->className() << ": error writing to " << path;
+        clearMetaDataFieldData(mesh);
+        return false;
+    }
+
+    return true;
 }
 
 QString vtkDataMeshWriter::description() const

--- a/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriter.cpp
+++ b/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriter.cpp
@@ -75,7 +75,7 @@ bool vtkDataMeshWriter::write(const QString& path)
 
 QString vtkDataMeshWriter::description() const
 {
-    return tr( "VTK Mesh Writer" );
+    return tr( "VTK with metadata Mesh Writer" );
 }
 
 QString vtkDataMeshWriter::identifier() const

--- a/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriter.h
+++ b/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriter.h
@@ -2,7 +2,7 @@
 
  medInria
 
- Copyright (c) INRIA 2013 - 2018. All rights reserved.
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
  See LICENSE.txt for details.
  
   This software is distributed WITHOUT ANY WARRANTY; without even

--- a/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriter.h
+++ b/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriter.h
@@ -14,18 +14,16 @@
 #pragma once
 
 #include "vtkDataMeshPluginExport.h"
-
-#include <dtkCoreSupport/dtkAbstractDataWriter.h>
+#include "vtkDataMeshWriterBase.h"
 
 class vtkDataSetWriter;
 
-class VTKDATAMESHPLUGIN_EXPORT vtkDataMeshWriter : public dtkAbstractDataWriter
+class VTKDATAMESHPLUGIN_EXPORT vtkDataMeshWriter : public vtkDataMeshWriterBase
 {
     Q_OBJECT
 
 public:
-             vtkDataMeshWriter();
-    virtual ~vtkDataMeshWriter();
+    vtkDataMeshWriter();
 
     virtual QStringList handled() const;
     static  QStringList s_handled();
@@ -40,7 +38,6 @@ public:
 
 public slots:
     bool write    (const QString& path);
-    bool canWrite (const QString& path);
 
 private:
     static const char ID[];

--- a/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriterBase.cpp
+++ b/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriterBase.cpp
@@ -1,3 +1,15 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
 #include "vtkDataMeshWriterBase.h"
 
 #include <dtkCoreSupport/dtkAbstractData>

--- a/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriterBase.cpp
+++ b/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriterBase.cpp
@@ -1,0 +1,57 @@
+#include "vtkDataMeshWriterBase.h"
+
+#include <dtkCoreSupport/dtkAbstractData>
+
+#include <vtkFieldData.h>
+#include <vtkSmartPointer.h>
+#include <vtkStringArray.h>
+
+const QString vtkDataMeshWriterBase::metaDataFieldPrefix = "medMetaData::";
+
+vtkDataMeshWriterBase::vtkDataMeshWriterBase() : dtkAbstractDataWriter()
+{
+}
+
+bool vtkDataMeshWriterBase::canWrite(const QString& /*path*/)
+{
+    if (!this->data())
+    {
+        return false;
+    }
+    return dynamic_cast<vtkMetaDataSet*>((vtkObject*)(this->data()->data()));
+}
+
+void vtkDataMeshWriterBase::addMetaDataAsFieldData(vtkMetaDataSet* dataSet)
+{
+    foreach (QString key, data()->metaDataList())
+    {
+        vtkSmartPointer<vtkStringArray> metaDataArray = vtkSmartPointer<vtkStringArray>::New();
+        QString arrayName = QString(metaDataFieldPrefix) + key;
+        metaDataArray->SetName(arrayName.toStdString().c_str());
+
+        foreach (QString value, data()->metaDataValues(key))
+        {
+            metaDataArray->InsertNextValue(value.toStdString().c_str());
+        }
+
+        dataSet->GetDataSet()->GetFieldData()->AddArray(metaDataArray);
+    }
+}
+
+void vtkDataMeshWriterBase::clearMetaDataFieldData(vtkMetaDataSet* dataSet)
+{
+    vtkFieldData* fieldData = dataSet->GetDataSet()->GetFieldData();
+    vtkSmartPointer<vtkFieldData> newFieldData = vtkSmartPointer<vtkFieldData>::New();
+
+    for (int i = 0; i < fieldData->GetNumberOfArrays(); i++)
+    {
+        QString arrayName = fieldData->GetArrayName(i);
+
+        if (!arrayName.startsWith(metaDataFieldPrefix))
+        {
+            newFieldData->AddArray(fieldData->GetAbstractArray(i));
+        }
+    }
+
+    dataSet->GetDataSet()->SetFieldData(newFieldData);
+}

--- a/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriterBase.h
+++ b/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriterBase.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "vtkDataMeshPluginExport.h"
+
+#include <dtkCoreSupport/dtkAbstractDataWriter.h>
+#include <vtkMetaDataSet.h>
+
+class VTKDATAMESHPLUGIN_EXPORT vtkDataMeshWriterBase : public dtkAbstractDataWriter
+{
+    Q_OBJECT
+
+public:
+    static const QString metaDataFieldPrefix;
+
+    vtkDataMeshWriterBase();
+
+public slots:
+    bool canWrite (const QString& path);
+
+    void addMetaDataAsFieldData(vtkMetaDataSet* dataSet);
+    void clearMetaDataFieldData(vtkMetaDataSet* dataSet);
+};

--- a/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriterBase.h
+++ b/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriterBase.h
@@ -1,3 +1,15 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2019. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
 #pragma once
 
 #include "vtkDataMeshPluginExport.h"


### PR DESCRIPTION
From a bug found by @mjuhoor  and @paulineMig, metadata were shown in attributes of a vtk in the Settings.

This PR allows to add metadata in a VTK file.

:m: