### PR TITLE
[cstddef] remove unused include & indentation

### DIFF
--- a/src/layers/legacy/medImageIO/itkGISImageIO.h
+++ b/src/layers/legacy/medImageIO/itkGISImageIO.h
@@ -16,19 +16,16 @@
 #pragma warning ( disable : 4786 )
 #endif
 
-#include <cstddef> // For ITK 3.20 that does not define correctly ptrdiff_t
-
 #include <itkImageIOBase.h>
 
 #include <medImageIOExport.h>
 
 namespace itk
 {
+class MEDIMAGEIO_EXPORT GISImageIO : public ImageIOBase
+{
 
-  class MEDIMAGEIO_EXPORT GISImageIO : public ImageIOBase
-  {
-
-  public:
+public:
     typedef GISImageIO         Self;
     typedef ImageIOBase        Superclass;
     typedef SmartPointer<Self> Pointer;
@@ -39,40 +36,40 @@ namespace itk
 
     /*-------- This part of the interfaces deals with reading data. ----- */
 
-  /** Determine the file type. Returns true if this ImageIO can read the
+    /** Determine the file type. Returns true if this ImageIO can read the
    * file specified. */
-  virtual bool CanReadFile(const char*);
+    virtual bool CanReadFile(const char*);
 
-  /** Set the spacing and dimension information for the set filename. */
-  virtual void ReadImageInformation();
-  
-  /** Reads the data from disk into the memory buffer provided. */
-  virtual void Read(void* buffer);
+    /** Set the spacing and dimension information for the set filename. */
+    virtual void ReadImageInformation();
 
-  /*-------- This part of the interfaces deals with writing data. ----- */
+    /** Reads the data from disk into the memory buffer provided. */
+    virtual void Read(void* buffer);
 
-  /** Determine the file type. Returns true if this ImageIO can write the
+    /*-------- This part of the interfaces deals with writing data. ----- */
+
+    /** Determine the file type. Returns true if this ImageIO can write the
    * file specified. */
-  virtual bool CanWriteFile(const char*);
+    virtual bool CanWriteFile(const char*);
 
-  /** Set the spacing and dimension information for the set filename. */
-  virtual void WriteImageInformation();
-  
-  /** Writes the data to disk from the memory buffer provided. Make sure
+    /** Set the spacing and dimension information for the set filename. */
+    virtual void WriteImageInformation();
+
+    /** Writes the data to disk from the memory buffer provided. Make sure
    * that the IORegions has been set properly. */
-  virtual void Write(const void* buffer);
+    virtual void Write(const void* buffer);
 
-  GISImageIO();
-  ~GISImageIO();
-  void PrintSelf(std::ostream& os, Indent indent) const {}
+    GISImageIO();
+    ~GISImageIO();
+    void PrintSelf(std::ostream& os, Indent indent) const {}
 
-  private:
-  GISImageIO(const Self&);
-  void operator=(const Self&);
+private:
+    GISImageIO(const Self&);
+    void operator=(const Self&);
 
-  void SwapBytesIfNecessary(void* buffer, unsigned long numberOfPixels);
+    void SwapBytesIfNecessary(void* buffer, unsigned long numberOfPixels);
 
-  bool m_IsBinary;
-  
-  };
+    bool m_IsBinary;
+
+};
 } // end of namespace

--- a/src/layers/legacy/medImageIO/itkGISImageIOFactory.h
+++ b/src/layers/legacy/medImageIO/itkGISImageIOFactory.h
@@ -12,8 +12,6 @@
 
 =========================================================================*/
 
-#include <cstddef> // For ITK 3.20 that does not define correctly ptrdiff_t
-
 #include <itkObjectFactoryBase.h>
 #include <itkImageIOBase.h>
 
@@ -27,35 +25,35 @@ namespace itk
 class MEDIMAGEIO_EXPORT GISImageIOFactory : public ObjectFactoryBase
 {
 public:  
-  /** Standard class typedefs. */
-  typedef GISImageIOFactory        Self;
-  typedef ObjectFactoryBase        Superclass;
-  typedef SmartPointer<Self>       Pointer;
-  typedef SmartPointer<const Self> ConstPointer;
-  
-  /** Class methods used to interface with the registered factories. */
-  virtual const char* GetITKSourceVersion() const;
-  virtual const char* GetDescription() const;
-  
-  /** Method for class instantiation. */
-  itkFactorylessNewMacro(Self)
+    /** Standard class typedefs. */
+    typedef GISImageIOFactory        Self;
+    typedef ObjectFactoryBase        Superclass;
+    typedef SmartPointer<Self>       Pointer;
+    typedef SmartPointer<const Self> ConstPointer;
 
-  /** Run-time type information (and related methods). */
-  itkTypeMacro(GISImageIOFactory, ObjectFactoryBase)
+    /** Class methods used to interface with the registered factories. */
+    virtual const char* GetITKSourceVersion() const;
+    virtual const char* GetDescription() const;
 
-  /** Register one factory of this type  */
-  static void RegisterOneFactory()
+    /** Method for class instantiation. */
+    itkFactorylessNewMacro(Self)
+
+    /** Run-time type information (and related methods). */
+    itkTypeMacro(GISImageIOFactory, ObjectFactoryBase)
+
+    /** Register one factory of this type  */
+    static void RegisterOneFactory()
     {
-    GISImageIOFactory::Pointer GISFactory = GISImageIOFactory::New();
-    ObjectFactoryBase::RegisterFactory(GISFactory);
+        GISImageIOFactory::Pointer GISFactory = GISImageIOFactory::New();
+        ObjectFactoryBase::RegisterFactory(GISFactory);
     }
 
 protected:
-  GISImageIOFactory();
-  ~GISImageIOFactory();
+    GISImageIOFactory();
+    ~GISImageIOFactory();
 
 private:
-  GISImageIOFactory(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
+    GISImageIOFactory(const Self&); //purposely not implemented
+    void operator=(const Self&); //purposely not implemented
 };
 } // end namespace itk

--- a/src/plugins/legacy/itkDataImage/readers/itkDataImageReaderCommand.cpp
+++ b/src/plugins/legacy/itkDataImage/readers/itkDataImageReaderCommand.cpp
@@ -11,8 +11,6 @@
 
 =========================================================================*/
 
-#include <cstddef> // For ITK 3.20 that does not define correctly ptrdiff_t
-
 #include <itkDataImageReaderCommand.h>
 
 #include <itkImageIOBase.h>
@@ -22,29 +20,28 @@
 namespace itk
 {
     void DataImageReaderCommand::Execute (Object *caller, const EventObject &event)
-    {
+    {       
         ImageIOBase *po = dynamic_cast<ImageIOBase *>(caller);
-
-        if (!po)
-            return;
         
-        if(typeid(event) == typeid(itk::ProgressEvent))
+        if(po && typeid(event) == typeid(itk::ProgressEvent))
         {
             if (m_Reader)
+            {
                 m_Reader->setProgress((int)(po->GetProgress()*100.0));
+            }
         }
     }
         
     void DataImageReaderCommand::Execute (const Object *caller, const EventObject &event)
     {
         ImageIOBase *po = dynamic_cast<ImageIOBase *>(const_cast<Object *>(caller) );
-        if (! po)
-            return;
         
-        if( typeid(event) == typeid ( itk::ProgressEvent  )  )
+        if(po && typeid(event) == typeid ( itk::ProgressEvent  )  )
         {
             if (m_Reader)
+            {
                 m_Reader->setProgress ( (int)(po->GetProgress()*100.0) );
+            }
         }
     }
 }


### PR DESCRIPTION
Remove cstddef includes which are not used anymore, and indent the class.

:m: