### PR TITLE
[Deprecated] qSort -> std::sort

### DIFF
--- a/src/layers/legacy/medCoreLegacy/data/annotationData/medImageMaskAnnotationData.cpp
+++ b/src/layers/legacy/medCoreLegacy/data/annotationData/medImageMaskAnnotationData.cpp
@@ -91,5 +91,5 @@ bool operator<( const QColor & lhs, const QColor & rhs ){
 void medImageMaskAnnotationData::setColorMap( const ColorMapType & colorMap )
 {
     m_colorMap = colorMap;
-    qSort( m_colorMap );
+    std::sort(m_colorMap.begin(), m_colorMap.end());
 }

--- a/src/layers/legacy/medCoreLegacy/gui/database/medDatabasePreview.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/database/medDatabasePreview.cpp
@@ -178,15 +178,14 @@ medDatabasePreviewDynamicScene::medDatabasePreviewDynamicScene(const QList<QPair
     d(new medDatabasePreviewDynamicScenePrivate)
 {
     d->seriesDescriptionDataIndexPairList = seriesDescriptionDataIndexList;
-    qSort(d->seriesDescriptionDataIndexPairList.begin(), d->seriesDescriptionDataIndexPairList.end(), &stringMedDataIndexPairLessThan);
+    std::sort(d->seriesDescriptionDataIndexPairList.begin(), d->seriesDescriptionDataIndexPairList.end(), &stringMedDataIndexPairLessThan);
 }
 
 medDatabasePreviewDynamicScene::~medDatabasePreviewDynamicScene()
 {
     delete d;
-    d = NULL;
+    d = nullptr;
 }
-
 
 void medDatabasePreviewDynamicScene::previewMouseMoveEvent(QMouseEvent *event, int width)
 {

--- a/src/layers/legacy/medCoreLegacy/gui/factories/medWorkspaceFactory.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/factories/medWorkspaceFactory.cpp
@@ -106,7 +106,8 @@ QList<medWorkspaceFactory::Details *> medWorkspaceFactory::workspaceDetailsSorte
         filteredDetails = details;
 
     QList<medWorkspaceFactory::Details*> detailsList = filteredDetails.values();
-    qSort(detailsList.begin(),detailsList.end(), wsDetailsSortByName);
+    std::sort(detailsList.begin(),detailsList.end(), wsDetailsSortByName);
+
     return detailsList;
 }
 

--- a/src/layers/legacy/medCoreLegacy/gui/lookUpTables/medClutEditor.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/lookUpTables/medClutEditor.cpp
@@ -556,8 +556,7 @@ void medClutEditorTable::updateVerticesToDisplay()
         d->verticesToDisplay = d->principalVertices;
     }
 
-    qSort( d->verticesToDisplay.begin(), d->verticesToDisplay.end(),
-           medClutEditorVertex::LessThan );
+    std::sort(d->verticesToDisplay.begin(), d->verticesToDisplay.end(), medClutEditorVertex::LessThan);
     this->update();
 }
 
@@ -694,8 +693,7 @@ void medClutEditorTable::addVertex( medClutEditorVertex *vertex, bool interpolat
         vertex->setParentItem( this );
     }
 
-    qSort( d->principalVertices.begin(), d->principalVertices.end(),
-           medClutEditorVertex::LessThan );
+    std::sort(d->principalVertices.begin(), d->principalVertices.end(), medClutEditorVertex::LessThan);
 
     if (interpolate)
     {
@@ -894,8 +892,7 @@ void medClutEditorTable::setTransferFunction( QList<double> &scalars,
         this->addVertex(new medClutEditorVertex( value, coord, colors.at( i ), this ));
     }
 
-    qSort( d->principalVertices.begin(), d->principalVertices.end(),
-           medClutEditorVertex::LessThan );
+    std::sort(d->principalVertices.begin(), d->principalVertices.end(), medClutEditorVertex::LessThan);
 
     scene->adjustRange();
 }

--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medSelectorToolBox.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medSelectorToolBox.cpp
@@ -55,7 +55,7 @@ medSelectorToolBox::medSelectorToolBox(QWidget *parent, QString tlbxId)
 
     // Sort toolboxes names alphabetically
     QList<QString> names = toolboxDataHash.keys();
-    qSort(names.begin(), names.end());
+    std::sort(names.begin(), names.end());
 
     int i = 1; // toolboxes positions
     foreach( QString name, names )

--- a/src/layers/legacy/medTest/medQtDataImageWriter.cpp
+++ b/src/layers/legacy/medTest/medQtDataImageWriter.cpp
@@ -83,9 +83,10 @@ QStringList medQtDataImageWriter::supportedFileExtensions() const
         sortedFormats.push_back(it);
     }
     CompareReversePriority compareReversePriority;
-    qSort( sortedFormats.begin(), sortedFormats.end(), compareReversePriority );
+    std::sort(sortedFormats.begin(), sortedFormats.end(), compareReversePriority);
 
-    foreach( FormatInfoList::const_iterator it, sortedFormats ) {
+    foreach( FormatInfoList::const_iterator it, sortedFormats )
+    {
         extensions << ( "." + it->fileExtension );
     }
     return extensions;

--- a/src/plugins/legacy/medVtkFibersData/interactors/medVtkFibersDataInteractor.cpp
+++ b/src/plugins/legacy/medVtkFibersData/interactors/medVtkFibersDataInteractor.cpp
@@ -196,11 +196,10 @@ void medVtkFibersDataInteractorPrivate::setROI (medAbstractData *data)
 
     roiManager->SetInput (converter->GetOutput());
     roiManager->SetDirectionMatrix (matrix2);
-
-    // manager->GetROILimiter()->Update();
     roiManager->GenerateData();
 
-    qSort(labels);
+    std::sort(labels.begin(), labels.end());
+
     roiLabels.clear();
 
     if (roiComboBox)

--- a/src/plugins/legacy/polygonRoi/medRoiManager.cpp
+++ b/src/plugins/legacy/polygonRoi/medRoiManager.cpp
@@ -120,7 +120,8 @@ void medRoiManager::sortListOfRois(QString seriesName)
                 break;
             }
         }
-        qSort(listOfRois->begin(), listOfRois->end(), sliceIndexLessThan);
+
+        std::sort(listOfRois->begin(), listOfRois->end(), sliceIndexLessThan);
     }
 }
 

--- a/src/plugins/legacy/polygonRoi/vtkInriaInteractorStylePolygonRepulsor.cxx
+++ b/src/plugins/legacy/polygonRoi/vtkInriaInteractorStylePolygonRepulsor.cxx
@@ -126,7 +126,7 @@ void vtkInriaInteractorStylePolygonRepulsor::OnLeftButtonDown()
         }
         if (!DistanceList.isEmpty())
         {
-            qSort(DistanceList);
+            std::sort(DistanceList.begin(), DistanceList.end());
 
             //-------------------------------------------COMPUTE RADIUS--------------------------------------------------------------//
             this->Radius = (int)((DistanceList[0]+0.5)*0.8); 


### PR DESCRIPTION
From a comment of @Florent2305 and according to the obsolete code of Qt : https://doc.qt.io/qt-5/qtalgorithms-obsolete.html#qSort-2

Switch qSort to std::sort.

:m: