### PR TITLE
[Annotation] slice numbers and zoom txt

### DIFF
--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
@@ -982,7 +982,9 @@ void vtkImageView2D::SetAnnotationsFromOrientation()
         {
             solution[3] = matrixOrientation[id1][0];
             solution[1] = matrixOrientation[id1][1];
-        } else {
+        }
+        else
+        {
             solution[3] = matrixOrientation[id1][1];
             solution[1] = matrixOrientation[id1][0];
         }
@@ -990,7 +992,9 @@ void vtkImageView2D::SetAnnotationsFromOrientation()
         {
             solution[0] = matrixOrientation[id2][0];
             solution[2] = matrixOrientation[id2][1];
-        } else {
+        }
+        else
+        {
             solution[0] = matrixOrientation[id2][1];
             solution[2] = matrixOrientation[id2][0];
         }
@@ -2160,7 +2164,6 @@ void vtkImageView2D::RemoveLayer(int layer)
 {  
     if (this->HasLayer(layer))
     {
-
         // ////////////////////////////////////////////////////////////////////////
         // Save image informations of layer 0
         double  bounds[6];

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageViewCornerAnnotation.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageViewCornerAnnotation.cxx
@@ -184,8 +184,6 @@ void vtkImageViewCornerAnnotation::TextReplace(vtkImageActor *imageActor,
     QString replaceText = "";
     QString textQ = "";
 
-    // Slice current and max
-
     if (imageActor && this->ShowSliceAndImage && this->ImageView)
     {
         //---- osSW

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageViewCornerAnnotation.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageViewCornerAnnotation.cxx
@@ -42,10 +42,9 @@ vtkImageViewCornerAnnotation::~vtkImageViewCornerAnnotation() = default;
 void vtkImageViewCornerAnnotation::SetImageView(vtkImageView* arg)
 {
     this->ImageView = arg;
-    this->view2d = vtkImageView2D::SafeDownCast (this->ImageView);
 }
 
-void vtkImageViewCornerAnnotation::TextReplace(vtkImageActor *ia,
+void vtkImageViewCornerAnnotation::TextReplace(vtkImageActor *imageActor,
                                                vtkImageMapToWindowLevelColors */*wl*/)
 {
     int slice = 0, slice_max = 0;
@@ -62,6 +61,11 @@ void vtkImageViewCornerAnnotation::TextReplace(vtkImageActor *ia,
     int coord[3] = {0, 0, 0};
     int coord_x = 0, coord_y = 0;
     double value = 0.0, zoom = 100.0;
+
+    if (!view2d)
+    {
+        this->view2d = vtkImageView2D::SafeDownCast (this->ImageView);
+    }
 
     if (this->ImageView)
     {
@@ -146,23 +150,23 @@ void vtkImageViewCornerAnnotation::TextReplace(vtkImageActor *ia,
         }
     }
 
-    if (view2d && ia)
+    if (view2d && imageActor)
     {
-        int sliceOrientation = view2d->GetSliceOrientation();
-
-        int min, max;
-        double position[3]={0.0, 0.0, 0.0};
-
-        view2d->GetSliceRange(min,max);
+        // Current slice and Slice Max
+        int min = 0, max = 0;
+        view2d->GetSliceRange(min, max);
         slice = view2d->GetSlice() - min +1;
         slice_max = max - min + 1;
 
+        // Slice Orientation & Position
+        int sliceOrientation = view2d->GetSliceOrientation();
         coord[sliceOrientation]=slice-1;
 
+        double position[3]={0.0, 0.0, 0.0};
         this->ImageView->GetWorldCoordinatesFromImageCoordinates(coord, position);
         pos_z = position[sliceOrientation];
 
-        ia_input = ia->GetInput();
+        ia_input = imageActor->GetInput();
         if (!wl_input && ia_input)
         {
             input_type_is_float = (ia_input->GetScalarType() == VTK_FLOAT ||
@@ -180,7 +184,9 @@ void vtkImageViewCornerAnnotation::TextReplace(vtkImageActor *ia,
     QString replaceText = "";
     QString textQ = "";
 
-    if (ia && this->ShowSliceAndImage && this->ImageView)
+    // Slice current and max
+
+    if (imageActor && this->ShowSliceAndImage && this->ImageView)
     {
         //---- osSW
         if (this->CornerText[0] && strlen(this->CornerText[0]))
@@ -188,7 +194,7 @@ void vtkImageViewCornerAnnotation::TextReplace(vtkImageActor *ia,
             textQ = this->CornerText[0];
 
             // Zoom
-            replaceText = QString::number(zoom);
+            replaceText = " Zoom: " + QString::number(zoom);
             textQ.replace("<zoom>", replaceText);
 
             // Slice current and max

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageViewCornerAnnotation.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageViewCornerAnnotation.h
@@ -47,7 +47,7 @@ class MEDVTKINRIA_EXPORT vtkImageViewCornerAnnotation : public vtkCornerAnnotati
   vtkImageViewCornerAnnotation();
   ~vtkImageViewCornerAnnotation();
 
-  virtual void TextReplace(vtkImageActor *ia, vtkImageMapToWindowLevelColors *);
+  virtual void TextReplace(vtkImageActor *imageActor, vtkImageMapToWindowLevelColors *);
 
  private:
   vtkImageViewCornerAnnotation(const vtkImageViewCornerAnnotation&);  // Not implemented.


### PR DESCRIPTION
Solve 2 annotations problems on 3.1: the "Zoom:" text was not written, and the slice/slice_max not updated.

I'm going to test on master and do the same PR if needed.

:m: