### PR TITLE
[Views] render cornerAnnotation + annotated cube button

### DIFF
--- a/src/layers/legacy/medCoreLegacy/parameters/medDoubleParameterL.cpp
+++ b/src/layers/legacy/medCoreLegacy/parameters/medDoubleParameterL.cpp
@@ -95,6 +95,8 @@ void medDoubleParameterL::setValue(double value)
         this->updateInternWigets();
         this->blockInternWidgetsSignals(false);
 
+        // If widgets from medDoubleParameterL is changed manually,
+        // this signal will be caught by medVtkViewItkDataImageInteractor
         emit valueChanged(m_value);
     }
 }

--- a/src/layers/legacy/medCoreLegacy/parameters/medDoubleParameterL.cpp
+++ b/src/layers/legacy/medCoreLegacy/parameters/medDoubleParameterL.cpp
@@ -260,4 +260,3 @@ void medDoubleParameterL::setSliderIntValue(int value)
     double dValue = currentDoubleValue * d->step + d->min;
     setValue(dValue);
 }
-

--- a/src/layers/legacy/medImageIO/vtkItkConversion.tpp
+++ b/src/layers/legacy/medImageIO/vtkItkConversion.tpp
@@ -110,7 +110,7 @@ bool vtkItkConversion<volumeType, imageDim>::GetConversion(vtkAlgorithmOutput *&
 /**
 * @brief  This internal function register into the good variable member the input image.
 * @param  pi_spInputImage [in] smart pointer on the itk input image.
-* @return True if succed. False in other cases.
+* @return True if succeed. False in other cases.
 */
 template <typename volumeType, unsigned int imageDim>
 bool vtkItkConversion<volumeType, imageDim>::initializeImage(typename itk::ImageBase<imageDim>::Pointer &pi_spInputImage)

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
@@ -1,10 +1,24 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2020. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
 #include "vtkImage2DDisplay.h"
+
+#include <vtkAlgorithmOutput.h>
+#include <vtkImageAlgorithm.h>
 #include <vtkImageMapper3D.h>
 #include <vtkImageProperty.h>
-#include <vtkImageAlgorithm.h>
-#include <vtkAlgorithmOutput.h>
 
-vtkStandardNewMacro(vtkImage2DDisplay);
+vtkStandardNewMacro(vtkImage2DDisplay)
 
 vtkImage2DDisplay::vtkImage2DDisplay()
 {
@@ -14,54 +28,10 @@ vtkImage2DDisplay::vtkImage2DDisplay()
     this->WindowLevel->SetOutputFormatToRGBA();
     this->ColorWindow       = 1e-3 * VTK_DOUBLE_MAX;
     this->ColorLevel        = 0;
-    this->ColorTransferFunction   = NULL;
-    this->OpacityTransferFunction = NULL;
+    this->ColorTransferFunction   = nullptr;
+    this->OpacityTransferFunction = nullptr;
     this->UseLookupTable    = false;
 }
-
-vtkImage2DDisplay::~vtkImage2DDisplay()
-{
-}
-
-/*void vtkImage2DDisplay::SetInput(vtkAlgorithmOutput *pi_poVtkAlgoPort)
-{
-    if (pi_poVtkAlgoPort)
-    {
-        if (pi_poVtkAlgoPort->GetProducer() && pi_poVtkAlgoPort->GetProducer()->IsA("vtkImageAlgorithm"))
-        {
-            vtkAlgorithmOutput *poVtkAlgoPortTmp = pi_poVtkAlgoPort;
-            vtkImageAlgorithm *poVtkImgAlgoTmp = static_cast<vtkImageAlgorithm*>(pi_poVtkAlgoPort->GetProducer());
-            vtkImageData *poVtkImgTmp = poVtkImgAlgoTmp->GetOutput();
-
-            InputProducer = poVtkImgAlgoTmp;
-
-            m_sVtkImageInfo.SetSpacing(poVtkImgTmp->GetSpacing());
-            m_sVtkImageInfo.SetOrigin(poVtkImgTmp->GetOrigin());
-            m_sVtkImageInfo.SetScalarRange(poVtkImgTmp->GetScalarRange());
-            m_sVtkImageInfo.SetExtent(poVtkImgTmp->GetExtent());
-            m_sVtkImageInfo.SetDimensions(poVtkImgTmp->GetDimensions());
-            m_sVtkImageInfo.scalarType = poVtkImgTmp->GetScalarType();
-            m_sVtkImageInfo.nbScalarComponent = poVtkImgTmp->GetNumberOfScalarComponents();
-            m_sVtkImageInfo.initialized = true;
-
-            if (!(poVtkImgTmp->GetScalarType() == VTK_UNSIGNED_CHAR && (poVtkImgTmp->GetNumberOfScalarComponents() == 3 || poVtkImgTmp->GetNumberOfScalarComponents() == 4)))
-            {
-                this->WindowLevel->SetInputConnection(poVtkAlgoPortTmp);
-                poVtkAlgoPortTmp = this->WindowLevel->GetOutputPort();
-            }
-            this->ImageActor->GetMapper()->SetInputConnection(poVtkAlgoPortTmp);
-        }
-        else
-        {
-            vtkErrorMacro(<< "Set input prior to adding layers");
-        }
-    }
-    else
-    {
-        memset(&m_sVtkImageInfo, 0, sizeof(m_sVtkImageInfo));
-    }
-}*/
-
 
 void vtkImage2DDisplay::SetInputData(vtkImageData *pi_poVtkImage)
 {

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
@@ -67,24 +67,24 @@ void vtkImage2DDisplay::SetInput(vtkImageData *pi_poVtkImage)
 {
     if (pi_poVtkImage)
     {
-            m_sVtkImageInfo.SetSpacing(pi_poVtkImage->GetSpacing());
-            m_sVtkImageInfo.SetOrigin(pi_poVtkImage->GetOrigin());
-            m_sVtkImageInfo.SetScalarRange(pi_poVtkImage->GetScalarRange());
-            m_sVtkImageInfo.SetExtent(pi_poVtkImage->GetExtent());
-            m_sVtkImageInfo.SetDimensions(pi_poVtkImage->GetDimensions());
-            m_sVtkImageInfo.scalarType = pi_poVtkImage->GetScalarType();
-            m_sVtkImageInfo.nbScalarComponent = pi_poVtkImage->GetNumberOfScalarComponents();
-            m_sVtkImageInfo.initialized = true;
+        m_sVtkImageInfo.SetSpacing(pi_poVtkImage->GetSpacing());
+        m_sVtkImageInfo.SetOrigin(pi_poVtkImage->GetOrigin());
+        m_sVtkImageInfo.SetScalarRange(pi_poVtkImage->GetScalarRange());
+        m_sVtkImageInfo.SetExtent(pi_poVtkImage->GetExtent());
+        m_sVtkImageInfo.SetDimensions(pi_poVtkImage->GetDimensions());
+        m_sVtkImageInfo.scalarType = pi_poVtkImage->GetScalarType();
+        m_sVtkImageInfo.nbScalarComponent = pi_poVtkImage->GetNumberOfScalarComponents();
+        m_sVtkImageInfo.initialized = true;
 
-            if (m_sVtkImageInfo.scalarType == VTK_UNSIGNED_CHAR && (m_sVtkImageInfo.nbScalarComponent == 3 || m_sVtkImageInfo.nbScalarComponent == 4))
-            {
-                this->ImageActor->GetMapper()->SetInputData(pi_poVtkImage);
-            }
-            else
-            {
-                this->WindowLevel->SetInputData(pi_poVtkImage);
-                this->ImageActor->GetMapper()->SetInputConnection(this->WindowLevel->GetOutputPort());
-            }
+        if (m_sVtkImageInfo.scalarType == VTK_UNSIGNED_CHAR && (m_sVtkImageInfo.nbScalarComponent == 3 || m_sVtkImageInfo.nbScalarComponent == 4))
+        {
+            this->ImageActor->GetMapper()->SetInputData(pi_poVtkImage);
+        }
+        else
+        {
+            this->WindowLevel->SetInputData(pi_poVtkImage);
+            this->ImageActor->GetMapper()->SetInputConnection(this->WindowLevel->GetOutputPort());
+        }
     }
     else
     {
@@ -92,6 +92,10 @@ void vtkImage2DDisplay::SetInput(vtkImageData *pi_poVtkImage)
     }
 }
 
+void vtkImage2DDisplay::SetInputProducer(vtkImageAlgorithm *inputImageAlgorithm)
+{
+    InputProducer = inputImageAlgorithm;
+}
 
 vtkLookupTable*vtkImage2DDisplay::GetLookupTable() const
 {

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
@@ -8,7 +8,7 @@ vtkStandardNewMacro(vtkImage2DDisplay);
 
 vtkImage2DDisplay::vtkImage2DDisplay()
 {
-    this->InputProducer     = 0;
+    this->InputProducer     = nullptr;
     this->ImageActor        = vtkImageActor::New();
     this->WindowLevel       = vtkImageMapToColors::New();
     this->WindowLevel->SetOutputFormatToRGBA();
@@ -63,7 +63,7 @@ vtkImage2DDisplay::~vtkImage2DDisplay()
 }*/
 
 
-void vtkImage2DDisplay::SetInput(vtkImageData *pi_poVtkImage)
+void vtkImage2DDisplay::SetInputData(vtkImageData *pi_poVtkImage)
 {
     if (pi_poVtkImage)
     {
@@ -92,9 +92,9 @@ void vtkImage2DDisplay::SetInput(vtkImageData *pi_poVtkImage)
     }
 }
 
-void vtkImage2DDisplay::SetInputProducer(vtkImageAlgorithm *inputImageAlgorithm)
+void vtkImage2DDisplay::SetInputProducer(vtkAlgorithmOutput *pi_poAlgorithmOutput)
 {
-    InputProducer = inputImageAlgorithm;
+    InputProducer = static_cast<vtkImageAlgorithm*>(pi_poAlgorithmOutput->GetProducer());
 }
 
 vtkLookupTable*vtkImage2DDisplay::GetLookupTable() const

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
@@ -23,7 +23,7 @@ vtkImage2DDisplay::~vtkImage2DDisplay()
 {
 }
 
-void vtkImage2DDisplay::SetInput(vtkAlgorithmOutput *pi_poVtkAlgoPort)
+/*void vtkImage2DDisplay::SetInput(vtkAlgorithmOutput *pi_poVtkAlgoPort)
 {
     if (pi_poVtkAlgoPort)
     {
@@ -32,9 +32,9 @@ void vtkImage2DDisplay::SetInput(vtkAlgorithmOutput *pi_poVtkAlgoPort)
             vtkAlgorithmOutput *poVtkAlgoPortTmp = pi_poVtkAlgoPort;
             vtkImageAlgorithm *poVtkImgAlgoTmp = static_cast<vtkImageAlgorithm*>(pi_poVtkAlgoPort->GetProducer());
             vtkImageData *poVtkImgTmp = poVtkImgAlgoTmp->GetOutput();
-            
+
             InputProducer = poVtkImgAlgoTmp;
-            
+
             m_sVtkImageInfo.SetSpacing(poVtkImgTmp->GetSpacing());
             m_sVtkImageInfo.SetOrigin(poVtkImgTmp->GetOrigin());
             m_sVtkImageInfo.SetScalarRange(poVtkImgTmp->GetScalarRange());
@@ -60,7 +60,38 @@ void vtkImage2DDisplay::SetInput(vtkAlgorithmOutput *pi_poVtkAlgoPort)
     {
         memset(&m_sVtkImageInfo, 0, sizeof(m_sVtkImageInfo));
     }
+}*/
+
+
+void vtkImage2DDisplay::SetInput(vtkImageData *pi_poVtkImage)
+{
+    if (pi_poVtkImage)
+    {
+            m_sVtkImageInfo.SetSpacing(pi_poVtkImage->GetSpacing());
+            m_sVtkImageInfo.SetOrigin(pi_poVtkImage->GetOrigin());
+            m_sVtkImageInfo.SetScalarRange(pi_poVtkImage->GetScalarRange());
+            m_sVtkImageInfo.SetExtent(pi_poVtkImage->GetExtent());
+            m_sVtkImageInfo.SetDimensions(pi_poVtkImage->GetDimensions());
+            m_sVtkImageInfo.scalarType = pi_poVtkImage->GetScalarType();
+            m_sVtkImageInfo.nbScalarComponent = pi_poVtkImage->GetNumberOfScalarComponents();
+            m_sVtkImageInfo.initialized = true;
+
+            if (m_sVtkImageInfo.scalarType == VTK_UNSIGNED_CHAR && (m_sVtkImageInfo.nbScalarComponent == 3 || m_sVtkImageInfo.nbScalarComponent == 4))
+            {
+                this->ImageActor->GetMapper()->SetInputData(pi_poVtkImage);
+            }
+            else
+            {
+                this->WindowLevel->SetInputData(pi_poVtkImage);
+                this->ImageActor->GetMapper()->SetInputConnection(this->WindowLevel->GetOutputPort());
+            }
+    }
+    else
+    {
+        memset(&m_sVtkImageInfo, 0, sizeof(m_sVtkImageInfo));
+    }
 }
+
 
 vtkLookupTable*vtkImage2DDisplay::GetLookupTable() const
 {

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.h
@@ -19,6 +19,8 @@ public:
 
   virtual void SetInput(vtkImageData *pi_poVtkImage);
 
+  void SetInputProducer(vtkImageAlgorithm *inputImageAlgorithm);
+
   virtual vtkLookupTable * GetLookupTable() const;
 
   virtual vtkImageActor* GetImageActor() { return this->ImageActor; }

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.h
@@ -15,7 +15,9 @@ public:
   static vtkImage2DDisplay * New();
   vtkTypeMacro (vtkImage2DDisplay, vtkObject);
 
-  virtual void SetInput(vtkAlgorithmOutput*  pi_poVtkAlgoPort);
+  //virtual void SetInput(vtkAlgorithmOutput*  pi_poVtkAlgoPort);
+
+  virtual void SetInput(vtkImageData *pi_poVtkImage);
 
   virtual vtkLookupTable * GetLookupTable() const;
 

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.h
@@ -17,9 +17,9 @@ public:
 
   //virtual void SetInput(vtkAlgorithmOutput*  pi_poVtkAlgoPort);
 
-  virtual void SetInput(vtkImageData *pi_poVtkImage);
+  virtual void SetInputData(vtkImageData *pi_poVtkImage);
 
-  void SetInputProducer(vtkImageAlgorithm *inputImageAlgorithm);
+  void SetInputProducer(vtkAlgorithmOutput *pi_poAlgorithmOutput);
 
   virtual vtkLookupTable * GetLookupTable() const;
 

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.h
@@ -1,21 +1,31 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2020. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
 #pragma once
-#include <vtkImageData.h>
+
+#include <medVtkImageInfo.h>
+
+#include <vtkColorTransferFunction.h>
 #include <vtkImageActor.h>
+#include <vtkImageData.h>
 #include <vtkImageMapToColors.h>
 #include <vtkLookupTable.h>
-#include <vtkColorTransferFunction.h>
 #include <vtkPiecewiseFunction.h>
-#include <vtkSetGet.h>
-#include "medVtkImageInfo.h"
-
 
 class vtkImage2DDisplay : public vtkObject
 {
 public:
   static vtkImage2DDisplay * New();
   vtkTypeMacro (vtkImage2DDisplay, vtkObject);
-
-  //virtual void SetInput(vtkAlgorithmOutput*  pi_poVtkAlgoPort);
 
   virtual void SetInputData(vtkImageData *pi_poVtkImage);
 
@@ -47,7 +57,7 @@ public:
 
 protected:
   vtkImage2DDisplay();
-  ~vtkImage2DDisplay();
+  ~vtkImage2DDisplay() = default;
 
 private:
   vtkSmartPointer<vtkImageMapToColors>        WindowLevel;

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.cpp
@@ -1,8 +1,21 @@
-#include "vtkImage3DDisplay.h"
-#include <vtkImageData.h>
-#include <vtkImageAlgorithm.h>
+/*=========================================================================
 
-vtkStandardNewMacro(vtkImage3DDisplay);
+ medInria
+
+ Copyright (c) INRIA 2013 - 2020. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include "vtkImage3DDisplay.h"
+
+#include <vtkImageAlgorithm.h>
+#include <vtkImageData.h>
+
+vtkStandardNewMacro(vtkImage3DDisplay)
 
 vtkImage3DDisplay::vtkImage3DDisplay()
 {
@@ -22,40 +35,6 @@ vtkImage3DDisplay::~vtkImage3DDisplay()
         this->LookupTable->Delete();
     }
 }
-
-/*
-void vtkImage3DDisplay::SetInputConnection(vtkAlgorithmOutput* pi_poVtkAlgoPort)
-{
-    if (pi_poVtkAlgoPort)
-    {
-        if (pi_poVtkAlgoPort->GetProducer() && pi_poVtkAlgoPort->GetProducer()->IsA("vtkImageAlgorithm"))
-        {
-            this->InputConnection = pi_poVtkAlgoPort;
-            vtkImageAlgorithm* poVtkImgAlgoTmp = static_cast<vtkImageAlgorithm*>(pi_poVtkAlgoPort->GetProducer());
-            vtkImageData* poVtkImgTmp = poVtkImgAlgoTmp->GetOutput();
-
-            m_sVtkImageInfo.SetSpacing(poVtkImgTmp->GetSpacing());
-            m_sVtkImageInfo.SetOrigin(poVtkImgTmp->GetOrigin());
-            m_sVtkImageInfo.SetScalarRange(poVtkImgTmp->GetScalarRange());
-            m_sVtkImageInfo.SetExtent(poVtkImgTmp->GetExtent());
-            m_sVtkImageInfo.SetDimensions(poVtkImgTmp->GetDimensions());
-            m_sVtkImageInfo.scalarType = poVtkImgTmp->GetScalarType();
-            m_sVtkImageInfo.nbScalarComponent = poVtkImgTmp->GetNumberOfScalarComponents();
-            m_sVtkImageInfo.initialized = true;
-        }
-        else
-        {
-            vtkErrorMacro(<< "Set input prior to adding layers");
-        }
-    }
-    else
-    {
-        memset(&m_sVtkImageInfo, 0, sizeof(m_sVtkImageInfo));
-        this->InputConnection = nullptr;
-    }
-}
-*/
-
 
 void vtkImage3DDisplay::SetInputData(vtkImageData *pi_poVtkImage)
 {
@@ -81,7 +60,7 @@ void vtkImage3DDisplay::SetInputProducer(vtkAlgorithmOutput *pi_poAlgorithmOutpu
     InputProducer = static_cast<vtkImageAlgorithm*>(pi_poAlgorithmOutput->GetProducer());
 }
 
-medVtkImageInfo* vtkImage3DDisplay::GetVtkImageInfo()
+medVtkImageInfo* vtkImage3DDisplay::GetMedVtkImageInfo()
 {
     return &m_sVtkImageInfo;
 }
@@ -95,8 +74,3 @@ vtkLookupTable* vtkImage3DDisplay::GetLookupTable()
 {
     return this->LookupTable;
 }
-
-/*vtkAlgorithmOutput* vtkImage3DDisplay::GetOutputPort()
-{
-    return this->InputConnection;
-}*/

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.cpp
@@ -6,7 +6,6 @@ vtkStandardNewMacro(vtkImage3DDisplay);
 
 vtkImage3DDisplay::vtkImage3DDisplay()
 {
-    //this->InputImageOld = 0;
     this->InputConnection = 0;
     this->Opacity = 1.0;
     this->Visibility = 1;
@@ -43,7 +42,6 @@ void vtkImage3DDisplay::SetInputConnection(vtkAlgorithmOutput* pi_poVtkAlgoPort)
             m_sVtkImageInfo.scalarType = poVtkImgTmp->GetScalarType();
             m_sVtkImageInfo.nbScalarComponent = poVtkImgTmp->GetNumberOfScalarComponents();
             m_sVtkImageInfo.initialized = true;
-
         } 
         else
         {

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.cpp
@@ -6,7 +6,7 @@ vtkStandardNewMacro(vtkImage3DDisplay);
 
 vtkImage3DDisplay::vtkImage3DDisplay()
 {
-    this->InputConnection = 0;
+    this->InputProducer = nullptr;
     this->Opacity = 1.0;
     this->Visibility = 1;
     this->ColorWindow = 1e-3 * VTK_DOUBLE_MAX;
@@ -23,9 +23,9 @@ vtkImage3DDisplay::~vtkImage3DDisplay()
     }
 }
 
-
+/*
 void vtkImage3DDisplay::SetInputConnection(vtkAlgorithmOutput* pi_poVtkAlgoPort)
-{    
+{
     if (pi_poVtkAlgoPort)
     {
         if (pi_poVtkAlgoPort->GetProducer() && pi_poVtkAlgoPort->GetProducer()->IsA("vtkImageAlgorithm"))
@@ -42,17 +42,43 @@ void vtkImage3DDisplay::SetInputConnection(vtkAlgorithmOutput* pi_poVtkAlgoPort)
             m_sVtkImageInfo.scalarType = poVtkImgTmp->GetScalarType();
             m_sVtkImageInfo.nbScalarComponent = poVtkImgTmp->GetNumberOfScalarComponents();
             m_sVtkImageInfo.initialized = true;
-        } 
+        }
         else
         {
             vtkErrorMacro(<< "Set input prior to adding layers");
         }
-    } 
+    }
     else
     {
         memset(&m_sVtkImageInfo, 0, sizeof(m_sVtkImageInfo));
         this->InputConnection = nullptr;
     }
+}
+*/
+
+
+void vtkImage3DDisplay::SetInputData(vtkImageData *pi_poVtkImage)
+{
+    if (pi_poVtkImage)
+    {
+        m_sVtkImageInfo.SetSpacing(pi_poVtkImage->GetSpacing());
+        m_sVtkImageInfo.SetOrigin(pi_poVtkImage->GetOrigin());
+        m_sVtkImageInfo.SetScalarRange(pi_poVtkImage->GetScalarRange());
+        m_sVtkImageInfo.SetExtent(pi_poVtkImage->GetExtent());
+        m_sVtkImageInfo.SetDimensions(pi_poVtkImage->GetDimensions());
+        m_sVtkImageInfo.scalarType = pi_poVtkImage->GetScalarType();
+        m_sVtkImageInfo.nbScalarComponent = pi_poVtkImage->GetNumberOfScalarComponents();
+        m_sVtkImageInfo.initialized = true;
+    }
+    else
+    {
+        memset(&m_sVtkImageInfo, 0, sizeof(m_sVtkImageInfo));
+    }
+}
+
+void vtkImage3DDisplay::SetInputProducer(vtkAlgorithmOutput *pi_poAlgorithmOutput)
+{
+    InputProducer = static_cast<vtkImageAlgorithm*>(pi_poAlgorithmOutput->GetProducer());
 }
 
 medVtkImageInfo* vtkImage3DDisplay::GetVtkImageInfo()
@@ -70,7 +96,7 @@ vtkLookupTable* vtkImage3DDisplay::GetLookupTable()
     return this->LookupTable;
 }
 
-vtkAlgorithmOutput* vtkImage3DDisplay::GetOutputPort()
+/*vtkAlgorithmOutput* vtkImage3DDisplay::GetOutputPort()
 {
     return this->InputConnection;
-}
+}*/

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.h
@@ -1,12 +1,24 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2020. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
 #pragma once
-#include "medVtkImageInfo.h"
+
+#include <medVtkImageInfo.h>
 
 #include <vtkAlgorithmOutput.h>
 #include <vtkImageAlgorithm.h>
 #include <vtkImageData.h>
 #include <vtkLookupTable.h>
 #include <vtkSetGet.h>
-
 
 class vtkImage3DDisplay : public vtkObject
 {
@@ -15,12 +27,9 @@ public:
 
     vtkTypeMacro (vtkImage3DDisplay, vtkObject);
 
-    //vtkSetObjectMacro(InputConnection, vtkAlgorithmOutput);
-
-    //virtual void SetInputConnection(vtkAlgorithmOutput*  pi_poVtkAlgoPort);
     virtual void SetInputData(vtkImageData *pi_poVtkImage);
     void SetInputProducer(vtkAlgorithmOutput *pi_poAlgorithmOutput);
-    virtual medVtkImageInfo* GetVtkImageInfo();
+    virtual medVtkImageInfo* GetMedVtkImageInfo();
 
     virtual bool isInputSet();
 
@@ -42,7 +51,6 @@ public:
     vtkSetMacro(ColorLevel, double);
     vtkGetMacro(ColorLevel, double);
 
-    //vtkAlgorithmOutput* GetOutputPort();
     virtual vtkImageAlgorithm* GetInputProducer() const { return this->InputProducer; }
 
 protected:
@@ -50,9 +58,7 @@ protected:
     ~vtkImage3DDisplay();
 
 private:
-    //vtkSmartPointer<vtkImageData>               InputImageOld;
-    //vtkSmartPointer<vtkAlgorithmOutput>         InputConnection;
-    vtkSmartPointer<vtkImageAlgorithm>            InputProducer;
+    vtkSmartPointer<vtkImageAlgorithm> InputProducer;
     double Opacity;
     int Visibility;
     double ColorWindow;

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.h
@@ -1,10 +1,12 @@
 #pragma once
-#include <vtkAlgorithmOutput.h>
-#include <vtkLookupTable.h>
-#include <vtkSetGet.h>
 #include "medVtkImageInfo.h"
 
+#include <vtkAlgorithmOutput.h>
+#include <vtkImageAlgorithm.h>
 #include <vtkImageData.h>
+#include <vtkLookupTable.h>
+#include <vtkSetGet.h>
+
 
 class vtkImage3DDisplay : public vtkObject
 {
@@ -15,7 +17,9 @@ public:
 
     //vtkSetObjectMacro(InputConnection, vtkAlgorithmOutput);
 
-    virtual void SetInputConnection(vtkAlgorithmOutput*  pi_poVtkAlgoPort);
+    //virtual void SetInputConnection(vtkAlgorithmOutput*  pi_poVtkAlgoPort);
+    virtual void SetInputData(vtkImageData *pi_poVtkImage);
+    void SetInputProducer(vtkAlgorithmOutput *pi_poAlgorithmOutput);
     virtual medVtkImageInfo* GetVtkImageInfo();
 
     virtual bool isInputSet();
@@ -38,7 +42,8 @@ public:
     vtkSetMacro(ColorLevel, double);
     vtkGetMacro(ColorLevel, double);
 
-    vtkAlgorithmOutput* GetOutputPort();
+    //vtkAlgorithmOutput* GetOutputPort();
+    virtual vtkImageAlgorithm* GetInputProducer() const { return this->InputProducer; }
 
 protected:
     vtkImage3DDisplay();
@@ -46,7 +51,8 @@ protected:
 
 private:
     //vtkSmartPointer<vtkImageData>               InputImageOld;
-    vtkSmartPointer<vtkAlgorithmOutput>         InputConnection;
+    //vtkSmartPointer<vtkAlgorithmOutput>         InputConnection;
+    vtkSmartPointer<vtkImageAlgorithm>            InputProducer;
     double Opacity;
     int Visibility;
     double ColorWindow;

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
@@ -125,8 +125,6 @@ vtkImageView::vtkImageView()
     this->ScalarBar->PickableOff();
     this->ScalarBar->VisibilityOn();
 
-
-
     for(int i=0; i<3; i++)
         this->CurrentPoint[i] = 0.0; //VTK_DOUBLE_MIN;
 
@@ -150,7 +148,6 @@ vtkImageView::vtkImageView()
     this->LookupTable->SetAlphaRange (0, 1);
     this->LookupTable->Build();
 }
-
 
 vtkImageView::~vtkImageView()
 {
@@ -231,6 +228,8 @@ vtkMTimeType vtkImageView::GetMTime()
 /** Attach an interactor for the internal render window. */
 void vtkImageView::SetupInteractor(vtkRenderWindowInteractor *arg)
 {
+    this->UnInstallPipeline();
+
     vtkSetObjectBodyMacro (Interactor, vtkRenderWindowInteractor, arg);
 
     this->InstallPipeline();
@@ -240,6 +239,8 @@ void vtkImageView::SetupInteractor(vtkRenderWindowInteractor *arg)
 /** Set your own renderwindow and renderer */
 void vtkImageView::SetRenderWindow(vtkRenderWindow *arg)
 {
+    this->UnInstallPipeline();
+
     vtkSetObjectBodyMacro (RenderWindow, vtkRenderWindow, arg);
 
     if (this->RenderWindow && this->RenderWindow->GetInteractor())
@@ -252,6 +253,8 @@ void vtkImageView::SetRenderWindow(vtkRenderWindow *arg)
 //----------------------------------------------------------------------------
 void vtkImageView::SetRenderer(vtkRenderer *arg)
 {
+    this->UnInstallPipeline();
+
     vtkSetObjectBodyMacro (Renderer, vtkRenderer, arg);
 
     this->InstallPipeline();
@@ -422,16 +425,19 @@ void vtkImageView::InstallPipeline()
 //----------------------------------------------------------------------------
 void vtkImageView::UnInstallPipeline()
 {
+    std::cout<<"### vtkImageView::UnInstallPipeline"<<std::endl;
     this->UnInstallInteractor();
 
     if (this->GetRenderer())
     {
+        std::cout<<"### vtkImageView::UnInstallPipeline A"<<std::endl;
         this->GetRenderer()->RemoveViewProp(this->CornerAnnotation);
         this->GetRenderer()->RemoveViewProp(this->ScalarBar);
     }
 
     if (this->RenderWindow && this->GetRenderer())
     {
+        std::cout<<"### vtkImageView::UnInstallPipeline B"<<std::endl;
         this->RenderWindow->RemoveRenderer(this->GetRenderer());
     }
 }
@@ -636,8 +642,6 @@ void vtkImageView::SetOpacityTransferFunction( vtkPiecewiseFunction * otf )
 {
     this->SetTransferFunctions( NULL, otf,this->GetCurrentLayer() );
 }
-
-
 
 //----------------------------------------------------------------------------
 void vtkImageView::SetLookupTable (vtkLookupTable* lookuptable)
@@ -969,7 +973,6 @@ void vtkImageView::GetColorRange( double r[2] )
     this->GetColorRange(r, currentLayer);
 }
 
-
 void vtkImageView::GetColorRange(double r[], int layer)
 {
     r[0] = this->GetColorLevel(layer) - 0.5 * this->GetColorWindow(layer);
@@ -1277,9 +1280,6 @@ void vtkImageView::ResetCamera()
 {
     if (this->GetRenderer())
     {
-        //  ResetCamera calls ResetCameraClippingRange anyway...
-        //      this->GetRenderer()->ResetCameraClippingRange();
-
         if ( this->GetMedVtkImageInfo () )
         {
             double bounds [6];
@@ -1410,9 +1410,7 @@ void vtkImageView::Reset()
 {
     this->ResetCurrentPoint();
     this->ResetWindowLevel();
-    // this->SetColorWindow (VTK_DOUBLE_MAX); // NT: ?? --> when i press reset I would like the windowlevels to be "reset" ?
     this->ResetCamera();
-
 }
 
 //----------------------------------------------------------------------------

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
@@ -377,9 +377,9 @@ vtkAlgorithmOutput* vtkImageView::ResliceImageToInput(vtkAlgorithmOutput* pi_poV
 /**  Set the input image to the viewer. */
 void vtkImageView::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix /*= 0*/, int layer /*= 0*/)
 {
-    //vtkSetObjectBodyMacro (Input, vtkImageData, arg);
     m_poInputVtkAlgoOutput = pi_poVtkAlgoOutput;
-    m_poInternalImageFromInput = ((vtkImageAlgorithm*)pi_poVtkAlgoOutput->GetProducer())->GetOutput();
+    m_poInternalImageFromInput = static_cast<vtkImageAlgorithm*>(pi_poVtkAlgoOutput->GetProducer())->GetOutput();
+
     if (pi_poVtkAlgoOutput)
     {
        this->WindowLevel->SetInputConnection(pi_poVtkAlgoOutput);

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
@@ -54,12 +54,6 @@
 #define snprintf _snprintf_s
 #endif
 
-
-//vtkStandardNewMacro(vtkImageView); // pure virtual class
-
-
-// Enumeration for the supported pixel types
-// NT: why not using the vtk IO definitions ?
 namespace {
 enum ImageViewType {
     IMAGE_VIEW_NONE = 0,
@@ -204,7 +198,6 @@ vtkImageView::~vtkImageView()
     }
     if (this->m_poInternalImageFromInput)
     {
-        //this->m_poInternalImageFromInput->Delete();
         this->m_poInternalImageFromInput = nullptr;
         this->m_poInputVtkAlgoOutput = nullptr;
     }
@@ -238,8 +231,6 @@ vtkMTimeType vtkImageView::GetMTime()
 /** Attach an interactor for the internal render window. */
 void vtkImageView::SetupInteractor(vtkRenderWindowInteractor *arg)
 {
-    //this->UnInstallPipeline();
-
     vtkSetObjectBodyMacro (Interactor, vtkRenderWindowInteractor, arg);
 
     this->InstallPipeline();
@@ -249,8 +240,6 @@ void vtkImageView::SetupInteractor(vtkRenderWindowInteractor *arg)
 /** Set your own renderwindow and renderer */
 void vtkImageView::SetRenderWindow(vtkRenderWindow *arg)
 {
-    //this->UnInstallPipeline();
-
     vtkSetObjectBodyMacro (RenderWindow, vtkRenderWindow, arg);
 
     if (this->RenderWindow && this->RenderWindow->GetInteractor())
@@ -263,8 +252,6 @@ void vtkImageView::SetRenderWindow(vtkRenderWindow *arg)
 //----------------------------------------------------------------------------
 void vtkImageView::SetRenderer(vtkRenderer *arg)
 {
-    //this->UnInstallPipeline();
-
     vtkSetObjectBodyMacro (Renderer, vtkRenderer, arg);
 
     this->InstallPipeline();
@@ -327,16 +314,18 @@ bool vtkImageView::Compare(vtkMatrix4x4 *mat1, vtkMatrix4x4 *mat2)
 */
 vtkAlgorithmOutput* vtkImageView::ResliceImageToInput(vtkAlgorithmOutput* pi_poVtkAlgoPort, vtkMatrix4x4 *matrix)
 {
-    vtkAlgorithmOutput *poResOutput = 0;
+    vtkAlgorithmOutput *poResOutput = nullptr;
     vtkImageData* image = ((vtkImageAlgorithm*)pi_poVtkAlgoPort->GetProducer())->GetOutput();
-    if (!pi_poVtkAlgoPort || !this->GetMedVtkImageInfo() || !this->GetMedVtkImageInfo()->initialized)
-        return NULL;
 
+    if (!pi_poVtkAlgoPort || !this->GetMedVtkImageInfo() || !this->GetMedVtkImageInfo()->initialized)
+    {
+        return nullptr;
+    }
 
     if ( pi_poVtkAlgoPort &&
-         this->Compare(image->GetOrigin(),      this->GetMedVtkImageInfo()->origin, 3) &&
-         this->Compare(image->GetSpacing(),     this->GetMedVtkImageInfo()->spacing, 3) &&
-         this->Compare(image->GetExtent(), this->GetMedVtkImageInfo()->extent, 6) &&
+         this->Compare(image->GetOrigin(),  this->GetMedVtkImageInfo()->origin, 3) &&
+         this->Compare(image->GetSpacing(), this->GetMedVtkImageInfo()->spacing, 3) &&
+         this->Compare(image->GetExtent(),  this->GetMedVtkImageInfo()->extent, 6) &&
          (matrix && this->Compare(matrix, this->OrientationMatrix)) )
     {
         poResOutput = pi_poVtkAlgoPort;
@@ -877,8 +866,6 @@ void vtkImageView::SetWindowSettingsFromTransferFunction(int layer)
     if ( touched )
     {
         this->SetColorRange( targetRange, layer );
-        //TODO call Modified on the right object
-        //    this->GetWindowLevel(layer)->Modified();
         this->ScalarBar->Modified();
     }
 }

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.h
@@ -82,7 +82,7 @@ class vtkImageAlgorithm;
    actor describing the image in the 2D - or 3D - scene. The rotation 3x3 component of this matrix
    has to be orthogonal (no scaling). The offset component may contain the origin information.
    In this case the user will have to make sure that this information is absent from the vtkImageData
-   instance given in SetInput(). For that you can call : view->GetInput()->SetOrigin(0,0,0).
+   instance given in SetInputData(). For that you can call : view->GetInput()->SetOrigin(0,0,0).
 
    \ingroup AdvancedRendering
    \see vtkImageView2D vtkImageViewCollection vtkImageView3D
@@ -216,7 +216,7 @@ public:
      by GetOrigin() on an itk::Image.
 
      CAUTION: if you provide non-zero origin to the viewer vtkImageData input
-     (SetInput()), then don't provide translation to the OrientationMatrix instance,
+     (SetInputData()), then don't provide translation to the OrientationMatrix instance,
      otherwise the information is redundant.
 
      The best behaviour is to force the origin of the vtkImageData input to zero and
@@ -527,7 +527,7 @@ protected:
      by GetOrigin() on an itk::Image.
 
      CAUTION: if you provide non-zero origin to the viewer vtkImageData input
-     (SetInput()), then don't provide translation to the OrientationMatrix instance,
+     (SetInputData()), then don't provide translation to the OrientationMatrix instance,
      otherwise the information is redundant.
 
      The best behaviour is to force the origin of the vtkImageData input to zero and

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.h
@@ -502,12 +502,9 @@ protected:
     virtual bool Compare(int *array1,    int *array2,    int size);
     virtual bool Compare(vtkMatrix4x4 *mat1, vtkMatrix4x4 *mat2);
 
-
     virtual vtkAlgorithmOutput* ResliceImageToInput(vtkAlgorithmOutput* pi_poVtkAlgoPort, vtkMatrix4x4 *matrix);
 
     virtual void GetWithinBoundsPosition (double* pos1, double* dos2);
-
-
 
 protected:
     /**

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
@@ -1577,7 +1577,7 @@ void vtkImageView2D::UnInstallPipeline()
   {
     //this->GetRenderer()->RemoveViewProp ( this->ImageActor );
     this->GetRenderer()->RemoveViewProp ( this->OrientationAnnotation );
-    //this->ImageActor->SetInput (nullptr);
+    //this->ImageActor->SetInputData (nullptr);
   }
 
   if( this->InteractorStyle )
@@ -1742,11 +1742,11 @@ void vtkImageView2D::SetFirstLayer(vtkAlgorithmOutput *pi_poInputAlgoImg, vtkMat
         {
             this->AddLayer(layer);
         }
-        vtkImageAlgorithm *inputImageAlgorithm = static_cast<vtkImageAlgorithm*>(pi_poInputAlgoImg->GetProducer());
-        this->GetImage2DDisplayForLayer(layer)->SetInputProducer(inputImageAlgorithm);
+        
+        this->GetImage2DDisplayForLayer(layer)->SetInputProducer(pi_poInputAlgoImg);
 
         this->Superclass::SetInput (pi_poInputAlgoImg, matrix, 0);
-        this->GetImage2DDisplayForLayer(layer)->SetInput(m_poInternalImageFromInput);
+        this->GetImage2DDisplayForLayer(layer)->SetInputData(m_poInternalImageFromInput);
         this->GetWindowLevel(layer)->SetInputConnection(pi_poInputAlgoImg);
         double *range = this->GetImage2DDisplayForLayer(layer)->GetMedVtkImageInfo()->scalarRange;
         this->SetColorRange(range,layer);
@@ -1813,7 +1813,7 @@ void vtkImageView2D::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4
       }
 
       vtkImage2DDisplay * imageDisplay = this->GetImage2DDisplayForLayer(layer);
-      imageDisplay->SetInput(((vtkImageAlgorithm*)reslicerOutputPort->GetProducer())->GetOutput());
+      imageDisplay->SetInputData(((vtkImageAlgorithm*)reslicerOutputPort->GetProducer())->GetOutput());
       imageDisplay->GetImageActor()->SetUserMatrix (this->OrientationMatrix);
       this->SetColorRange(imageDisplay->GetMedVtkImageInfo()->scalarRange, layer);
   }

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
@@ -936,6 +936,8 @@ the CornerAnnotation are modified.
 */
 void vtkImageView2D::SetAnnotationsFromOrientation()
 {
+    std::cout<<"### vtkImageView2D::SetAnnotationsFromOrientation"<<std::endl;
+
   // This method has to be called after the camera
   // has been set according to orientation and convention.
   // We rely on the camera settings to compute the oriention
@@ -1480,7 +1482,6 @@ void vtkImageView2D::InstallPipeline()
 
   if (this->GetRenderer())
   {
-    //this->GetRenderer()->AddViewProp( this->ImageActor );
     this->GetRenderer()->AddViewProp( this->OrientationAnnotation );
     this->GetRenderer()->GetActiveCamera()->ParallelProjectionOn();
   }
@@ -1532,18 +1533,20 @@ home made InteractorStyle, and make it observe all events we need
 */
 void vtkImageView2D::UnInstallPipeline()
 {
-  if ( this->GetRenderer() )
-  {
-      this->GetRenderer()->RemoveViewProp ( this->OrientationAnnotation );
-  }
+    std::cout<<"### --- vtkImageView2D::UnInstallPipeline"<<std::endl;
+    if ( this->GetRenderer() )
+    {
+        std::cout<<"### --- vtkImageView2D::UnInstallPipeline A"<<std::endl;
+        this->GetRenderer()->RemoveViewProp ( this->OrientationAnnotation );
+    }
 
-  if( this->InteractorStyle )
-  {
-    this->InteractorStyle->RemoveObserver ( this->Command );
-  }
+    if( this->InteractorStyle )
+    {
+        std::cout<<"### --- vtkImageView2D::UnInstallPipeline B"<<std::endl;
+        this->InteractorStyle->RemoveObserver ( this->Command );
+    }
 
-
-  this->Superclass::UnInstallPipeline();
+    this->Superclass::UnInstallPipeline();
 }
 
 //----------------------------------------------------------------------------
@@ -1567,14 +1570,13 @@ void vtkImageView2D::InstallInteractor()
 
   if (this->RenderWindow)
   {
-
-    for (LayerInfoVecType::iterator it = this->LayerInfoVec.begin(); it!=this->LayerInfoVec.end(); ++it)
-    {
-      if (vtkRenderer *renderer = it->Renderer)
+      for (auto it : LayerInfoVec)
       {
-        this->RenderWindow->AddRenderer(renderer);
+          if (vtkRenderer *renderer = it.Renderer)
+          {
+              this->RenderWindow->AddRenderer(renderer);
+          }
       }
-    }
   }
 
   this->Axes2DWidget->SetImageView (this);
@@ -1605,36 +1607,36 @@ void vtkImageView2D::InstallInteractor()
 //----------------------------------------------------------------------------
 void vtkImageView2D::UnInstallInteractor()
 {
-  this->RulerWidget->SetInteractor ( nullptr );
-  this->DistanceWidget->SetInteractor ( nullptr );
-  this->AngleWidget->SetInteractor ( nullptr );
-  this->Axes2DWidget->SetImageView ( nullptr );
+    std::cout<<"### vtkImageView2D::UnInstallInteractor"<<std::endl;
+    this->RulerWidget->SetInteractor ( nullptr );
+    this->DistanceWidget->SetInteractor ( nullptr );
+    this->AngleWidget->SetInteractor ( nullptr );
+    this->Axes2DWidget->SetImageView ( nullptr );
 
-  if (this->Interactor)
-  {
-    this->Interactor->SetRenderWindow (nullptr);
-    this->Interactor->SetInteractorStyle (nullptr);
-  }
+    if (this->Interactor)
+    {
+        this->Interactor->SetRenderWindow (nullptr);
+        this->Interactor->SetInteractorStyle (nullptr);
+    }
 
-  if (this->RenderWindow)
-   {
-     for (LayerInfoVecType::iterator it = this->LayerInfoVec.begin(); it!=this->LayerInfoVec.end(); ++it)
-     {
-      if (vtkRenderer *renderer = it->Renderer)
-       {
-        this->RenderWindow->RemoveRenderer(renderer);
-       }
-     }
-   }
+    if (this->RenderWindow)
+    {
+        for (auto it : LayerInfoVec)
+        {
+            if (vtkRenderer *renderer = it.Renderer)
+            {
+                this->RenderWindow->RemoveRenderer(renderer);
+            }
+        }
+    }
 
+    for (std::list<vtkDataSet2DWidget*>::iterator it = this->DataSetWidgets.begin(); it!=this->DataSetWidgets.end(); ++it )
+    {
+        (*it)->SetImageView(nullptr);
+        (*it)->Off();
+    }
 
-  for (std::list<vtkDataSet2DWidget*>::iterator it = this->DataSetWidgets.begin(); it!=this->DataSetWidgets.end(); ++it )
-  {
-    (*it)->SetImageView(nullptr);
-    (*it)->Off();
-  }
-
-  this->IsInteractorInstalled = 0;
+    this->IsInteractorInstalled = 0;
 }
 
 //----------------------------------------------------------------------------
@@ -1724,17 +1726,20 @@ void vtkImageView2D::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4
         }
         else // layer > 0
         {
-            this->AddLayer(layer);
-            pi_poVtkAlgoOutput = this->ResliceImageToInput(pi_poVtkAlgoOutput, matrix);
-            this->SetInputLayer(pi_poVtkAlgoOutput, matrix, layer);
+            SetInputLayer(pi_poVtkAlgoOutput, matrix, layer);
         }
-        this->SetInputEnd(pi_poVtkAlgoOutput, matrix, layer);
+
+        SetInputEnd(pi_poVtkAlgoOutput, matrix, layer);
     }
 }
 
 void vtkImageView2D::SetInputLayer(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix /*= 0*/, int layer /*= 0*/)
 {
     // layer > 0
+
+    this->AddLayer(layer);
+    pi_poVtkAlgoOutput = this->ResliceImageToInput(pi_poVtkAlgoOutput, matrix);
+
     vtkImage2DDisplay *imageDisplay = this->GetImage2DDisplayForLayer(layer);
     imageDisplay->SetInputProducer(pi_poVtkAlgoOutput);
     imageDisplay->SetInputData(static_cast<vtkImageAlgorithm*>(pi_poVtkAlgoOutput->GetProducer())->GetOutput());
@@ -1819,11 +1824,9 @@ void vtkImageView2D::RemoveLayerActor(vtkActor *actor, int layer)
     this->SetCurrentLayer(layer);
     this->Slice = this->GetSliceForWorldCoordinates (this->CurrentPoint);
     this->UpdateDisplayExtent();
-    // this->UpdateCenter();
     this->UpdateSlicePlane();
     this->InvokeEvent (vtkImageView2D::SliceChangedEvent);
 }
-
 
 //----------------------------------------------------------------------------
 /**

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
@@ -44,6 +44,8 @@
 #include <vtkStreamingDemandDrivenPipeline.h>
 #include <vtkTransform.h>
 
+#include <sstream>
+
 vtkStandardNewMacro(vtkImageView2D)
 
 //----------------------------------------------------------------------------

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
@@ -1740,8 +1740,8 @@ void vtkImageView2D::SetFirstLayer(vtkAlgorithmOutput *pi_poInputAlgoImg, vtkMat
         if( layer > 0 )
           this->AddLayer(layer);
 
-        this->GetImage2DDisplayForLayer(layer)->SetInput(pi_poInputAlgoImg);
         this->Superclass::SetInput (pi_poInputAlgoImg, matrix, 0);
+        this->GetImage2DDisplayForLayer(layer)->SetInput(m_poInternalImageFromInput);
         this->GetWindowLevel(layer)->SetInputConnection(pi_poInputAlgoImg);
         double *range = this->GetImage2DDisplayForLayer(layer)->GetMedVtkImageInfo()->scalarRange;
         this->SetColorRange(range,layer);
@@ -1807,16 +1807,8 @@ void vtkImageView2D::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4
           return;
       }
 
-      // determine the scalar range. Copy the update extent to match the input's one
-      //double range[2];
-      //TODO GPR: to check
-      //reslicedImage->UpdateExtent (this->GetInput()->GetUpdateExtent());
-      //reslicedImage->PropagateUpdateExtent();
-      //reslicedImage->Update();
-      //reslicedImage->GetScalarRange(range);
-
       vtkImage2DDisplay * imageDisplay = this->GetImage2DDisplayForLayer(layer);
-      imageDisplay->SetInput(reslicerOutputPort);
+      imageDisplay->SetInput(((vtkImageAlgorithm*)reslicerOutputPort->GetProducer())->GetOutput());
       imageDisplay->GetImageActor()->SetUserMatrix (this->OrientationMatrix);
       this->SetColorRange(imageDisplay->GetMedVtkImageInfo()->scalarRange, layer);
   }

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
@@ -1737,8 +1737,13 @@ void vtkImageView2D::SetFirstLayer(vtkAlgorithmOutput *pi_poInputAlgoImg, vtkMat
 {
     if(pi_poInputAlgoImg)
     {
+        // If the image is not the first one --> verif
         if( layer > 0 )
-          this->AddLayer(layer);
+        {
+            this->AddLayer(layer);
+        }
+        vtkImageAlgorithm *inputImageAlgorithm = static_cast<vtkImageAlgorithm*>(pi_poInputAlgoImg->GetProducer());
+        this->GetImage2DDisplayForLayer(layer)->SetInputProducer(inputImageAlgorithm);
 
         this->Superclass::SetInput (pi_poInputAlgoImg, matrix, 0);
         this->GetImage2DDisplayForLayer(layer)->SetInput(m_poInternalImageFromInput);
@@ -1790,7 +1795,7 @@ void vtkImageView2D::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4
   {
       SetFirstLayer( pi_poVtkAlgoOutput, matrix, layer);
   }
-  else // layer >0
+  else // layer > 0
   {
       this->AddLayer(layer);
 

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
@@ -2,7 +2,7 @@
 
  medInria
 
- Copyright (c) INRIA 2013 - 2018. All rights reserved.
+ Copyright (c) INRIA 2013 - 2020. All rights reserved.
  See LICENSE.txt for details.
 
   This software is distributed WITHOUT ANY WARRANTY; without even
@@ -11,83 +11,40 @@
 
 =========================================================================*/
 
+#include "vtkImage2DDisplay.h"
 #include "vtkImageView2D.h"
 
-#include "vtkBoundingBox.h"
-#include "vtkCamera.h"
-#include "vtkCommand.h"
-#include "vtkImageActor.h"
-#include "vtkImageData.h"
-#include "vtkImageMapToColors.h"
-#include "vtkObjectFactory.h"
-#include "vtkRenderWindow.h"
-#include "vtkRenderWindowInteractor.h"
-#include "vtkRenderer.h"
-#include "vtkMatrix4x4.h"
-#include "vtkTransform.h"
-#include "vtkScalarBarActor.h"
-#include "vtkCornerAnnotation.h"
-#include "vtkTextProperty.h"
-#include "vtkLookupTable.h"
-#include "vtkMath.h"
-#include "vtkPlane.h"
-#include "vtkCutter.h"
-#include "vtkActor.h"
-#include "vtkPolyDataMapper.h"
-#include "vtkProp3DCollection.h"
-#include "vtkDataSetCollection.h"
-#include "vtkPoints.h"
-#include "vtkIdList.h"
-#include "vtkOutlineSource.h"
-#include "vtkMatrixToLinearTransform.h"
-#include "vtkPointData.h"
-#include "vtkUnsignedCharArray.h"
-#include "vtkIntArray.h"
-#include "vtkImageAccumulate.h"
-#include "vtkCoordinate.h"
-#include "vtkTextActor.h"
-#include "vtkAxisActor2D.h"
-#include "vtkProperty.h"
-#include <vtkOrientationAnnotation.h>
-#include <vtkImageView2DCommand.h>
-#include <vtkProperty2D.h>
-#include <vtkSmartPointer.h>
-#include <vtkAxisActor2D.h>
-#include <vtkAxes2DWidget.h>
-#include <vtkRulerWidget.h>
-#include "vtkDistanceWidget.h"
-#include "vtkDistanceRepresentation2D.h"
-#include "vtkAngleWidget.h"
-#include "vtkAngleRepresentation2D.h"
-#include "vtkLeaderActor2D.h"
-#include "vtkProperty2D.h"
-#include <vtkPointHandleRepresentation2D.h>
-#include <vtkDataSet2DWidget.h>
-#include <vtkImageViewCornerAnnotation.h>
-#include <vtkImageCast.h>
-#include <vtkColorTransferFunction.h>
-#include <vtkPiecewiseFunction.h>
-#include <vtkImageReslice.h>
-#include <vtkInformation.h>
-#include <vtkStreamingDemandDrivenPipeline.h>
-
-#include <vtkTextActor3D.h>
-#include <vtkImageMapper3D.h>
-
-#include <vector>
-#include <string>
-#include <sstream>
-#include <cmath>
-
-#include <vtkImageFromBoundsSource.h>
-#include <vtkRendererCollection.h>
-#include "vtkImage2DDisplay.h"
-
-#include <vtkImageAlgorithm.h>
 #include <vtkAlgorithmOutput.h>
+#include <vtkAngleWidget.h>
+#include <vtkAngleRepresentation2D.h>
+#include <vtkAxes2DWidget.h>
+#include <vtkAxisActor2D.h>
+#include <vtkCamera.h>
+#include <vtkDataSet2DWidget.h>
+#include <vtkDataSetCollection.h>
+#include <vtkDistanceWidget.h>
+#include <vtkDistanceRepresentation2D.h>
+#include <vtkImageView2DCommand.h>
+#include <vtkImageViewCornerAnnotation.h>
+#include <vtkInformation.h>
+#include <vtkLeaderActor2D.h>
+#include <vtkMatrixToLinearTransform.h>
+#include <vtkOrientationAnnotation.h>
+#include <vtkPlane.h>
+#include <vtkPointData.h>
+#include <vtkPointSet.h>
+#include <vtkPolyData.h>
+#include <vtkProp3DCollection.h>
+#include <vtkProperty2D.h>
+#include <vtkRenderer.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
+#include <vtkRulerWidget.h>
+#include <vtkScalarBarActor.h>
+#include <vtkStreamingDemandDrivenPipeline.h>
+#include <vtkTransform.h>
 
-
-vtkStandardNewMacro(vtkImageView2D);
+vtkStandardNewMacro(vtkImageView2D)
 
 //----------------------------------------------------------------------------
 vtkImageView2D::vtkImageView2D()
@@ -1718,12 +1675,6 @@ int vtkImageView2D::GetInterpolate(int layer) const
   return iRes;
 }
 
-////----------------------------------------------------------------------------
-//void vtkImageView2D::SetTransferFunctions(vtkColorTransferFunction* color, vtkPiecewiseFunction *opacity)
-//{
-//    this->SetTransferFunctions (color, opacity, CurrentLayer);
-//}
-
 //----------------------------------------------------------------------------
 void vtkImageView2D::ApplyColorTransferFunction(vtkScalarsToColors * colors, int layer)
 {
@@ -1735,23 +1686,9 @@ void vtkImageView2D::ApplyColorTransferFunction(vtkScalarsToColors * colors, int
 
 void vtkImageView2D::SetFirstLayer(vtkAlgorithmOutput *pi_poInputAlgoImg, vtkMatrix4x4 *matrix, int layer)
 {
-    if(pi_poInputAlgoImg)
-    {
-        // If the image is not the first one --> verif
-        if( layer > 0 )
-        {
-            this->AddLayer(layer);
-        }
-        
-        this->GetImage2DDisplayForLayer(layer)->SetInputProducer(pi_poInputAlgoImg);
-
-        this->Superclass::SetInput (pi_poInputAlgoImg, matrix, 0);
-        this->GetImage2DDisplayForLayer(layer)->SetInputData(m_poInternalImageFromInput);
-        this->GetWindowLevel(layer)->SetInputConnection(pi_poInputAlgoImg);
-        double *range = this->GetImage2DDisplayForLayer(layer)->GetMedVtkImageInfo()->scalarRange;
-        this->SetColorRange(range,layer);
-        this->Reset();
-    }
+    this->GetImage2DDisplayForLayer(layer)->SetInputProducer(pi_poInputAlgoImg);
+    this->Superclass::SetInput (pi_poInputAlgoImg, matrix, 0);
+    this->GetImage2DDisplayForLayer(layer)->SetInputData(m_poInternalImageFromInput);
 }
 
 /**
@@ -1789,60 +1726,56 @@ int vtkImageView2D::GetFirstLayer() const
 /** Set/Get the input image to the viewer. */
 void vtkImageView2D::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix /*= 0*/, int layer /*= 0*/)
 {
-  vtkRenderer *renderer = 0;
+    if (pi_poVtkAlgoOutput)
+    {
+        if (layer == 0 || IsFirstLayer(layer))
+        {
+            SetFirstLayer(pi_poVtkAlgoOutput, matrix, layer);
+        }
+        else // layer > 0
+        {
+            this->AddLayer(layer);
 
-  if ( layer == 0 || IsFirstLayer(layer))
-  {
-      SetFirstLayer( pi_poVtkAlgoOutput, matrix, layer);
-  }
-  else // layer > 0
-  {
-      this->AddLayer(layer);
+            vtkAlgorithmOutput *reslicerOutputPort = this->ResliceImageToInput(pi_poVtkAlgoOutput, matrix);
+            if (!reslicerOutputPort)
+            {
+                vtkErrorMacro (<< "Could not reslice image to input");
+                return;
+            }
 
-      if (!this->GetMedVtkImageInfo() || !this->GetMedVtkImageInfo()->initialized)
-      {
-          vtkErrorMacro (<< "Set input prior to adding layers");
-          return;
-      }
+            vtkImage2DDisplay * imageDisplay = this->GetImage2DDisplayForLayer(layer);
+            imageDisplay->SetInputProducer(reslicerOutputPort);
+            imageDisplay->SetInputData(static_cast<vtkImageAlgorithm*>(reslicerOutputPort->GetProducer())->GetOutput());
+            imageDisplay->GetImageActor()->SetUserMatrix (this->OrientationMatrix);
+            this->SetColorRange(imageDisplay->GetMedVtkImageInfo()->scalarRange, layer);
+        }
 
-      vtkAlgorithmOutput *reslicerOutputPort = this->ResliceImageToInput(pi_poVtkAlgoOutput, matrix);
-      if (!reslicerOutputPort)
-      {
-          vtkErrorMacro (<< "Could not reslice image to input");
-          return;
-      }
+        this->LayerInfoVec[layer].ImageAlgo = static_cast<vtkImageAlgorithm*>(pi_poVtkAlgoOutput->GetProducer());
 
-      vtkImage2DDisplay * imageDisplay = this->GetImage2DDisplayForLayer(layer);
-      imageDisplay->SetInputData(((vtkImageAlgorithm*)reslicerOutputPort->GetProducer())->GetOutput());
-      imageDisplay->GetImageActor()->SetUserMatrix (this->OrientationMatrix);
-      this->SetColorRange(imageDisplay->GetMedVtkImageInfo()->scalarRange, layer);
-  }
+        vtkRenderer *renderer = this->GetRendererForLayer(layer);
+        if (renderer)
+        {
+            renderer->AddViewProp (this->GetImage2DDisplayForLayer(layer)->GetImageActor());
 
-  renderer = this->GetRendererForLayer(layer);
-  this->LayerInfoVec[layer].ImageAlgo = (vtkImageAlgorithm*)pi_poVtkAlgoOutput->GetProducer();
-  if (!renderer)
-    return;
+            this->SetCurrentLayer(layer);
+            this->Slice = this->GetSliceForWorldCoordinates (this->CurrentPoint);
+            this->UpdateDisplayExtent();
+            this->UpdateSlicePlane();
+            this->InvokeEvent (vtkImageView2D::SliceChangedEvent);
 
-  if ( this->GetImage2DDisplayForLayer(layer) )
-    renderer->AddViewProp (this->GetImage2DDisplayForLayer(layer)->GetImageActor());
+            // So ugly to do it, for each new layer,
+            // but it 's the only way i found so far to get the annotation correctly rendered ... - RDE
+            renderer->AddViewProp(this->CornerAnnotation);
+            renderer->AddViewProp(this->ScalarBar);
+            renderer->AddViewProp(this->OrientationAnnotation);
 
-  this->SetCurrentLayer(layer);
-  this->Slice = this->GetSliceForWorldCoordinates (this->CurrentPoint);
-  this->UpdateDisplayExtent();
-  this->UpdateSlicePlane();
-  this->InvokeEvent (vtkImageView2D::SliceChangedEvent);
-
-  // So ugly to do it, for each new layer,
-  // but it 's the only way i found so far to get the annotation correctly rendered ... - RDE
-  renderer->AddViewProp(this->CornerAnnotation);
-  renderer->AddViewProp(this->ScalarBar);
-  renderer->AddViewProp(this->OrientationAnnotation);
-
-  if(this->ShowRulerWidget)
-  {
-    this->ShowRulerWidgetOff();
-    this->ShowRulerWidgetOn();
-  }
+            if(this->ShowRulerWidget)
+            {
+                this->ShowRulerWidgetOff();
+                this->ShowRulerWidgetOn();
+            }
+        }
+    }
 }
 
 void vtkImageView2D::SetInput (vtkActor *actor, int layer, vtkMatrix4x4 *matrix, const int imageSize[], const double imageSpacing[], const double imageOrigin[])
@@ -1876,7 +1809,6 @@ void vtkImageView2D::SetInput (vtkActor *actor, int layer, vtkMatrix4x4 *matrix,
     this->SetCurrentLayer(layer);
     this->Slice = this->GetSliceForWorldCoordinates (this->CurrentPoint);
     this->UpdateDisplayExtent();
-    // this->UpdateCenter();
     this->UpdateSlicePlane();
     this->InvokeEvent (vtkImageView2D::SliceChangedEvent);
 
@@ -1921,7 +1853,7 @@ vtkImageActor *vtkImageView2D::GetImageActor(int layer) const
 //----------------------------------------------------------------------------
 medVtkImageInfo* vtkImageView2D::GetMedVtkImageInfo(int layer) const
 {
-    medVtkImageInfo* psRes = nullptr;
+    medVtkImageInfo *imageInfo = nullptr;
 
     if (layer == 0)
     {
@@ -1929,10 +1861,10 @@ medVtkImageInfo* vtkImageView2D::GetMedVtkImageInfo(int layer) const
     }
     if (this->HasLayer(layer))
     {
-        psRes = this->GetImage2DDisplayForLayer(layer)->GetMedVtkImageInfo();
+        imageInfo = this->GetImage2DDisplayForLayer(layer)->GetMedVtkImageInfo();
     }
 
-    return psRes;
+    return imageInfo;
 }
 
 //----------------------------------------------------------------------------

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
@@ -1534,24 +1534,11 @@ void vtkImageView2D::UnInstallPipeline()
 {
   if ( this->GetRenderer() )
   {
-    //this->GetRenderer()->RemoveViewProp ( this->ImageActor );
-    this->GetRenderer()->RemoveViewProp ( this->OrientationAnnotation );
-    //this->ImageActor->SetInputData (nullptr);
+      this->GetRenderer()->RemoveViewProp ( this->OrientationAnnotation );
   }
 
   if( this->InteractorStyle )
   {
-    /*
-    this->InteractorStyle->RemoveObservers(vtkImageView2DCommand::SliceMoveEvent);
-    this->InteractorStyle->RemoveObservers(vtkImageView2DCommand::RequestedPositionEvent);
-    this->InteractorStyle->RemoveObservers(vtkImageView2DCommand::ResetViewerEvent);
-    this->InteractorStyle->RemoveObservers(vtkImageView2DCommand::StartWindowLevelEvent);
-    this->InteractorStyle->RemoveObservers(vtkImageView2DCommand::WindowLevelEvent);
-    this->InteractorStyle->RemoveObservers(vtkImageView2DCommand::CharEvent);
-    this->InteractorStyle->RemoveObservers(vtkImageView2DCommand::DefaultMoveEvent);
-    this->InteractorStyle->RemoveObservers(vtkImageView2DCommand::CameraZoomEvent);
-    this->InteractorStyle->RemoveObservers(vtkImageView2DCommand::CameraPanEvent);
-    */
     this->InteractorStyle->RemoveObserver ( this->Command );
   }
 
@@ -1688,9 +1675,10 @@ void vtkImageView2D::ApplyColorTransferFunction(vtkScalarsToColors * colors, int
 
 void vtkImageView2D::SetFirstLayer(vtkAlgorithmOutput *pi_poInputAlgoImg, vtkMatrix4x4 *matrix, int layer)
 {
-    this->GetImage2DDisplayForLayer(layer)->SetInputProducer(pi_poInputAlgoImg);
+    vtkImage2DDisplay *imageDisplay = this->GetImage2DDisplayForLayer(layer);
+    imageDisplay->SetInputProducer(pi_poInputAlgoImg);
     this->Superclass::SetInput (pi_poInputAlgoImg, matrix, 0);
-    this->GetImage2DDisplayForLayer(layer)->SetInputData(m_poInternalImageFromInput);
+    imageDisplay->SetInputData(m_poInternalImageFromInput);
 }
 
 /**
@@ -1737,45 +1725,46 @@ void vtkImageView2D::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4
         else // layer > 0
         {
             this->AddLayer(layer);
-
-            vtkAlgorithmOutput *reslicerOutputPort = this->ResliceImageToInput(pi_poVtkAlgoOutput, matrix);
-            if (!reslicerOutputPort)
-            {
-                vtkErrorMacro (<< "Could not reslice image to input");
-                return;
-            }
-
-            vtkImage2DDisplay * imageDisplay = this->GetImage2DDisplayForLayer(layer);
-            imageDisplay->SetInputProducer(reslicerOutputPort);
-            imageDisplay->SetInputData(static_cast<vtkImageAlgorithm*>(reslicerOutputPort->GetProducer())->GetOutput());
-            imageDisplay->GetImageActor()->SetUserMatrix (this->OrientationMatrix);
-            this->SetColorRange(imageDisplay->GetMedVtkImageInfo()->scalarRange, layer);
+            pi_poVtkAlgoOutput = this->ResliceImageToInput(pi_poVtkAlgoOutput, matrix);
+            this->SetInputLayer(pi_poVtkAlgoOutput, matrix, layer);
         }
+        this->SetInputEnd(pi_poVtkAlgoOutput, matrix, layer);
+    }
+}
 
-        this->LayerInfoVec[layer].ImageAlgo = static_cast<vtkImageAlgorithm*>(pi_poVtkAlgoOutput->GetProducer());
+void vtkImageView2D::SetInputLayer(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix /*= 0*/, int layer /*= 0*/)
+{
+    // layer > 0
+    vtkImage2DDisplay *imageDisplay = this->GetImage2DDisplayForLayer(layer);
+    imageDisplay->SetInputProducer(pi_poVtkAlgoOutput);
+    imageDisplay->SetInputData(static_cast<vtkImageAlgorithm*>(pi_poVtkAlgoOutput->GetProducer())->GetOutput());
+    imageDisplay->GetImageActor()->SetUserMatrix (this->OrientationMatrix);
+    this->SetColorRange(imageDisplay->GetMedVtkImageInfo()->scalarRange, layer);
+}
 
-        vtkRenderer *renderer = this->GetRendererForLayer(layer);
-        if (renderer)
+void vtkImageView2D::SetInputEnd(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix /*= 0*/, int layer /*= 0*/)
+{
+    this->LayerInfoVec[layer].ImageAlgo = static_cast<vtkImageAlgorithm*>(pi_poVtkAlgoOutput->GetProducer());
+
+    vtkRenderer *renderer = this->GetRendererForLayer(layer);
+    if (renderer)
+    {
+        renderer->AddViewProp (this->GetImage2DDisplayForLayer(layer)->GetImageActor());
+
+        this->SetCurrentLayer(layer);
+        this->Slice = this->GetSliceForWorldCoordinates (this->CurrentPoint);
+        this->UpdateDisplayExtent();
+        this->UpdateSlicePlane();
+        this->InvokeEvent (vtkImageView2D::SliceChangedEvent);
+
+        renderer->AddViewProp(this->CornerAnnotation);
+        renderer->AddViewProp(this->ScalarBar);
+        renderer->AddViewProp(this->OrientationAnnotation);
+
+        if(this->ShowRulerWidget)
         {
-            renderer->AddViewProp (this->GetImage2DDisplayForLayer(layer)->GetImageActor());
-
-            this->SetCurrentLayer(layer);
-            this->Slice = this->GetSliceForWorldCoordinates (this->CurrentPoint);
-            this->UpdateDisplayExtent();
-            this->UpdateSlicePlane();
-            this->InvokeEvent (vtkImageView2D::SliceChangedEvent);
-
-            // So ugly to do it, for each new layer,
-            // but it 's the only way i found so far to get the annotation correctly rendered ... - RDE
-            renderer->AddViewProp(this->CornerAnnotation);
-            renderer->AddViewProp(this->ScalarBar);
-            renderer->AddViewProp(this->OrientationAnnotation);
-
-            if(this->ShowRulerWidget)
-            {
-                this->ShowRulerWidgetOff();
-                this->ShowRulerWidgetOn();
-            }
+            this->ShowRulerWidgetOff();
+            this->ShowRulerWidgetOn();
         }
     }
 }

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.h
@@ -130,6 +130,8 @@ public:
     // Description:
     // Set/Get the input image to the viewer.
     virtual void SetInput (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = 0, int layer = 0);
+    virtual void SetInputLayer (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = 0, int layer = 0);
+    virtual void SetInputEnd (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = 0, int layer = 0);
     virtual void SetInput (vtkActor *actor, int layer = 0, vtkMatrix4x4 *matrix = 0, const int imageSize[3] = 0, const double imageSpacing[] = 0, const double imageOrigin[] = 0);
 
     void RemoveLayerActor(vtkActor *actor, int layer = 0);

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.h
@@ -2,7 +2,7 @@
 
  medInria
 
- Copyright (c) INRIA 2013 - 2018. All rights reserved.
+ Copyright (c) INRIA 2013 - 2020. All rights reserved.
  See LICENSE.txt for details.
  
   This software is distributed WITHOUT ANY WARRANTY; without even
@@ -18,7 +18,6 @@
 
 #include <vtkImageView.h>
 #include <vtkInteractorStyleImageView2D.h>
-
 #include <vtkSmartPointer.h>
 
 #include <vector>
@@ -58,7 +57,7 @@ class vtkImageAlgorithm;
 
 
  A) SLICE_ORIENTATION enum
- the slice orientation enum has changed to match VTK : XY / XZ / YZ
+ the slice orientation enum has changed to match VTK: XY / XZ / YZ
  The axis enum is therefore of no need.
 
  B) The ImageToColor instance has been moved to ImageView (see vtkImageView.h)
@@ -66,7 +65,7 @@ class vtkImageAlgorithm;
  C) Orientation and Convention systems have been put in place,
  thus replacing the DirectionMatrix system
 
- D) The Zoom / Pan differentiation : is it needed ?
+ D) The Zoom / Pan differentiation: is it needed ?
 
  E) again here Visibility --> Show
 
@@ -76,7 +75,7 @@ class vtkImageAlgorithm;
  of the overall code. So I put it back.
  One thing remains though. Pierre differentiated the Zoom event from the Pan event,
  thus authorizing sync. of one and not the other. In the system I propose there is
- no differentiation, they are gathered in the CameraMove event. to be discussed.
+ no differentiation, they are gathered in the CameraMove event. To be discussed.
 
  G) All mouse interactions have thus been put in place.
 
@@ -133,16 +132,12 @@ public:
     virtual void SetInput (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = 0, int layer = 0);
     virtual void SetInput (vtkActor *actor, int layer = 0, vtkMatrix4x4 *matrix = 0, const int imageSize[3] = 0, const double imageSpacing[] = 0, const double imageOrigin[] = 0);
 
-
     void RemoveLayerActor(vtkActor *actor, int layer = 0);
-    
-    //int AddInput (vtkImageData *image, vtkMatrix4x4 *matrix);
 
-    virtual vtkActor* AddDataSet (vtkPointSet* arg, vtkProperty* prop = NULL);
+    virtual vtkActor* AddDataSet (vtkPointSet* arg, vtkProperty* prop = nullptr);
     virtual void RemoveDataSet (vtkPointSet *arg);
 
     medVtkImageInfo* GetMedVtkImageInfo(int layer = 0) const;
-
 
     virtual void InstallInteractor();
     virtual void UnInstallInteractor();
@@ -151,7 +146,7 @@ public:
 
     /**
    Description:
-   The orientation of the view is a abstract representation of the object
+   The orientation of the view is an abstract representation of the object
    we are looking at. It results from the acquisition plane. Setting the View
    Orientation by calling SetViewOrientation() will imply the view to set its
    inner "slice" orientation. (slice orientation == 2 means plane of acquisition.)
@@ -441,8 +436,6 @@ protected:
     // Get layer specific renderer.
     vtkImage2DDisplay * GetImage2DDisplayForLayer(int layer) const;
     vtkRenderer * GetRendererForLayer(int layer) const;
-
-
 
     //BTX
     std::list<vtkDataSet2DWidget*>::iterator FindDataSetWidget(vtkPointSet* arg);

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2DCommand.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2DCommand.cxx
@@ -42,7 +42,6 @@ vtkImageView2DCommand::~vtkImageView2DCommand()
 {
 }
 
-
 void
 vtkImageView2DCommand::Execute(vtkObject*    caller,
                                unsigned long event,
@@ -61,28 +60,22 @@ vtkImageView2DCommand::Execute(vtkObject*    caller,
     {
         this->Viewer->Reset();
         this->Viewer->Render();
-        return;
     }
     // Reset
-    if (event == vtkImageView2DCommand::ResetWindowLevelEvent)
+    else if (event == vtkImageView2DCommand::ResetWindowLevelEvent)
     {
         this->Viewer->ResetWindowLevel();
         this->Viewer->Render();
-        return;
     }
-
     // Start
-    if (event == vtkImageView2DCommand::StartWindowLevelEvent)
+    else if (event == vtkImageView2DCommand::StartWindowLevelEvent)
     {
         this->InitialWindow = this->Viewer->GetColorWindow();
         this->InitialLevel = this->Viewer->GetColorLevel();
-        return;
     }
-
     // Adjust the window level here
-    if (event == vtkImageView2DCommand::WindowLevelEvent)
+    else if (event == vtkImageView2DCommand::WindowLevelEvent)
     {
-
         int *size = this->Viewer->GetRenderWindow()->GetSize();
 
         double* range = this->Viewer->GetMedVtkImageInfo()->scalarRange;
@@ -120,10 +113,9 @@ vtkImageView2DCommand::Execute(vtkObject*    caller,
         }
 
         this->Viewer->SetColorWindowLevel(newWindow, newLevel);
-        return;
     }
-
-    if (event == vtkImageView2DCommand::CharEvent)
+    // Char Event
+    else if (event == vtkImageView2DCommand::CharEvent)
     {
         vtkRenderWindowInteractor *rwi = this->Viewer->GetRenderWindow()->GetInteractor();
 
@@ -133,72 +125,37 @@ vtkImageView2DCommand::Execute(vtkObject*    caller,
             this->Viewer->SetInterpolate ((this->Viewer->GetInterpolate(iLayer) + 1)%2, iLayer);
             this->Viewer->Render();
         }
-
-        return;
     }
-
-    // Start Slice Move
-    if (event == vtkImageView2DCommand::StartSliceMoveEvent)
-    {
-        return;
-    }
-
-    // End Slice Move
-    if (event == vtkImageView2DCommand::EndSliceMoveEvent)
-    {
-        return;
-    }
-
     // Move Slice
-    if (event == vtkImageView2DCommand::SliceMoveEvent)
+    else if (event == vtkImageView2DCommand::SliceMoveEvent)
     {
         this->Viewer->SetSlice (this->Viewer->GetSlice()+isi->GetSliceStep());
         this->Viewer->Render();
-        return;
     }
-
-    // Start Slice Move
-    if (event == vtkImageView2DCommand::StartTimeChangeEvent)
-    {
-        return;
-    }
-
-    // End Slice Move
-    if (event == vtkImageView2DCommand::EndTimeChangeEvent)
-    {
-        return;
-    }
-
     // Position requested
-    if (event == vtkImageView2DCommand::RequestedPositionEvent)
+    else if (event == vtkImageView2DCommand::RequestedPositionEvent)
     {
         double position[3];
         this->Viewer->GetWorldCoordinatesFromDisplayPosition (isi->GetRequestedPosition (), position);
         this->Viewer->SetCurrentPoint(position);
         this->Viewer->Render();
-        return;
     }
-
     // The cursor left the view, cursor position needs to be reset
-    if (event == vtkCommand::LeaveEvent)
+    else if (event == vtkCommand::LeaveEvent)
     {
         this->Viewer->UpdateCursorPosition(this->Viewer->GetCurrentPoint());
         this->Viewer->Render();
-        return;
     }
-
     // Cursor Position requested
-    if (event == vtkImageView2DCommand::RequestedCursorInformationEvent)
+    else if (event == vtkImageView2DCommand::RequestedCursorInformationEvent)
     {
         double position[3];
         this->Viewer->GetWorldCoordinatesFromDisplayPosition (isi->GetRequestedPosition (), position);
         this->Viewer->vtkImageView::UpdateCursorPosition(position);
         this->Viewer->Render();
-        return;
     }
-
-    // default move : align cursor and update annotation accordingly
-    if( event == vtkImageView2DCommand::DefaultMoveEvent)
+    // default move: align cursor and update annotation accordingly
+    else if( event == vtkImageView2DCommand::DefaultMoveEvent)
     {
         vtkRenderWindowInteractor *rwi = this->Viewer->GetInteractor();
         if (!rwi)
@@ -210,25 +167,38 @@ vtkImageView2DCommand::Execute(vtkObject*    caller,
         this->Viewer->SetCurrentPoint(position);
         if (isi->GetState() == VTKIS_NONE)
             this->Viewer->Render();
-
-        return;
     }
-
     // Zooming
-    if (event == vtkImageView2DCommand::CameraZoomEvent)
+    else if (event == vtkImageView2DCommand::CameraZoomEvent)
     {
         this->Viewer->Modified();
-        return;
     }
-
     // Panning
-    if (event == vtkImageView2DCommand::CameraPanEvent)
+    else if (event == vtkImageView2DCommand::CameraPanEvent)
     {
         this->Viewer->Modified();
-        return;
-
     }
 
+    // Start Slice Move
+//    else if (event == vtkImageView2DCommand::StartTimeChangeEvent)
+//    {
+//        return;
+//    }
+
+//    // End Slice Move
+//    else if (event == vtkImageView2DCommand::EndTimeChangeEvent)
+//    {
+//        return;
+//    }
+//    // Start Slice Move
+//    else if (event == vtkImageView2DCommand::StartSliceMoveEvent)
+//    {
+//        return;
+//    }
+
+//    // End Slice Move
+//    else if (event == vtkImageView2DCommand::EndSliceMoveEvent)
+//    {
+//        return;
+//    }
 }
-
-

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -477,7 +477,7 @@ void vtkImageView3D::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4
     if(pi_poVtkAlgoOutput)
     {
         this->Superclass::SetInput (pi_poVtkAlgoOutput, matrix, layer);
-        this->GetImage3DDisplayForLayer(0)->SetInputConnection(pi_poVtkAlgoOutput);
+        this->GetImage3DDisplayForLayer(0)->SetInputData(m_poInternalImageFromInput);
 
         double *range = vtkImgTmp->GetScalarRange();
         this->SetColorRange(range,0);
@@ -548,7 +548,7 @@ void vtkImageView3D::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4
 
     this->AddLayer (layer);
 
-    this->GetImage3DDisplayForLayer(layer)->SetInputConnection (poVtkAlgoOutputTmp);
+    this->GetImage3DDisplayForLayer(layer)->SetInputProducer(poVtkAlgoOutputTmp);
 
     // set default display properties
     this->VolumeProperty->SetShade(layer, 1);
@@ -598,7 +598,7 @@ void vtkImageView3D::InternalUpdate()
         {
             if (!it->ImageDisplay->GetVtkImageInfo() || !it->ImageDisplay->GetVtkImageInfo()->initialized)
                 continue;
-            appender->AddInputConnection(it->ImageDisplay->GetOutputPort());
+            appender->AddInputConnection(it->ImageDisplay->GetInputProducer()->GetOutputPort());
         }
         if (this->LayerInfoVec.size()>1)
         {

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -607,21 +607,11 @@ void vtkImageView3D::InternalUpdate()
     }
     appender->Update();
     appender->GetOutput();
-    // hack: modify the input MTime such that it is higher
-    // than the VolumeMapper's one to force it to refresh
-    // (see vtkSmartVolumeMapper::ConnectMapperInput(vtkVolumeMapper *m))
-    /*
-    if (this->VolumeMapper->GetInput())
-    {
-        unsigned long mtime = this->VolumeMapper->GetInput()->GetMTime();
-        while (input->GetMTime()<=mtime)
-            input->Modified();
-    }
-    */
+
     this->VolumeMapper->SetInputConnection( appender->GetOutputPort());
     this->VolumeMapper->Update();
     this->VolumeMapper->Modified();
-    //appender->Delete();
+
     // If an image is already of type unsigned char, there is no need to
     // map it through a lookup table
     if ( !multiLayers && multichannelInput )
@@ -879,30 +869,6 @@ void vtkImageView3D::SetRenderingMode(int arg)
     item = this->ExtraPlaneCollection->GetNextProp3D();
   }
 }
-
-// //---------------------------------------------------------------------------
-// void vtkImageView3D::SetUseVRQuality (bool on)
-// {
-//   this->VolumeMapper->SetUseVRQuality( on );
-// }
-
-// //---------------------------------------------------------------------------
-// bool vtkImageView3D::GetUseVRQuality ()
-// {
-//   return this->VolumeMapper->GetUseVRQuality();
-// }
-
-// //---------------------------------------------------------------------------
-// void vtkImageView3D::SetVRQuality (float vrq)
-// {
-//   this->VolumeMapper->SetVRQuality( vrq );
-// }
-
-// //---------------------------------------------------------------------------
-// float vtkImageView3D::GetVRQuality ()
-// {
-//   return this->VolumeMapper->GetVRQuality();
-// }
 
 //---------------------------------------------------------------------------
 void vtkImageView3D::SetOrientationMarker(vtkActor *actor)

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -143,13 +143,17 @@ vtkMTimeType vtkImageView3D::GetMTime()
 
   const int numObjects = sizeof(objectsToInclude) / sizeof(vtkObject *);
 
-  for ( int i(0); i<numObjects; ++i ) {
-    vtkObject * object = objectsToInclude[i];
-    if (object) {
-      const vtkMTimeType testMtime = object->GetMTime();
-      if ( testMtime > mTime )
-    mTime = testMtime;
-    }
+  for ( int i(0); i<numObjects; ++i )
+  {
+      vtkObject * object = objectsToInclude[i];
+      if (object)
+      {
+          const vtkMTimeType testMtime = object->GetMTime();
+          if ( testMtime > mTime )
+          {
+              mTime = testMtime;
+          }
+      }
   }
 
   this->ExtraPlaneCollection->InitTraversal();
@@ -505,26 +509,14 @@ void vtkImageView3D::InternalUpdate()
     bool multichannelInput = (this->m_poInternalImageFromInput->GetScalarType() == VTK_UNSIGNED_CHAR &&
                               (this->m_poInternalImageFromInput->GetNumberOfScalarComponents() == 3 ||
                                this->m_poInternalImageFromInput->GetNumberOfScalarComponents() == 4 ));
-    if(this->GetMedVtkImageInfo() == nullptr || !this->GetMedVtkImageInfo()->initialized)
-    {
-        this->Renderer->RemoveAllViewProps();
-        //TODO apparently RemoveAllViewProps() is not enough, though it should be
-        this->ActorX->GetMapper()->SetInputConnection(nullptr);
-        this->ActorY->GetMapper()->SetInputConnection(nullptr);
-        this->ActorZ->GetMapper()->SetInputConnection(nullptr);
-        this->Render();
-        return;
-    }
+
     vtkImageAppendComponents *appender = vtkImageAppendComponents::New();
     if (this->LayerInfoVec.size()>0 && !multichannelInput)
     {
         // append all scalar buffer into the same image
-        for( LayerInfoVecType::const_iterator it = this->LayerInfoVec.begin();
-             it!=this->LayerInfoVec.end(); ++it)
+        for (auto it : this->LayerInfoVec)
         {
-            if (!it->ImageDisplay->GetMedVtkImageInfo() || !it->ImageDisplay->GetMedVtkImageInfo()->initialized)
-                continue;
-            appender->AddInputConnection(it->ImageDisplay->GetInputProducer()->GetOutputPort());
+            appender->AddInputConnection(it.ImageDisplay->GetInputProducer()->GetOutputPort());
         }
         if (this->LayerInfoVec.size()>1)
         {

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -476,6 +476,7 @@ void vtkImageView3D::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4
 
     if(pi_poVtkAlgoOutput)
     {
+        this->GetImage3DDisplayForLayer(0)->SetInputProducer(pi_poVtkAlgoOutput);
         this->Superclass::SetInput (pi_poVtkAlgoOutput, matrix, layer);
         this->GetImage3DDisplayForLayer(0)->SetInputData(m_poInternalImageFromInput);
 

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -2,7 +2,7 @@
 
  medInria
 
- Copyright (c) INRIA 2013 - 2018. All rights reserved.
+ Copyright (c) INRIA 2013 - 2020. All rights reserved.
  See LICENSE.txt for details.
  
   This software is distributed WITHOUT ANY WARRANTY; without even
@@ -11,75 +11,42 @@
 
 =========================================================================*/
 
+#include "vtkImage3DDisplay.h"
 #include "vtkImageView3D.h"
 
 #ifndef VTK_MAJOR_VERSION
 #  include "vtkVersion.h"
 #endif
 
-#include <vtkBoundingBox.h>
+#include <vtkActor.h>
+#include <vtkAnnotatedCubeActor.h>
+#include <vtkColorTransferFunction.h>
+#include <vtkDataSetCollection.h>
+#include <vtkDataSetSurfaceFilter.h>
+#include <vtkImageActor.h>
+#include <vtkImageAppendComponents.h>
+#include <vtkImageCast.h>
+#include <vtkImageMapper3D.h>
+#include <vtkImageMapToColors.h>
 #include <vtkInteractorStyleTrackball.h>
+#include <vtkPiecewiseFunction.h>
+#include <vtkPointSet.h>
+#include <vtkPolyDataMapper.h>
+#include <vtkPolyDataNormals.h>
+#include <vtkProp3DCollection.h>
+#include <vtkProperty.h>
+#include <vtkRenderer.h>
+#include <vtkRenderWindow.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkRendererCollection.h>
-#include <vtkImageData.h>
-#include <vtkPiecewiseFunction.h>
-#include <vtkColorTransferFunction.h>
-#include <vtkFiniteDifferenceGradientEstimator.h>
-#include <vtkProperty.h>
-#include <vtkVolume.h>
-#include <vtkImageMapToWindowLevelColors.h>
-#include <vtkImageDataGeometryFilter.h>
-#include <vtkPolyDataMapper.h>
-#include <vtkImageActor.h>
-#include <vtkAxes.h>
-#include <vtkMatrix4x4.h>
-#include <vtkTubeFilter.h>
-#include <vtkLookupTable.h>
-#include <vtkAnnotatedCubeActor.h>
-#include <vtkPropAssembly.h>
-#include <vtkAxesActor.h>
+#include <vtkSmartVolumeMapper.h>
 #include <vtkTextProperty.h>
-#include <vtkCaptionActor2D.h>
-#include <vtkPointData.h>
-#include <vtkImageReslice.h>
-#include "vtkRenderWindow.h"
-#include "vtkScalarsToColors.h"
-#include <vtkCamera.h>
-#include <vtkDataSet.h>
-#include <vtkDataSetMapper.h>
-#include <vtkPlane.h>
-#include <vtkPlaneCollection.h>
-#include <vtkGeometryFilter.h>
-#include <vtkDataSetSurfaceFilter.h>
-#include <vtkPolyDataNormals.h>
-#include <vtkCellData.h>
-#include <vtkMath.h>
-#include <vtkOrientedBoxWidget.h>
-#include <vtkPlaneWidget.h>
-#include <vtkOrientationMarkerWidget.h>
-#include <vtkVolumeProperty.h>
-#include <vtkImageMapToColors.h>
-#include "vtkScalarBarActor.h"
-#include "vtkSmartVolumeMapper.h"
-#include <vtkImageAppendComponents.h>
-#include <vtkImageAppend.h>
-#include <vtkImageCast.h>
-#include <vtkSmartPointer.h>
-#include <vtkDataSetCollection.h>
-#include <vtkProp3DCollection.h>
-#include <vtkImageMapper3D.h>
 
-#include <vtkAlgorithmOutput.h>
-#include <vtkImageAlgorithm.h>
-#include "vtkImage3DDisplay.h"
-
-
-vtkStandardNewMacro(vtkImageView3D);
+vtkStandardNewMacro(vtkImageView3D)
 
 //----------------------------------------------------------------------------
 vtkImageView3D::vtkImageView3D()
 {
-
   this->VolumeProperty  = vtkVolumeProperty::New();
   this->VolumeActor     = vtkVolume::New();
 
@@ -386,7 +353,6 @@ void vtkImageView3D::SetupWidgets()
   this->BoxWidget->AddObserver (vtkCommand::InteractionEvent, this->Callback);
 
   this->PlaneWidget->SetKeyPressActivationValue ('p');
-  //   this->PlaneWidget->NormalToZAxisOn();
 }
 
 //----------------------------------------------------------------------------
@@ -408,7 +374,6 @@ void vtkImageView3D::UnInstallPipeline()
 {
   if (this->Renderer)
   {
-    //this->Renderer->RemoveViewProp (this->VolumeActor);
     this->Renderer->RemoveViewProp (this->ActorX);
     this->Renderer->RemoveViewProp (this->ActorY);
     this->Renderer->RemoveViewProp (this->ActorZ);
@@ -466,110 +431,71 @@ void vtkImageView3D::UnInstallInteractor()
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix /*= 0*/, int layer /*= 0*/)
 {
-  vtkImageData *vtkImgTmp = ((vtkImageAlgorithm*)pi_poVtkAlgoOutput->GetProducer())->GetOutput();
-  if(layer==0)
-  {
-    if (this->GetMedVtkImageInfo() && this->GetMedVtkImageInfo()->initialized)
-    {
-      this->RemoveAllLayers();
-    }
-
     if(pi_poVtkAlgoOutput)
     {
-        this->GetImage3DDisplayForLayer(0)->SetInputProducer(pi_poVtkAlgoOutput);
-        this->Superclass::SetInput (pi_poVtkAlgoOutput, matrix, layer);
-        this->GetImage3DDisplayForLayer(0)->SetInputData(m_poInternalImageFromInput);
+        if(layer == 0)
+        {
+            SetFirstLayer( pi_poVtkAlgoOutput, matrix, layer);
+        }
 
-        double *range = vtkImgTmp->GetScalarRange();
-        this->SetColorRange(range,0);
-        this->VolumeProperty->SetShade(0, 1);
-        this->VolumeProperty->SetComponentWeight(0, 1.0);
-        vtkColorTransferFunction *rgb   = this->GetDefaultColorTransferFunction();
-        vtkPiecewiseFunction     *alpha = this->GetDefaultOpacityTransferFunction();
+        int * w_extent = this->GetMedVtkImageInfo()->extent;
+        int size [3] = { w_extent [1] - w_extent[0], w_extent [3] - w_extent[2], w_extent [5] - w_extent[4] };
 
-        this->SetTransferFunctions (rgb, alpha, 0);
-        rgb->Delete();
-        alpha->Delete();
+        if ( (size[0] < 2) ||(size[1] < 2) || (size[2] < 2) )
+        {
+            vtkWarningMacro ( <<"Cannot do volume rendering for a single slice, skipping"<<endl);
+            this->ActorX->GetMapper()->SetInputConnection (nullptr);
+            this->ActorY->GetMapper()->SetInputConnection (nullptr);
+            this->ActorZ->GetMapper()->SetInputConnection (nullptr);
+
+            this->VolumeMapper->SetInputConnection(nullptr);
+            this->BoxWidget->SetInputConnection (nullptr);
+            this->PlaneWidget->SetInputConnection(nullptr);
+
+            return;
+        }
+
+        if (layer>0 && layer<4)
+        {
+            // reslice input image if needed
+            vtkAlgorithmOutput *poReslicerOutput = this->ResliceImageToInput(pi_poVtkAlgoOutput, matrix);
+            if (!poReslicerOutput)
+            {
+                vtkErrorMacro (<< "Could not reslice image to input");
+                return;
+            }
+
+            vtkAlgorithmOutput *poVtkAlgoOutputTmp = poReslicerOutput;
+            // cast it if needed
+            if (static_cast<vtkImageAlgorithm*>(poReslicerOutput->GetProducer())->GetOutput()->GetScalarType()
+                    != this->GetMedVtkImageInfo()->scalarType)
+            {
+                vtkImageCast *cast = vtkImageCast::New();
+                cast->SetInputConnection(poReslicerOutput);
+                cast->SetOutputScalarType (this->GetMedVtkImageInfo()->scalarType);
+                cast->Update();
+
+                poVtkAlgoOutputTmp = cast->GetOutputPort();
+            }
+
+            this->AddLayer(layer);
+            this->GetImage3DDisplayForLayer(layer)->SetInputProducer(poVtkAlgoOutputTmp);
+        }
+        else if (layer >= 4)
+        {
+            vtkErrorMacro( <<"Only 4 layers are supported in 3D fusion" );
+            return;
+        }
+
+        this->InternalUpdate();
     }
-  }
+}
 
-  if( !pi_poVtkAlgoOutput)
-  {
-    return;
-  }
-
-  // Get whole extent : More reliable than dimensions if not up-to-date.
-  int * w_extent = vtkImgTmp->GetExtent();
-
-  int size [3] = { w_extent [1] - w_extent[0], w_extent [3] - w_extent[2], w_extent [5] - w_extent[4] };
-
-  if ( (size[0] < 2) ||(size[1] < 2) || (size[2] < 2) )
-  {
-    vtkWarningMacro ( <<"Cannot do volume rendering for a single slice, skipping"<<endl);
-    this->ActorX->GetMapper()->SetInputConnection (nullptr);
-    this->ActorY->GetMapper()->SetInputConnection (nullptr);
-    this->ActorZ->GetMapper()->SetInputConnection (nullptr);
-
-    this->VolumeMapper->SetInputConnection(nullptr);
-    this->BoxWidget->SetInputConnection (nullptr);
-    this->PlaneWidget->SetInputConnection(nullptr);
-
-    return;
-  }
-
-  // bool multiLayers = false;
-
-  if (layer>0 && layer<4)
-  {
-    if (!this->GetMedVtkImageInfo() || !this->GetMedVtkImageInfo()->initialized)
-    {
-      vtkErrorMacro (<< "Set input prior to adding layers");
-      return;
-    }
-
-    // reslice input image if needed
-    vtkAlgorithmOutput *poReslicerOutput = this->ResliceImageToInput(pi_poVtkAlgoOutput, matrix);
-    if (!poReslicerOutput)
-    {
-      vtkErrorMacro (<< "Could not reslice image to input");
-      return;
-    }
-
-    vtkAlgorithmOutput *poVtkAlgoOutputTmp = poReslicerOutput;
-    // cast it if needed
-    if (static_cast<vtkImageAlgorithm*>(poReslicerOutput->GetProducer())->GetOutput()->GetScalarType()!=this->GetMedVtkImageInfo()->scalarType)
-    {
-      vtkImageCast *cast = vtkImageCast::New();
-      cast->SetInputConnection(poReslicerOutput);
-      cast->SetOutputScalarType (this->GetMedVtkImageInfo()->scalarType);
-      cast->Update();
-
-      poVtkAlgoOutputTmp = cast->GetOutputPort();
-    }
-
-    this->AddLayer (layer);
-
-    this->GetImage3DDisplayForLayer(layer)->SetInputProducer(poVtkAlgoOutputTmp);
-
-    // set default display properties
-    this->VolumeProperty->SetShade(layer, 1);
-    this->VolumeProperty->SetComponentWeight(layer, 1.0);
-
-    vtkColorTransferFunction *rgb   = this->GetDefaultColorTransferFunction();
-    vtkPiecewiseFunction     *alpha = this->GetDefaultOpacityTransferFunction();
-
-    this->SetTransferFunctions (rgb, alpha, layer);
-
-    rgb->Delete();
-    alpha->Delete();
-  }
-  else if (layer >=4)
-  {
-    vtkErrorMacro( <<"Only 4 layers are supported in 3D fusion" );
-    return;
-  }
-
-  this->InternalUpdate();
+void vtkImageView3D::SetFirstLayer(vtkAlgorithmOutput *pi_poInputAlgoImg, vtkMatrix4x4 *matrix, int layer)
+{
+    this->GetImage3DDisplayForLayer(0)->SetInputProducer(pi_poInputAlgoImg);
+    this->Superclass::SetInput (pi_poInputAlgoImg, matrix, layer);
+    this->GetImage3DDisplayForLayer(0)->SetInputData(m_poInternalImageFromInput);
 }
 
 //----------------------------------------------------------------------------
@@ -593,11 +519,10 @@ void vtkImageView3D::InternalUpdate()
     if (this->LayerInfoVec.size()>0 && !multichannelInput)
     {
         // append all scalar buffer into the same image
-        //vtkImageAppendComponents *appender = vtkImageAppendComponents::New();
         for( LayerInfoVecType::const_iterator it = this->LayerInfoVec.begin();
              it!=this->LayerInfoVec.end(); ++it)
         {
-            if (!it->ImageDisplay->GetVtkImageInfo() || !it->ImageDisplay->GetVtkImageInfo()->initialized)
+            if (!it->ImageDisplay->GetMedVtkImageInfo() || !it->ImageDisplay->GetMedVtkImageInfo()->initialized)
                 continue;
             appender->AddInputConnection(it->ImageDisplay->GetInputProducer()->GetOutputPort());
         }
@@ -630,17 +555,14 @@ void vtkImageView3D::InternalUpdate()
         this->VolumeProperty->IndependentComponentsOn();
         this->VolumeProperty->ShadeOn();
         this->PlanarWindowLevelX->SetInputConnection(this->m_poInputVtkAlgoOutput);
-        //this->PlanarWindowLevelX->SetInputData(this->m_poInternalImageFromInput);
         this->PlanarWindowLevelX->SetOutputFormatToRGB();
         this->PlanarWindowLevelX->UpdateInformation();
         this->PlanarWindowLevelX->Update();
         this->PlanarWindowLevelY->SetInputConnection(this->m_poInputVtkAlgoOutput);
-        //this->PlanarWindowLevelY->SetInputData(this->m_poInternalImageFromInput);
         this->PlanarWindowLevelY->SetOutputFormatToRGB();
         this->PlanarWindowLevelY->UpdateInformation();
         this->PlanarWindowLevelY->Update();
         this->PlanarWindowLevelZ->SetInputConnection(this->m_poInputVtkAlgoOutput);
-        //this->PlanarWindowLevelZ->SetInputData(this->m_poInternalImageFromInput);
         this->PlanarWindowLevelZ->SetOutputFormatToRGB();
         this->PlanarWindowLevelZ->UpdateInformation();
         this->PlanarWindowLevelZ->Update();
@@ -696,24 +618,25 @@ void vtkImageView3D::SetTransferFunctions (vtkColorTransferFunction * color,
                                            vtkPiecewiseFunction * opacity,
                                            int layer)
 {
-  if (this->HasLayer (layer))
-  {
-    if (!this->GetImage3DDisplayForLayer(layer)->GetVtkImageInfo())
-      return;
-    double *range = this->GetImage3DDisplayForLayer(layer)->GetVtkImageInfo()->scalarRange;
-    this->SetTransferFunctionRangeFromWindowSettings(color, opacity, range[0], range[1]);
-    this->VolumeProperty->SetColor(layer, color );
-
-    this->VolumeProperty->SetScalarOpacity(layer, opacity );
-    if (layer == 0)
+    if (this->HasLayer (layer))
     {
-       //update planar window level only if we change layer 0
-       this->PlanarWindowLevelX->SetLookupTable(color);
-       this->PlanarWindowLevelY->SetLookupTable(color);
-       this->PlanarWindowLevelZ->SetLookupTable(color);
-    }
-  }
+        if (this->GetImage3DDisplayForLayer(layer)->GetMedVtkImageInfo())
+        {
+            double *range = this->GetImage3DDisplayForLayer(layer)->GetMedVtkImageInfo()->scalarRange;
+            this->SetTransferFunctionRangeFromWindowSettings(color, opacity, range[0], range[1]);
 
+            this->VolumeProperty->SetColor(layer, color );
+            this->VolumeProperty->SetScalarOpacity(layer, opacity );
+
+            if (layer == 0)
+            {
+                //update planar window level only if we change layer 0
+                this->PlanarWindowLevelX->SetLookupTable(color);
+                this->PlanarWindowLevelY->SetLookupTable(color);
+                this->PlanarWindowLevelZ->SetLookupTable(color);
+            }
+        }
+    }
 }
 
 //----------------------------------------------------------------------------
@@ -799,7 +722,6 @@ void vtkImageView3D::SetColorLevel (double s,int layer)
   }
 }
 
-
 //----------------------------------------------------------------------------
 void vtkImageView3D::UpdateVolumeFunctions(int layer)
 {
@@ -820,7 +742,6 @@ void vtkImageView3D::UpdateVolumeFunctions(int layer)
   color->RemoveAllPoints();
   opacity->RemoveAllPoints();
 
-  // this->OpacityFunction->AddPoint (0.0,  0.0);
   for ( int i = 0; i < numColors; ++i )
   {
     double x = range[0] + factor * static_cast< double >( i ) * width;
@@ -942,8 +863,7 @@ unsigned int vtkImageView3D::GetCroppingMode()
 void vtkImageView3D::SetCurrentPoint (double pos[3])
 {
   this->Superclass::SetCurrentPoint (pos);
-  //if (this->GetRenderingMode() == vtkImageView3D::PLANAR_RENDERING) // No! Because
-  // if suddenly you switch from VR to MPR, you are screwed
+
   this->UpdateDisplayExtent();
 }
 
@@ -1068,11 +988,19 @@ int vtkImageView3D::GetNumberOfLayers() const
     // so we need one more check to know the real number of layer
     if( this->LayerInfoVec.size() == 1)
     {
-        if( this->LayerInfoVec.at(0).ImageDisplay->GetVtkImageInfo() == nullptr)
+        if( this->LayerInfoVec.at(0).ImageDisplay->GetMedVtkImageInfo() == nullptr)
+        {
             return 0;
-        else return 1;
+        }
+        else
+        {
+            return 1;
+        }
     }
-    else return static_cast<int>(this->LayerInfoVec.size());
+    else
+    {
+        return static_cast<int>(this->LayerInfoVec.size());
+    }
 }
 
 //----------------------------------------------------------------------------
@@ -1146,10 +1074,8 @@ void vtkImageView3D::ApplyColorTransferFunction(vtkScalarsToColors * colors, int
   return;
 }
 
-
 vtkColorTransferFunction * vtkImageView3D::GetColorTransferFunction(int layer) const
 {
-
   if (this->HasLayer(layer))
     //warning if it does not exist, a default one is created.
     return this->VolumeProperty->GetRGBTransferFunction(layer);
@@ -1254,8 +1180,13 @@ void vtkImageView3D::StoreLookupTable(vtkLookupTable *lookuptable, int layer)
 
 medVtkImageInfo* vtkImageView3D::GetMedVtkImageInfo(int layer /*= 0*/) const
 {
-  vtkImage3DDisplay * imageDisplay = this->GetImage3DDisplayForLayer(layer);
-  if (!imageDisplay)
-    return nullptr;
-  return imageDisplay->GetVtkImageInfo();
+    vtkImage3DDisplay * imageDisplay = this->GetImage3DDisplayForLayer(layer);
+    medVtkImageInfo *imageInfo = nullptr;
+
+    if (imageDisplay)
+    {
+        imageInfo = imageDisplay->GetMedVtkImageInfo();
+    }
+
+    return imageInfo;
 }

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -376,6 +376,7 @@ void vtkImageView3D::InstallPipeline()
 //----------------------------------------------------------------------------
 void vtkImageView3D::UnInstallPipeline()
 {
+    std::cout<<"### vtkImageView3D::UnInstallPipeline"<<std::endl;
   if (this->Renderer)
   {
     this->Renderer->RemoveViewProp (this->ActorX);
@@ -414,18 +415,19 @@ void vtkImageView3D::InstallInteractor()
 //----------------------------------------------------------------------------
 void vtkImageView3D::UnInstallInteractor()
 {
+    std::cout<<"### vtkImageView3D::UnInstallInteractor"<<std::endl;
     this->BoxWidget->SetInteractor (nullptr);
     this->PlaneWidget->SetInteractor (nullptr);
     this->Marker->SetInteractor (nullptr);
 
     if (this->Interactor)
     {
-        auto poRenderer = this->Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer();
-        while (poRenderer)
-        {
-            this->RenderWindow->RemoveRenderer(poRenderer);
-            poRenderer = this->Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer();
-        }
+//        auto poRenderer = this->Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer();
+//        while (poRenderer)
+//        {
+//            this->RenderWindow->RemoveRenderer(poRenderer);
+//            poRenderer = this->Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer();
+//        }
         this->Interactor->SetRenderWindow (nullptr);
         this->Interactor->SetInteractorStyle (nullptr);
     }

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
@@ -67,7 +67,7 @@ public:
 
     // Rendeing Modes available.
     // PLANAR_RENDERING will render every vtkImageActor instance added with Add2DPhantom()
-    // whereas VOLUME_RENDERING will render the volume added with SetInput().
+    // whereas VOLUME_RENDERING will render the volume added with SetInputData().
     //BTX
     enum RenderingModeIds
     {

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
@@ -142,6 +142,8 @@ public:
     virtual unsigned int GetCroppingMode ();
 
     virtual void SetInput (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = 0, int layer = 0);
+    virtual void test3D (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = 0, int layer = 0);
+    virtual void SetInputLayer (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = 0, int layer = 0);
     void SetFirstLayer(vtkAlgorithmOutput *pi_poInputAlgoImg, vtkMatrix4x4 *matrix, int layer);
 
     virtual void SetOrientationMatrix (vtkMatrix4x4* matrix);

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
@@ -2,7 +2,7 @@
 
  medInria
 
- Copyright (c) INRIA 2013 - 2018. All rights reserved.
+ Copyright (c) INRIA 2013 - 2020. All rights reserved.
  See LICENSE.txt for details.
  
   This software is distributed WITHOUT ANY WARRANTY; without even
@@ -15,18 +15,12 @@
 
 #include <medVtkInriaExport.h>
 
-#include <vector>
-
 #include <vtkImageView.h>
-#include <vtkOrientedBoxWidget.h>
-
-#include <vtkPlaneWidget.h>
-#include <vtkVolume.h>
 #include <vtkImageView3DCroppingBoxCallback.h>
 #include <vtkOrientationMarkerWidget.h>
+#include <vtkOrientedBoxWidget.h>
+#include <vtkPlaneWidget.h>
 #include <vtkVolumeProperty.h>
-#include <vtkSmartPointer.h>
-
 
 class vtkVolume;
 class vtkPiecewiseFunction;
@@ -52,7 +46,7 @@ class vtkProp3DCollection;
 
    This class allows to view 3D images. Images have to be
    vtkImageData.
-   volume rendering and mulptiplane reconstructions are provided
+   volume rendering and multiplane reconstructions are provided
    remote plan can also be used, so can be an orientation cube, ...
 */
 
@@ -65,7 +59,7 @@ public:
 
     vtkMTimeType GetMTime();
 
-    // Rendeing Modes available.
+    // Rendering Modes available.
     // PLANAR_RENDERING will render every vtkImageActor instance added with Add2DPhantom()
     // whereas VOLUME_RENDERING will render the volume added with SetInputData().
     //BTX
@@ -148,7 +142,8 @@ public:
     virtual unsigned int GetCroppingMode ();
 
     virtual void SetInput (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = 0, int layer = 0);
-    //virtual void AddInput (vtkImageData* input, vtkMatrix4x4 *matrix = 0);
+    void SetFirstLayer(vtkAlgorithmOutput *pi_poInputAlgoImg, vtkMatrix4x4 *matrix, int layer);
+
     virtual void SetOrientationMatrix (vtkMatrix4x4* matrix);
 
     using vtkImageView::SetColorWindow;
@@ -169,7 +164,6 @@ public:
 
     virtual void SetVisibility(int visibility, int layer);
     virtual int  GetVisibility(int layer) const;
-
 
     virtual void SetShowActorX (unsigned int);
     vtkGetMacro (ShowActorX, unsigned int);
@@ -279,9 +273,9 @@ protected:
     unsigned int ShowActorY;
     unsigned int ShowActorZ;
 
-    int          LastNodeIndex;
+    int LastNodeIndex;
 
-    int          CroppingMode;
+    int  CroppingMode;
 
     double Opacity;
     int Visibility;

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImage4DInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImage4DInteractor.cpp
@@ -117,8 +117,8 @@ void medVtkViewItkDataImage4DInteractor::setInputData(medAbstractData *data)
             d->imageData->setMetaData("SequenceDuration", QString::number(m_poConv->getTotalTime()));
             d->imageData->setMetaData("SequenceFrameRate", QString::number((double)(m_poConv->getNumberOfVolumes() -1 )/ (double)m_poConv->getTotalTime()));
 
-            dtkDebug() << "SequenceDuration" << m_poConv->getTotalTime();
-            dtkDebug() << "SequenceFrameRate" <<(double)(m_poConv->getNumberOfVolumes() -1)/ m_poConv->getTotalTime();
+            qDebug() << "SequenceDuration" << m_poConv->getTotalTime();
+            qDebug() << "SequenceFrameRate" <<(double)(m_poConv->getNumberOfVolumes() -1)/ m_poConv->getTotalTime();
 
             d->view2d->GetImageActor(d->view2d->GetCurrentLayer())->GetProperty()->SetInterpolationTypeToCubic();
             initParameters(d->imageData);

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
@@ -525,8 +525,8 @@ void medVtkViewItkDataImageInteractor::setWindowLevelFromMinMax()
         //--- block
         this->windowLevelParameter()->blockSignals(true);
 
-        // Call function from vtkImageView shared by view2d and view3d
         d->view2d->SetColorWindowLevel(window, level, imageLayer);
+        d->view3d->SetColorWindowLevel(window, level, imageLayer);
 
         this->windowLevelParameter()->blockSignals(false);
         //--- unblock
@@ -598,8 +598,8 @@ void medVtkViewItkDataImageInteractor::moveToSlice(int slice)
 
 void medVtkViewItkDataImageInteractor::update()
 {
-    // Call function from vtkImageView shared by view2d and view3d
     d->view2d->Render();
+    d->view3d->Render();
 }
 
 void medVtkViewItkDataImageInteractor::updateWidgets()
@@ -635,8 +635,8 @@ void medVtkViewItkDataImageInteractor::updateImageViewInternalLayer()
 
     if( imageLayer == d->view->currentLayer() )
     {
-        // Call function from vtkImageView shared by view2d and view3d
         d->view2d->SetCurrentLayer(imageLayer);
+        d->view3d->SetCurrentLayer(imageLayer);
     }
 }
 

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
@@ -169,28 +169,31 @@ void medVtkViewItkDataImageInteractor::setInputData(medAbstractData *data)
 {
     medAbstractInteractor::setInputData(data);
     d->imageData = dynamic_cast<medAbstractImageData *>(data);
-    if(!d->imageData)
-        return;
-
-    if (!SetViewInput (data, d->view->layer(data)))
+    if(d->imageData)
     {
-        qDebug() << "Unable to add data: " << data->identifier() << " to view " << this->identifier();
-        return;
+        if (!SetViewInput (data, d->view->layer(data)))
+        {
+            qDebug() << "Unable to add data: " << data->identifier() << " to view " << this->identifier();
+            return;
+        }
+
+        if( d->imageData->PixelType() == typeid(double) || d->imageData->PixelType() == typeid(float) )
+        {
+            d->isFloatImage = true;
+        }
+
+        initParameters(d->imageData);
+
+        double* range = d->view2d->GetScalarRange(d->view->layer(d->imageData));
+        this->initWindowLevelParameters(range);
     }
-
-    if( d->imageData->PixelType() == typeid(double) || d->imageData->PixelType() == typeid(float) )
-        d->isFloatImage = true;
-
-    initParameters(d->imageData);
-
-    double* range = d->view2d->GetScalarRange(d->view->layer(d->imageData));
-    this->initWindowLevelParameters(range);
 }
 
 void medVtkViewItkDataImageInteractor::removeData()
 {
-    d->view2d->RemoveLayer(d->view->layer(d->imageData));
-    d->view3d->RemoveLayer(d->view->layer(d->imageData));
+    unsigned int imageLayer = d->view->layer(d->imageData);
+    d->view2d->RemoveLayer(imageLayer);
+    d->view3d->RemoveLayer(imageLayer);
 }
 
 bool medVtkViewItkDataImageInteractor::SetViewInput(medAbstractData* data, int layer)
@@ -229,8 +232,6 @@ bool medVtkViewItkDataImageInteractor::SetViewInput(medAbstractData* data, int l
 
 void medVtkViewItkDataImageInteractor::initParameters(medAbstractImageData* data)
 {
-    d->imageData = data;
-
     d->lutParam = new medStringListParameterL("Lut", this);
     QStringList luts = QStringList() << "Default" << "Black & White" << "Black & White Inversed"
                                      << "Spectrum" << "Hot Metal" << "Hot Green"
@@ -314,16 +315,14 @@ void medVtkViewItkDataImageInteractor::initWindowLevelParameters(double *range)
     double levelMin = range[0] - halfWidth;
     double levelMax = range[1] + halfWidth;
 
+    d->intensityStep = (levelMax - levelMin) / 100;
+
     this->windowLevelParameter()->addVariant("Window", QVariant(window), QVariant(windowMin), QVariant(windowMax));
-    this->windowLevelParameter()->addVariant("Level", QVariant(level), QVariant(levelMin), QVariant(levelMax));
+    this->windowLevelParameter()->addVariant("Level",  QVariant(level),  QVariant(levelMin),  QVariant(levelMax));
 
     d->minIntensityParameter = new medDoubleParameterL("Min Intensity", this);
-    connect(d->minIntensityParameter, SIGNAL(valueChanged(double)), this, SLOT(setWindowLevelFromMinMax()));
-
     d->maxIntensityParameter = new medDoubleParameterL("Max Intensity", this);
-    connect(d->maxIntensityParameter, SIGNAL(valueChanged(double)), this, SLOT(setWindowLevelFromMinMax()));
 
-    d->intensityStep = (levelMax - levelMin) / 100;
     d->minIntensityParameter->setSingleStep(d->intensityStep);
     d->maxIntensityParameter->setSingleStep(d->intensityStep);
 
@@ -340,32 +339,36 @@ void medVtkViewItkDataImageInteractor::initWindowLevelParameters(double *range)
 
     d->minIntensityParameter->setRange(levelMin, levelMax);
     d->maxIntensityParameter->setRange(levelMin, levelMax);
-
     d->minIntensityParameter->setValue(range[0]);
     d->maxIntensityParameter->setValue(range[1]);
 
-    d->view->render();
+    connect(d->minIntensityParameter, SIGNAL(valueChanged(double)), this, SLOT(setWindowLevelFromMinMax()));
+    connect(d->maxIntensityParameter, SIGNAL(valueChanged(double)), this, SLOT(setWindowLevelFromMinMax()));
 }
 
 void medVtkViewItkDataImageInteractor::setOpacity(double opacity)
 {
-    d->view3d->SetOpacity (opacity, d->view->layer(d->imageData));
-    d->view2d->SetOpacity (opacity, d->view->layer(d->imageData));
+    unsigned int imageLayer = d->view->layer(d->imageData);
+
+    d->view3d->SetOpacity (opacity, imageLayer);
+    d->view2d->SetOpacity (opacity, imageLayer);
 
     update();
 }
 
 void medVtkViewItkDataImageInteractor::setVisibility(bool visible)
 {
+    unsigned int imageLayer = d->view->layer(d->imageData);
+
     if(visible)
     {
-        d->view2d->SetVisibility(1, d->view->layer(d->imageData));
-        d->view3d->SetVisibility(1, d->view->layer(d->imageData));
+        d->view2d->SetVisibility(1, imageLayer);
+        d->view3d->SetVisibility(1, imageLayer);
     }
     else
     {
-        d->view2d->SetVisibility(0, d->view->layer(d->imageData));
-        d->view3d->SetVisibility(0, d->view->layer(d->imageData));
+        d->view2d->SetVisibility(0, imageLayer);
+        d->view3d->SetVisibility(0, imageLayer);
     }
 
     update();
@@ -378,6 +381,8 @@ QString medVtkViewItkDataImageInteractor::lut() const
 
 void medVtkViewItkDataImageInteractor::setLut(QString value)
 {
+    unsigned int imageLayer = d->view->layer(d->imageData);
+
     typedef vtkTransferFunctionPresets Presets;
     vtkColorTransferFunction * rgb   = vtkColorTransferFunction::New();
     vtkPiecewiseFunction     * alpha = vtkPiecewiseFunction::New();
@@ -385,13 +390,14 @@ void medVtkViewItkDataImageInteractor::setLut(QString value)
     Presets::GetTransferFunction(value.toStdString(), rgb, alpha );
 
     vtkLookupTable *lut = vtkLookupTableManager::GetLookupTable(value.toStdString());
-    d->view3d->SetTransferFunctions(rgb, alpha, d->view->layer(d->imageData));
-    d->view3d->SetLookupTable(lut, d->view->layer(d->imageData));
+    d->view3d->SetTransferFunctions(rgb, alpha, imageLayer);
+    d->view3d->SetLookupTable(lut, imageLayer);
 
-    if (d->view->layer(d->imageData) == 0)
+    if (imageLayer == 0)
+    {
         lut = vtkLookupTableManager::removeLUTAlphaChannel(lut);
-
-    d->view2d->SetLookupTable(lut, d->view->layer(d->imageData));
+    }
+    d->view2d->SetLookupTable(lut, imageLayer);
 
     rgb->Delete();
     alpha->Delete();
@@ -476,13 +482,13 @@ QWidget* medVtkViewItkDataImageInteractor::buildToolBoxWidget()
 {
     QWidget *toolbox = new QWidget;
     QFormLayout *layout = new QFormLayout(toolbox);
-
     QHBoxLayout *minLayout = new QHBoxLayout;
+    QHBoxLayout *maxLayout = new QHBoxLayout;
+
     d->minIntensityParameter->getSlider()->setOrientation(Qt::Horizontal);
     minLayout->addWidget(d->minIntensityParameter->getSlider());
     minLayout->addWidget(d->minIntensityParameter->getSpinBox());
 
-    QHBoxLayout *maxLayout = new QHBoxLayout;
     d->maxIntensityParameter->getSlider()->setOrientation(Qt::Horizontal);
     maxLayout->addWidget(d->maxIntensityParameter->getSlider());
     maxLayout->addWidget(d->maxIntensityParameter->getSpinBox());
@@ -491,7 +497,6 @@ QWidget* medVtkViewItkDataImageInteractor::buildToolBoxWidget()
     layout->addRow(d->maxIntensityParameter->getLabel(), maxLayout);
     layout->addRow(d->lutParam->getLabel(), d->lutParam->getComboBox());
     layout->addRow(d->presetParam->getLabel(), d->presetParam->getComboBox());
-
     layout->addRow(d->enableInterpolation->getLabel(), d->enableInterpolation->getWidget());
 
     return toolbox;
@@ -499,46 +504,34 @@ QWidget* medVtkViewItkDataImageInteractor::buildToolBoxWidget()
 
 QWidget* medVtkViewItkDataImageInteractor::buildLayerWidget()
 {
-        this->opacityParameter()->getSlider()->setOrientation(Qt::Horizontal);
-        return this->opacityParameter()->getSlider();
+    this->opacityParameter()->getSlider()->setOrientation(Qt::Horizontal);
+    return this->opacityParameter()->getSlider();
 }
 
 void medVtkViewItkDataImageInteractor::setWindowLevelFromMinMax()
 {
+    qDebug()<<"### medVtkViewItkDataImageInteractor::setWindowLevelFromMinMax";
     medDoubleParameterL *sender = dynamic_cast<medDoubleParameterL *>(this->sender());
-    if(!sender)
-        return;
 
-    double minIntensityValue = d->minIntensityParameter->value();
-    double maxIntensityValue = d->maxIntensityParameter->value();
-
-    if( sender == d->minIntensityParameter && minIntensityValue >= maxIntensityValue )
+    if(sender)
     {
-        d->maxIntensityParameter->blockSignals(true);
-        d->maxIntensityParameter->setValue(minIntensityValue + d->intensityStep);
-        d->maxIntensityParameter->blockSignals(false);
+        double minIntensity = d->minIntensityParameter->value();
+        double maxIntensity = d->maxIntensityParameter->value();
+
+        double level = 0.5 * (maxIntensity - minIntensity) + minIntensity;
+        double window = maxIntensity - minIntensity;
+
+        //--- block
+        this->windowLevelParameter()->blockSignals(true);
+
+        unsigned int imageLayer = d->view->layer(d->imageData);
+
+        d->view2d->SetColorWindowLevel(window, level, imageLayer);
+        d->view3d->SetColorWindowLevel(window, level, imageLayer);
+
+        this->windowLevelParameter()->blockSignals(false);
+        //--- end block
     }
-    else if( sender == d->maxIntensityParameter && maxIntensityValue <= minIntensityValue )
-    {
-        d->minIntensityParameter->blockSignals(true);
-        d->minIntensityParameter->setValue(maxIntensityValue - d->intensityStep);
-        d->minIntensityParameter->blockSignals(false);
-    }
-
-    double minIntensityValueUpdated = d->minIntensityParameter->value();
-    double maxIntensityValueUpdated = d->maxIntensityParameter->value();
-
-    double level = 0.5 * (maxIntensityValueUpdated - minIntensityValueUpdated) + minIntensityValueUpdated;
-    double window = maxIntensityValueUpdated - minIntensityValueUpdated;
-
-    this->windowLevelParameter()->blockSignals(true);
-
-    unsigned int layer = d->view->layer(d->imageData);
-
-    d->view2d->SetColorWindowLevel(window, level, layer);
-    d->view3d->SetColorWindowLevel(window, level, layer);
-
-    this->windowLevelParameter()->blockSignals(false);
 }
 
 void medVtkViewItkDataImageInteractor::updateInterpolateStatus(bool pi_bStatus, int pi_iLayer)
@@ -553,29 +546,35 @@ void medVtkViewItkDataImageInteractor::setWindowLevel(QHash<QString, QVariant> v
 {
     if(values.size() != 2 )
     {
-        dtkWarn() << "Window/Level parameters are incorrect";
+        qWarning() << "Window/Level parameters are incorrect";
         return;
     }
 
     double w = values["Window"].toDouble();
     double l = values["Level"].toDouble();
     if(w != w || l != l) // NaN values
+    {
         return;
+    }
 
-    if (d->view2d->GetColorWindow(d->view->layer(d->imageData)) != w)
-        d->view2d->SetColorWindow(w, d->view->layer(d->imageData));
+    unsigned int imageLayer = d->view->layer(d->imageData);
 
-
-    if (d->view3d->GetColorWindow(d->view->layer(d->imageData)) != w)
-        d->view3d->SetColorWindow(w, d->view->layer(d->imageData));
-
-    if (d->view2d->GetColorLevel(d->view->layer(d->imageData)) != l)
-        d->view2d->SetColorLevel(l, d->view->layer(d->imageData));
-
-
-    if (d->view3d->GetColorLevel(d->view->layer(d->imageData)) != l)
-        d->view3d->SetColorLevel(l, d->view->layer(d->imageData));
-
+    if (d->view2d->GetColorWindow(imageLayer) != w)
+    {
+        d->view2d->SetColorWindow(w, imageLayer);
+    }
+    if (d->view3d->GetColorWindow(imageLayer) != w)
+    {
+        d->view3d->SetColorWindow(w, imageLayer);
+    }
+    if (d->view2d->GetColorLevel(imageLayer) != l)
+    {
+        d->view2d->SetColorLevel(l, imageLayer);
+    }
+    if (d->view3d->GetColorLevel(imageLayer) != l)
+    {
+        d->view3d->SetColorLevel(l, imageLayer);
+    }
 
     d->minIntensityParameter->blockSignals(true);
     d->maxIntensityParameter->blockSignals(true);
@@ -589,8 +588,6 @@ void medVtkViewItkDataImageInteractor::setWindowLevel(QHash<QString, QVariant> v
 
 void medVtkViewItkDataImageInteractor::moveToSlice(int slice)
 {
-    //TODO find a way to get woorldCoordinate for slice from vtkInria.
-    // instead of moving to the slice corresponding on the first layer dropped.
     if(d->view->is2D() && slice != d->view2d->GetSlice())
     {
         d->view2d->SetSlice(slice);
@@ -635,11 +632,13 @@ void medVtkViewItkDataImageInteractor::setUpViewForThumbnail()
 
 void medVtkViewItkDataImageInteractor::updateImageViewInternalLayer()
 {
-    if( d->view->layer(d->imageData) != d->view->currentLayer() )
-        return;
+    unsigned int imageLayer = d->view->layer(d->imageData);
 
-    d->view2d->SetCurrentLayer(d->view->layer(d->imageData));
-    d->view3d->SetCurrentLayer(d->view->layer(d->imageData));
+    if( imageLayer == d->view->currentLayer() )
+    {
+        d->view2d->SetCurrentLayer(imageLayer);
+        d->view3d->SetCurrentLayer(imageLayer);
+    }
 }
 
 void medVtkViewItkDataImageInteractor::createSlicingParam()
@@ -679,8 +678,9 @@ void medVtkViewItkDataImageInteractor::updateSlicingParam()
 void medVtkViewItkDataImageInteractor::enableWindowLevel(bool enable)
 {
     if(enable)
+    {
         d->view2d->SetLeftButtonInteractionStyle ( vtkInteractorStyleImageView2D::InteractionTypeWindowLevel );
-
+    }
 }
 
 void medVtkViewItkDataImageInteractor::interpolation(bool pi_bActive)

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
@@ -193,7 +193,6 @@ void medVtkViewItkDataImageInteractor::removeData()
     d->view3d->RemoveLayer(d->view->layer(d->imageData));
 }
 
-
 bool medVtkViewItkDataImageInteractor::SetViewInput(medAbstractData* data, int layer)
 {
     bool bRes = true;

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.h
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.h
@@ -47,6 +47,12 @@ public:
 
     void createSlicingParam();
 
+    /**
+     * @brief getCurrentLayer return the current layer number in the view
+     * @return unsigned int current number
+     */
+    unsigned int getCurrentLayer();
+
 public slots:
     virtual void setOpacity (double opacity);
     void moveToSlice(int slice);

--- a/src/plugins/legacy/medVtkView/medVtkViewNavigator.cpp
+++ b/src/plugins/legacy/medVtkView/medVtkViewNavigator.cpp
@@ -75,6 +75,7 @@ class medVtkViewNavigatorPrivate
     medBoolParameterL *showRulerParameter;
     medBoolParameterL *showAnnotationParameter;
     medBoolParameterL *showScalarBarParameter;
+    medBoolParameterL *showAnnotatedCubeParameter;
     
     QPushButton *fourImageSplitterButton;
 
@@ -147,22 +148,26 @@ medVtkViewNavigator::medVtkViewNavigator(medAbstractView *parent) :
     d->showRulerParameter = new medBoolParameterL("Ruler", this);
     d->showAnnotationParameter = new medBoolParameterL("Annotations", this);
     d->showScalarBarParameter = new medBoolParameterL("Scalar Bar", this);
+    d->showAnnotatedCubeParameter = new medBoolParameterL("Annotated Cube", this);
 
     d->showAxesParameter->setText("Axes");
     d->showRulerParameter->setText("Ruler");
     d->showAnnotationParameter->setText("Annotations");
     d->showScalarBarParameter->setText("Scalar Bar");
+    d->showAnnotatedCubeParameter->setText("Annotated Cube");
 
     connect(d->showAxesParameter, SIGNAL(valueChanged(bool)), this, SLOT(showAxes(bool)));
     connect(d->showRulerParameter, SIGNAL(valueChanged(bool)), this, SLOT(showRuler(bool)));
     connect(d->showAnnotationParameter, SIGNAL(valueChanged(bool)), this, SLOT(showAnnotations(bool)));
     connect(d->showScalarBarParameter, SIGNAL(valueChanged(bool)), this, SLOT(showScalarBar(bool)));
+    connect(d->showAnnotatedCubeParameter, SIGNAL(valueChanged(bool)), this, SLOT(showAnnotatedCube(bool)));
 
     d->showAxesParameter->setValue(false);
     d->showRulerParameter->setValue(true);
     d->showAnnotationParameter->setValue(true);
     d->showScalarBarParameter->setValue(false);
-    
+    d->showAnnotatedCubeParameter->setValue(true);
+
     d->enableZooming = new medBoolParameterL("Zooming", this);
     d->enableZooming->setIcon(QIcon (":/icons/magnify.png"));
     d->enableZooming->setToolTip(tr("Zooming"));
@@ -191,6 +196,7 @@ medVtkViewNavigator::medVtkViewNavigator(medAbstractView *parent) :
                     << d->showRulerParameter
                     << d->showAnnotationParameter
                     << d->showScalarBarParameter
+                    << d->showAnnotatedCubeParameter
                     << this->positionBeingViewedParameter()
                     << this->timeLineParameter();
 
@@ -199,6 +205,9 @@ medVtkViewNavigator::medVtkViewNavigator(medAbstractView *parent) :
     connect(this, SIGNAL(orientationChanged()),
             dynamic_cast<medAbstractImageView*>(parent), SIGNAL(orientationChanged()));
 
+    // these parameters are always shown
+    d->showScalarBarParameter->show();
+    d->showAnnotationParameter->show();
 }
 
 medVtkViewNavigator::~medVtkViewNavigator()
@@ -385,6 +394,7 @@ QWidget* medVtkViewNavigator::buildToolBoxWidget()
     showOptionsLayout->addWidget(d->showRulerParameter->getCheckBox());
     showOptionsLayout->addWidget(d->showAnnotationParameter->getCheckBox());
     showOptionsLayout->addWidget(d->showScalarBarParameter->getCheckBox());
+    showOptionsLayout->addWidget(d->showAnnotatedCubeParameter->getCheckBox());
     showOptionsLayout->setContentsMargins(0, 0, 0, 10);
 
     QVBoxLayout* layout = new QVBoxLayout(toolBoxWidget);
@@ -570,6 +580,11 @@ void medVtkViewNavigator::showScalarBar(bool show)
     d->currentView->Render();
 }
 
+void medVtkViewNavigator::showAnnotatedCube(bool show)
+{
+    d->view3d->SetShowCube(static_cast<int>(show));
+    d->currentView->Render();
+}
 
 /*=========================================================================
 
@@ -611,7 +626,6 @@ void medVtkViewNavigator::changeOrientation(medImageView::Orientation orientatio
         cam["Camera Focal"] = QVariant(focal);
         cam["Parallel Scale"] = QVariant(ps);
 
-
         if(d->parent->cameraParameter())
             d->parent->cameraParameter()->setValues(cam);
     }
@@ -634,17 +648,17 @@ void medVtkViewNavigator::changeOrientation(medImageView::Orientation orientatio
 
     // hack - if we have transitioned to 3d view, and do not have any image data, grab it from 2d and make it invisible.
     // This is to fix poor performance in vtk 6.2 and a crash in 6.3 caused by a lack of extent data for the renderer
-    if (d->currentView == d->view3d && (!d->currentView->GetMedVtkImageInfo() || !d->currentView->GetMedVtkImageInfo()->initialized))
-    {
-        if (d->view2d->GetMedVtkImageInfo() && d->view2d->GetMedVtkImageInfo()->initialized)
-        {
-            d->view3d->GetActorX()->SetOpacity(0.0);
-            d->view3d->GetActorY()->SetOpacity(0.0);
-            d->view3d->GetActorZ()->SetOpacity(0.0);
-            d->currentView->SetInput(d->view2d->Get2DDisplayMapperInputAlgorithm(0)->GetInputConnection(0,0), d->view2d->GetOrientationMatrix());
-            d->currentView->ResetCamera();
-        }
-    }
+//    if (d->currentView == d->view3d && (!d->currentView->GetMedVtkImageInfo() || !d->currentView->GetMedVtkImageInfo()->initialized))
+//    {
+//        if (d->view2d->GetMedVtkImageInfo() && d->view2d->GetMedVtkImageInfo()->initialized)
+//        {
+//            d->view3d->GetActorX()->SetOpacity(0.0);
+//            d->view3d->GetActorY()->SetOpacity(0.0);
+//            d->view3d->GetActorZ()->SetOpacity(0.0);
+//            d->currentView->SetInput(d->view2d->Get2DDisplayMapperInputAlgorithm(0)->GetInputConnection(0,0), d->view2d->GetOrientationMatrix());
+//            d->currentView->ResetCamera();
+//        }
+//    }
     d->currentView->SetRenderWindow(renWin);
     d->currentView->SetCurrentPoint(pos);
     d->currentView->GlobalWarningDisplayOff();
@@ -664,15 +678,13 @@ void medVtkViewNavigator::updateWidgets()
     {
         d->showAxesParameter->hide();
         d->showRulerParameter->hide();
-        d->showAnnotationParameter->hide();
-        d->showScalarBarParameter->hide();
+        d->showAnnotatedCubeParameter->show();
     }
     else
     {
         d->showAxesParameter->show();
         d->showRulerParameter->show();
-        d->showAnnotationParameter->show();
-        d->showScalarBarParameter->show();
+        d->showAnnotatedCubeParameter->hide();
     }
 }
 

--- a/src/plugins/legacy/medVtkView/medVtkViewNavigator.h
+++ b/src/plugins/legacy/medVtkView/medVtkViewNavigator.h
@@ -87,6 +87,7 @@ protected slots:
     void showRuler(bool);
     void showAnnotations(bool);
     void showScalarBar(bool);
+    void showAnnotatedCube(bool show);
 
     void enableZooming(bool);
     void enableSlicing(bool);


### PR DESCRIPTION
This Pull Request is based on https://github.com/medInria/medInria-public/pull/539

I'm continuing to solve the min/max intensities slowness for the 1st layer of multiples ones. Doing it, i updated a bit the code.

Changes:
 - Add Annotated Cube button in order to deactivate the cube in view, like the other parameters in view the view navigator.
 - Add 2 layers, set the 1st layer as current one: the patient name, study and series are not updated. Fixes https://github.com/medInria/medInria-public/issues/545
 - Remove useless code to continue to improve speed when the user opens an image (as done in PR 539)

:m: