### PR TITLE
Remove generic field data from VTK attributes combo

### DIFF
--- a/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
+++ b/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
@@ -205,9 +205,6 @@ void vtkDataMeshInteractor::setupParameters()
         for (int i = 0;  i < d->metaDataSet->GetDataSet()->GetCellData()->GetNumberOfArrays(); i++)
             nameList << QString::fromUtf8(d->metaDataSet->GetDataSet()->GetCellData()->GetArrayName(i));
 
-        for (int i = 0;  i < d->metaDataSet->GetDataSet()->GetFieldData()->GetNumberOfArrays(); i++)
-            nameList << QString::fromUtf8(d->metaDataSet->GetDataSet()->GetFieldData()->GetArrayName(i));
-
         foreach(QString name, nameList)
             d->attributesParam->addItem(name);
 


### PR DESCRIPTION
Fixes the bug discussed in https://github.com/medInria/medInria-public/pull/522

Only point and cell data should be displayed in the VTK attributes combobox. This fix allows us to load images generated by MUSIC 2 without metadata tags being displayed in the attributes list.

_Note that cell data is not actually handled, only point data (see link below) but that is a separate issue:
https://github.com/medInria/medInria-public/blob/master/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp#L397_