### PR TITLE
[nullptr] small typo

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medToolBoxTab.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medToolBoxTab.cpp
@@ -27,7 +27,7 @@ medToolBoxTab::~medToolBoxTab(void)
 {
     delete d;
 
-    d = unllptr;
+    d = nullptr;
 }
 
 


### PR DESCRIPTION
Small typo in medToolBoxTab with a nullptr.

:m: