### PR TITLE
Spherical harmonics corrections

### DIFF
--- a/src/plugins/legacy/itkDataSHImage/CMakeLists.txt
+++ b/src/plugins/legacy/itkDataSHImage/CMakeLists.txt
@@ -99,28 +99,12 @@ add_library(${TARGET_NAME} SHARED
 target_link_libraries(${TARGET_NAME}
   ${QT_LIBRARIES}
   dtkCore
-  ITKIOBMP
-  ITKIOBioRad
-  ITKIOBruker
-  ITKIOGDCM
-  ITKIOGIPL
-  ITKIOHDF5
-  ITKIOJPEG
-  ITKIOJPEG2000
-  ITKIOLSM
-  ITKIOMRC
-  ITKIOMeta
-  ITKIOMINC
-  ITKIONIFTI
-  ITKIONRRD
-  ITKIOPNG
-  ITKIOStimulate
-  ITKIOVTK
   dtkCore
   dtkLog
   medCore
   medLog
   medVtkInria
+  medImageIO
   )
 
 

--- a/src/plugins/legacy/itkDataSHImage/interactors/itkDataSHImageVtkViewInteractor.cpp
+++ b/src/plugins/legacy/itkDataSHImage/interactors/itkDataSHImageVtkViewInteractor.cpp
@@ -265,7 +265,6 @@ void itkDataSHImageVtkViewInteractor::setupParameters()
     medBoolParameterL *flipXParam = new medBoolParameterL("FlipX", this);
     medBoolParameterL *flipYParam = new medBoolParameterL("FlipY", this);
     medBoolParameterL *flipZParam = new medBoolParameterL("FlipZ", this);
-    flipZParam->setValue(true);
 
     medBoolParameterL *enhanceParam = new medBoolParameterL("Enhance", this);
 

--- a/src/plugins/legacy/itkDataSHImage/management/vtkSphericalHarmonicSource.cxx
+++ b/src/plugins/legacy/itkDataSHImage/management/vtkSphericalHarmonicSource.cxx
@@ -42,7 +42,7 @@ double sphLegendre(const int l,const int m,const double theta) {
     const unsigned lmm = l-m;
     const unsigned lpm = l+m;
     const double fact   = boost::math::factorial<double>(lmm)/boost::math::factorial<double>(lpm);
-    const double factor = static_cast<double>(2*l+1)/(8.0*vtkMath::Pi())*fact;
+    const double factor = static_cast<double>(2*l+1) * fact / (4.0 * vtkMath::Pi());
     return sqrt(factor)*boost::math::legendre_p(l,m,cos(theta));
 }
 #else
@@ -107,8 +107,7 @@ vtkSphericalHarmonicSource::vtkSphericalHarmonicSource(const int tess) {
     DeformOn();
     NormalizeOff();
 
-    // By Default we flip the z-axis, the internal x,y,z have z flipped with respect to visu
-    SetFlipVector(false,false,true);
+    SetFlipVector(false,false,false);
     MaxThesisFuncOff();
 
     TesselationType = Icosahedron;
@@ -340,7 +339,10 @@ ComputeSHMatrixMaxThesis(const int order,vtkPolyData *shell,const bool* FlipVect
 
             for (int m=1,j1=j-1,j2=j+1;m<=l;++m,--j1,++j2) {
                 const double temp = std::sqrt(2.0)*sphLegendre(l,m,theta);
-                B(j1,i) = temp*cos(m*phi);
+                if (m % 2 != 0)
+                    B(j1,i) = - temp*cos(m*phi);
+                else
+                    B(j1,i) = temp*cos(m*phi);
                 B(j2,i) = temp*sin(m*phi);
             }
         }

--- a/src/plugins/legacy/itkDataSHImage/readers/itkDataSHImageReader.cpp
+++ b/src/plugins/legacy/itkDataSHImage/readers/itkDataSHImageReader.cpp
@@ -73,7 +73,8 @@ bool itkDataSHImageReader::canRead (const QString &path)
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(path.toLatin1().constData(),
                                                                            itk::ImageIOFactory::ReadMode);
 
-    if (!imageIO.IsNull()) {
+    if (!imageIO.IsNull())
+    {
         if (!imageIO->CanReadFile ( path.toLatin1().constData() ))
             return false;
 
@@ -87,7 +88,15 @@ bool itkDataSHImageReader::canRead (const QString &path)
             qDebug() << e.GetDescription();
             return false;
         }
-        if (imageIO->GetNumberOfComponents/*PerPixel*/() != 15 && imageIO->GetNumberOfComponents/*PerPixel*/() != 28)
+
+        unsigned int vectorSize = imageIO->GetNumberOfComponents();
+        double order = -1.5 + std::sqrt(2 * vectorSize + 0.25);
+
+        if (std::abs(order - static_cast<int>(order)) > 1.0e-6)
+            return false;
+
+        int castOrder = static_cast<int>(order);
+        if ((castOrder <= 2)||(castOrder % 2 != 0))
             return false;
 
         return true;


### PR DESCRIPTION
Corrects two problems:
- MaxSH basis was not fitting the one from M Descoteaux PhD, corrected
- SH images were required to be of order less than 6, not a limit anymore
- Reading SH images on my computer was failing on med 3.1.1 future version, corrected

To be merged also to medinria3.1.x branch
