### PR TITLE
Boutiques

### DIFF
--- a/src/plugins/legacy/medBoutiques/boutiquesGUI/medBoutiquesAbstractFileHandler.cpp
+++ b/src/plugins/legacy/medBoutiques/boutiquesGUI/medBoutiquesAbstractFileHandler.cpp
@@ -3,21 +3,12 @@
 #include <QJsonArray>
 #include <QJsonValue>
 
-FormatAndExtension::FormatAndExtension(const QJsonArray &typeAndExtension) {
+FormatAndExtension::FormatAndExtension(const QJsonArray &typeAndExtension)
+{
     if(typeAndExtension.size() < 2)
     {
         return;
     }
     this->type = typeAndExtension[0].toString();
     this->extension = typeAndExtension[1].toString();
-}
-
-medBoutiquesAbstractFileHandler::medBoutiquesAbstractFileHandler():QObject()
-{
-
-}
-
-medBoutiquesAbstractFileHandler::~medBoutiquesAbstractFileHandler()
-{
-
 }

--- a/src/plugins/legacy/medBoutiques/boutiquesGUI/medBoutiquesAbstractFileHandler.h
+++ b/src/plugins/legacy/medBoutiques/boutiquesGUI/medBoutiquesAbstractFileHandler.h
@@ -34,8 +34,8 @@ class medBoutiquesAbstractFileHandler : public QObject
     Q_OBJECT
 
 public:
-    medBoutiquesAbstractFileHandler();
-    virtual ~medBoutiquesAbstractFileHandler();
+    medBoutiquesAbstractFileHandler() = default;
+    virtual ~medBoutiquesAbstractFileHandler() = default;
 
     virtual void checkAcceptDragEvent(QDragEnterEvent *event) = 0;
     virtual QString createTemporaryInputFileForMimeData(const QMimeData *mimeData) = 0;

--- a/src/plugins/legacy/medBoutiques/boutiquesGUI/medBoutiquesConfiguration.h
+++ b/src/plugins/legacy/medBoutiques/boutiquesGUI/medBoutiquesConfiguration.h
@@ -30,11 +30,13 @@
 
 class BoutiquesPaths {
 public:
-    static QString Boutiques() {
+    static QString Boutiques()
+    {
         return QDir(QCoreApplication::applicationDirPath() + BOUTIQUES_DIRECTORY).absolutePath();
     }
 
-    static QDir BoutiquesTemp() {
+    static QDir BoutiquesTemp()
+    {
         QDir temporaryDirectory(QCoreApplication::applicationDirPath() + BOUTIQUES_DIRECTORY + BOUTIQUES_TEMPORARY_DIR);
         if (!temporaryDirectory.exists()){
           temporaryDirectory.mkpath(".");
@@ -42,24 +44,31 @@ public:
         return temporaryDirectory;
     }
 
-    static QString Settings() {
+    static QString Settings()
+    {
         return QFileInfo(QCoreApplication::applicationDirPath() + BOUTIQUES_DIRECTORY + BOUTIQUES_GUI_SETTINGS_PATH).absoluteFilePath();
     }
 
-    static QString Python() {
+    static QString Python()
+    {
 #ifndef Q_OS_WIN
         return PYTHON_PATH;
 #else
         return "\"" + QFileInfo(QCoreApplication::applicationDirPath() + BOUTIQUES_DIRECTORY + PYTHON_PATH).absoluteFilePath() + "\"";
 #endif
     }
-    static QString Bosh() {
+    static QString Bosh()
+    {
         return QFileInfo(QCoreApplication::applicationDirPath() + BOUTIQUES_DIRECTORY + BOSH_PATH).absoluteFilePath();
     }
-    static QString Docker() {
+
+    static QString Docker()
+    {
         return DOCKER_PATH;
     }
-    static QString VCRedis() {
+
+    static QString VCRedis()
+    {
         return QFileInfo(QCoreApplication::applicationDirPath() + BOUTIQUES_DIRECTORY + VCREDIS_PATH).absoluteFilePath();
     }
 };

--- a/src/plugins/legacy/medBoutiques/boutiquesGUI/medBoutiquesFileHandler.cpp
+++ b/src/plugins/legacy/medBoutiques/boutiquesGUI/medBoutiquesFileHandler.cpp
@@ -84,7 +84,8 @@ QList<FormatObject> medBoutiquesFileHandler::getFileFormatsForData(medAbstractDa
     }
 
     // Warn user if no compatible writer, and return an empty list
-    if (possibleWriters.isEmpty()) {
+    if (possibleWriters.isEmpty())
+    {
         medMessageController::instance()->showError("Sorry, we have no exporter for this format.");
         return fileFormats;
     }
@@ -161,6 +162,7 @@ QString medBoutiquesFileHandler::createTemporaryInputFileForMimeData(const QMime
     if (index.isValidForSeries())
     {
         medAbstractData *data = medDataManager::instance()->retrieveData(index);
+
         const FormatAndExtension &formatAndExtension = this->getFormatAndExtensionForData(data);
         return this->createTemporaryInputFile(data, formatAndExtension.type, formatAndExtension.extension);
     }
@@ -174,6 +176,10 @@ QString medBoutiquesFileHandler::createTemporaryInputFileForCurrentInput()
     return this->createTemporaryInputFile(nullptr, "Type 1", ".ext1");
 #else
     medAbstractData *data = toolbox->getInput();
+    if(data == nullptr) {
+        QMessageBox::warning(nullptr, "No input selected", "There is no file opened as input filter. Select an input file for the filter (on the left panel), it will then be usable as an input for the Boutiques tool.");
+        return "";
+    }
     const FormatAndExtension &formatAndExtension = this->getFormatAndExtensionForData(data);
     return this->createTemporaryInputFile(data, formatAndExtension.type, formatAndExtension.extension);
 #endif
@@ -329,7 +335,8 @@ QString medBoutiquesFileHandler::createTemporaryInputFile(medAbstractData *data,
 {
     Q_UNUSED(data)
     QTemporaryFile file(BoutiquesPaths::BoutiquesTemp().absoluteFilePath("XXXXXX_" + chosenType + chosenExtension));
-    if (!chosenType.isEmpty() && file.open()) {
+    if (!chosenType.isEmpty() && file.open())
+    {
         temporaryFiles.push_back(QDir::temp().absoluteFilePath(file.fileName()));
         QString absoluteFilePath = QFileInfo(file).absoluteFilePath();
 #ifndef BOUTIQUE_GUI_STANDALONE

--- a/src/plugins/legacy/medBoutiques/boutiquesGUI/medBoutiquesInstaller.cpp
+++ b/src/plugins/legacy/medBoutiques/boutiquesGUI/medBoutiquesInstaller.cpp
@@ -11,7 +11,9 @@ void medBoutiquesInstaller::checkBoutiquesInstallation(QWidget *parent)
         // If can't open the settings: install boutiques
         file.close();
         medBoutiquesInstaller::installBoutiques(parent);
-    } else {
+    }
+    else
+    {
         QJsonDocument jsonDocument(QJsonDocument::fromJson(file.readAll()));
         QJsonObject settings = jsonDocument.object();
 
@@ -74,7 +76,8 @@ void medBoutiquesInstaller::installBoutiques(QWidget *parent, QJsonObject *setti
 {
     bool pythonAndDockerAreWorking = true;
 
-    if (QSysInfo::productType() == "winrt" || QSysInfo::productType() == "windows") {
+    if (QSysInfo::productType() == "winrt" || QSysInfo::productType() == "windows")
+    {
 
         // On Windows:
 
@@ -100,7 +103,9 @@ void medBoutiquesInstaller::installBoutiques(QWidget *parent, QJsonObject *setti
             }
         }
 
-    } else {
+    }
+    else
+    {
         // On Linux:
 
         if(!medBoutiquesInstaller::isPythonWorking(parent))

--- a/src/plugins/legacy/medBoutiques/boutiquesGUI/medBoutiquesInvocationGUIWidget.cpp
+++ b/src/plugins/legacy/medBoutiques/boutiquesGUI/medBoutiquesInvocationGUIWidget.cpp
@@ -361,7 +361,8 @@ void medBoutiquesInvocationGUIWidget::parseDescriptor(QJsonObject *invocationJSO
             InputObject &inputObject = it->second;
             inputObject.group = &groupObject;
             const QJsonValue &isOptional = inputObject.description["optional"];
-            if(isOptional.isNull() || (isOptional.isBool() && !isOptional.toBool()) ) {
+            if(isOptional.isNull() || (isOptional.isBool() && !isOptional.toBool()) )
+            {
                 groupIsOptional = false;
             }
         }
@@ -583,11 +584,13 @@ void medBoutiquesInvocationGUIWidget::parseDescriptor(QJsonObject *invocationJSO
                     {
                         // Set the minimum and maximum, set value and connect to valueChanged signal
                         QSpinBox *spinBox = new QSpinBox();
-                        if(inputObject.description["minimum"].isDouble()) {
+                        if(inputObject.description["minimum"].isDouble())
+                        {
                             int exclusiveOffset = inputObject.description["exclusive-minimum"].toBool() ? 1 : 0;
                             spinBox->setMinimum(inputObject.description["minimum"].toInt() + exclusiveOffset);
                         }
-                        if(inputObject.description["maximum"].isDouble()) {
+                        if(inputObject.description["maximum"].isDouble())
+                        {
                             int exclusiveOffset = inputObject.description["exclusive-maximum"].toBool() ? 1 : 0;
                             spinBox->setMaximum(inputObject.description["maximum"].toInt() - exclusiveOffset);
                         }
@@ -600,11 +603,13 @@ void medBoutiquesInvocationGUIWidget::parseDescriptor(QJsonObject *invocationJSO
                     {
                         // Set the minimum and maximum, set value and connect to valueChanged signal
                         QDoubleSpinBox *spinBox = new QDoubleSpinBox();
-                        if(inputObject.description["minimum"].isDouble()) {
+                        if(inputObject.description["minimum"].isDouble())
+                        {
                             double exclusiveOffset = inputObject.description["exclusive-minimum"].toBool() ? 0.0001 : 0.0;
                             spinBox->setMinimum(inputObject.description["minimum"].toDouble() + exclusiveOffset);
                         }
-                        if(inputObject.description["maximum"].isDouble()) {
+                        if(inputObject.description["maximum"].isDouble())
+                        {
                             double exclusiveOffset = inputObject.description["exclusive-maximum"].toBool() ? 0.0001 : 0.0;
                             spinBox->setMaximum(inputObject.description["maximum"].toDouble() - exclusiveOffset);
                         }

--- a/src/plugins/legacy/medBoutiques/boutiquesGUI/medBoutiquesSearchToolsWidget.cpp
+++ b/src/plugins/legacy/medBoutiques/boutiquesGUI/medBoutiquesSearchToolsWidget.cpp
@@ -194,7 +194,8 @@ void medBoutiquesSearchToolsWidget::selectionChanged()
 {
     // Display a short description when a tool is selected
     ToolDescription *tool = this->getSelectedTool();
-    if(tool == nullptr) {
+    if(tool == nullptr)
+    {
         return;
     }
     const QJsonObject &jsonObject = this->getToolDescriptor(tool->id);
@@ -280,7 +281,8 @@ void medBoutiquesSearchToolsWidget::prettyPrint()
 {
     // Pretty print the tool help when a tool is selected
     ToolDescription *tool = this->getSelectedTool();
-    if(tool == nullptr) {
+    if(tool == nullptr)
+    {
         return;
     }
 

--- a/src/plugins/legacy/medBoutiques/medBoutiques.cpp
+++ b/src/plugins/legacy/medBoutiques/medBoutiques.cpp
@@ -24,14 +24,6 @@
 // medBoutiques
 // /////////////////////////////////////////////////////////////////
 
-medBoutiques::medBoutiques() : dtkAbstractProcess()
-{
-}
-
-medBoutiques::~medBoutiques()
-{
-}
-
 bool medBoutiques::registered()
 {
     return dtkAbstractProcessFactory::instance()->registerProcessType("medBoutiques", createmedBoutiques);

--- a/src/plugins/legacy/medBoutiques/medBoutiques.h
+++ b/src/plugins/legacy/medBoutiques/medBoutiques.h
@@ -25,8 +25,8 @@ class MEDBOUTIQUESPLUGIN_EXPORT medBoutiques : public dtkAbstractProcess
     Q_OBJECT
 
 public:
-             medBoutiques();
-    virtual ~medBoutiques();
+             medBoutiques() = default;
+    virtual ~medBoutiques() = default;
 
     virtual QString description() const;
 

--- a/src/plugins/legacy/medBoutiques/medBoutiquesPlugin.cpp
+++ b/src/plugins/legacy/medBoutiques/medBoutiquesPlugin.cpp
@@ -46,11 +46,13 @@ medBoutiquesPlugin::~medBoutiquesPlugin()
 
 bool medBoutiquesPlugin::initialize()
 {
-    if(!medBoutiques::registered()) {
+    if(!medBoutiques::registered())
+    {
         dtkWarn() << "Unable to register medBoutiques type";
     }
 
-    if(!medBoutiquesToolBox::registered()) {
+    if(!medBoutiquesToolBox::registered())
+    {
         dtkWarn() << "Unable to register medBoutiques toolbox";
     }
 

--- a/src/plugins/legacy/medBoutiques/medBoutiquesToolBox.cpp
+++ b/src/plugins/legacy/medBoutiques/medBoutiquesToolBox.cpp
@@ -141,7 +141,8 @@ void medBoutiquesToolBox::executionSuccess(const QString &outputFileName)
 
 void medBoutiquesToolBox::open_waitForImportedSignal(medDataIndex index, QUuid uuid)
 {
-    if(d->expectedUuids.contains(uuid)) {
+    if(d->expectedUuids.contains(uuid))
+    {
         d->expectedUuids.removeAll(uuid);
         disconnect(medDataManager::instance(), SIGNAL(dataImported(medDataIndex,QUuid)), this, SLOT(open_waitForImportedSignal(medDataIndex,QUuid)));
         if (index.isValid()) {


### PR DESCRIPTION
 - Fix typos, 
 - Fix output image display bug (the output image was not opened automatically anymore after a boutiques process success), 
 - Warn the user if he sets the filter input as an input for the boutiques process when there is no filter input opened yet.