### PR TITLE
Feedback APHP

### DIFF
--- a/src/plugins/legacy/polygonRoi/data/polygonRoi.cpp
+++ b/src/plugins/legacy/polygonRoi/data/polygonRoi.cpp
@@ -120,7 +120,7 @@ polygonRoi::polygonRoi(vtkImageView2D *view, QColor color, medAbstractRoi *paren
     vtkSmartPointer<vtkContourOverlayRepresentation> contourRep = vtkSmartPointer<vtkContourOverlayRepresentation>::New();
     contourRep->GetLinesProperty()->SetLineWidth(4);
     contourRep->GetProperty()->SetPointSize(5);
-    contourRep->GetProperty()->SetColor(1.0, 0.0, 1.0);
+    contourRep->GetProperty()->SetColor(1.0, 0.0, 0.0);
     contourRep->GetActiveProperty()->SetOpacity(0);
     contourRep->SetPixelTolerance(20);
     d->contour = vtkContourWidget::New();

--- a/src/plugins/legacy/polygonRoi/data/polygonRoi.cpp
+++ b/src/plugins/legacy/polygonRoi/data/polygonRoi.cpp
@@ -71,13 +71,6 @@ void PolygonRoiObserver::Execute ( vtkObject *caller, unsigned long event, void 
 
     switch ( event )
     {
-        case vtkImageView2D::SliceChangedEvent:
-        {
-            roi->manageVisibility();
-            emit roi->updateCursorState(CURSORSTATE::CS_SLICE_CHANGED);
-            emit roi->toggleRepulsorButton(false);
-            break;
-        }
         case vtkCommand::EndInteractionEvent:
         case vtkCommand::MouseMoveEvent:
         {
@@ -103,7 +96,7 @@ public:
         contour->GetContourRepresentation()->RemoveAllObservers();
         contour->Delete();
         view->RemoveObserver(observer);
-        observer->Delete();        
+        observer->Delete();
         view = nullptr;
         if (copyRoi)
         {
@@ -145,7 +138,6 @@ polygonRoi::polygonRoi(vtkImageView2D *view, QColor color, medAbstractRoi *paren
     setIdSlice(view->GetSlice());
     d->observer = PolygonRoiObserver::New();
     d->observer->setRoi(this);
-    d->view->AddObserver(vtkImageView2D::SliceChangedEvent,d->observer,0);
     d->contour->AddObserver(vtkCommand::EndInteractionEvent,d->observer,10);
     d->contour->AddObserver(vtkCommand::MouseMoveEvent,d->observer,10);
     contourRep->AddObserver(vtkCommand::PlacePointEvent,d->observer,0);
@@ -461,16 +453,10 @@ void polygonRoi::updateContourOtherView(medAbstractImageView *view, bool state)
         {
             return;
         }
-        if (view->orientation() == medImageView::VIEW_ORIENTATION_3D)
-        {
-            vtkImageView3D* view3D = static_cast<medVtkViewBackend*>(view->backend())->view3D;
-            view3D->RemoveDataSet(d->polyData);
-        }
-        else
-        {
-            vtkImageView2D* view2D = static_cast<medVtkViewBackend*>(view->backend())->view2D;
-            view2D->RemoveDataSet(d->polyData);
-        }
+        vtkImageView3D* view3D = static_cast<medVtkViewBackend*>(view->backend())->view3D;
+        view3D->RemoveDataSet(d->polyData);
+        vtkImageView2D* view2D = static_cast<medVtkViewBackend*>(view->backend())->view2D;
+        view2D->RemoveDataSet(d->polyData);
     }
 }
 

--- a/src/plugins/legacy/polygonRoi/data/polygonRoi.cpp
+++ b/src/plugins/legacy/polygonRoi/data/polygonRoi.cpp
@@ -140,7 +140,6 @@ polygonRoi::polygonRoi(vtkImageView2D *view, QColor color, medAbstractRoi *paren
     d->observer->setRoi(this);
     d->contour->AddObserver(vtkCommand::EndInteractionEvent,d->observer,10);
     d->contour->AddObserver(vtkCommand::MouseMoveEvent,d->observer,10);
-    contourRep->AddObserver(vtkCommand::PlacePointEvent,d->observer,0);
     d->copyRoi = nullptr;
 
     d->roiColor = color;
@@ -152,6 +151,11 @@ polygonRoi::~polygonRoi()
 {
     delete d;
     d = nullptr;
+}
+
+void polygonRoi::setEnableLeftButtonInteraction(bool state)
+{
+    d->contour->GetEventTranslator()->SetTranslation(vtkCommand::LeftButtonPressEvent, state);
 }
 
 bool polygonRoi::isClosed()

--- a/src/plugins/legacy/polygonRoi/data/polygonRoi.h
+++ b/src/plugins/legacy/polygonRoi/data/polygonRoi.h
@@ -79,9 +79,7 @@ public slots:
 signals:
     void updateCursorState(CURSORSTATE state);
     void interpolate();
-    void toggleRepulsorButton(bool state);
     void enableOtherViewsVisibility(bool state);
-
 private:
     polygonRoiPrivate *d;
     friend class PolygonRoiObserver;

--- a/src/plugins/legacy/polygonRoi/data/polygonRoi.h
+++ b/src/plugins/legacy/polygonRoi/data/polygonRoi.h
@@ -56,7 +56,6 @@ public:
     void addViewToList(medAbstractImageView *viewToAdd);
     void updateContourOtherView(medAbstractImageView *view, bool state);
     bool isClosed();
-    void setEnabled(bool state);
     vtkPolyData *createPolyDataFromContour();
     void manageVisibility();
 
@@ -81,6 +80,7 @@ signals:
     void updateCursorState(CURSORSTATE state);
     void interpolate();
     void enableOtherViewsVisibility(bool state);
+
 private:
     polygonRoiPrivate *d;
     friend class PolygonRoiObserver;

--- a/src/plugins/legacy/polygonRoi/data/polygonRoi.h
+++ b/src/plugins/legacy/polygonRoi/data/polygonRoi.h
@@ -71,6 +71,7 @@ public:
     QVector<QVector2D> copyContour();
     bool pasteContour(QVector<QVector2D> nodes);
     int getNumberOfNodes();
+    void setEnableLeftButtonInteraction(bool state);
 public slots:
     virtual void undo();
     virtual void redo();

--- a/src/plugins/legacy/polygonRoi/medTagRoiManager.cpp
+++ b/src/plugins/legacy/polygonRoi/medTagRoiManager.cpp
@@ -92,7 +92,6 @@ medTagRoiManager::medTagRoiManager(medAbstractView *view, polygonEventFilter *ev
 medTagRoiManager::~medTagRoiManager()
 {
     delete d;
-
 }
 
 polygonRoi* medTagRoiManager::appendRoi()
@@ -604,7 +603,6 @@ void medTagRoiManager::connectRois()
         connect(roi, SIGNAL(updateCursorState(CURSORSTATE)), d->eventCursor, SLOT(setCursorState(CURSORSTATE)), Qt::UniqueConnection);
         connect(roi, SIGNAL(interpolate()), this, SLOT(interpolateIfNeeded()), Qt::UniqueConnection);
         connect(roi, SIGNAL(interpolate()), d->eventCursor, SLOT(manageTick()), Qt::UniqueConnection);
-        connect(roi, SIGNAL(toggleRepulsorButton(bool)), this, SIGNAL(toggleRepulsorButton(bool)), Qt::UniqueConnection);
         connect(roi, SIGNAL(enableOtherViewsVisibility(bool)), this, SIGNAL(enableOtherViewsVisibility(bool)), Qt::UniqueConnection);
     }
 }

--- a/src/plugins/legacy/polygonRoi/medTagRoiManager.cpp
+++ b/src/plugins/legacy/polygonRoi/medTagRoiManager.cpp
@@ -547,7 +547,7 @@ void medTagRoiManager::createMaskWithLabel(int label)
             }
         }
     }
-    QString desc = QString("mask with label ") + QString::number(label);
+    QString desc = QString("mask: ") + QString(d->name);
     medUtilities::setDerivedMetaData(output, inputData, desc);
     medDataManager::instance()->importData(output, false);
     return;
@@ -699,7 +699,9 @@ double medTagRoiManager::getMinimumDistanceFromNodesToEventPosition(double event
             roi->getContour()->GetContourRepresentation()->GetNthNodeDisplayPosition(i, contourPos);
             dist = getDistance(eventPos, contourPos);
             if ( dist < minDist )
+            {
                 minDist = dist;
+            }
         }
     }
     return minDist;
@@ -764,6 +766,10 @@ void medTagRoiManager::deleteNode(double X, double Y)
         {
             d->rois.removeOne(roi);
             delete roi;
+        }
+        else
+        {
+            roi->getContour()->SetWidgetState(vtkContourWidget::Define);
         }
     }
     interpolateIfNeeded();

--- a/src/plugins/legacy/polygonRoi/medTagRoiManager.cpp
+++ b/src/plugins/legacy/polygonRoi/medTagRoiManager.cpp
@@ -616,6 +616,15 @@ void medTagRoiManager::manageVisibility()
     d->view->render();
 }
 
+void medTagRoiManager::setEnableInteraction(bool state)
+{
+   polygonRoi *roi = existingRoiInSlice();
+   if ( roi )
+   {
+       roi->setEnableLeftButtonInteraction(state);
+   }
+}
+
 void medTagRoiManager::enableOtherViewVisibility(medAbstractImageView *v, bool state)
 {
     for (polygonRoi *roi : d->rois)
@@ -659,7 +668,7 @@ bool medTagRoiManager::pasteContour(QVector<QVector2D> nodes)
     return true;
 }
 
-bool medTagRoiManager::mouseIsCloseFromContour(double mousePos[2])
+bool medTagRoiManager::mouseIsCloseFromNodes(double mousePos[2])
 {
     polygonRoi *roi = existingRoiInSlice();
     if (roi)
@@ -1065,7 +1074,7 @@ void medTagRoiManager::resampleCurve(vtkPolyData *poly,int nbPoints)
     points->Delete();
 }
 
-int medTagRoiManager::findClosestContourFromPoint(QVector3D worldMouseCoord)
+double medTagRoiManager::findClosestContourFromPoint(QVector3D worldMouseCoord)
 {
     double minDist = DBL_MAX;
     for (polygonRoi *roi : d->rois)

--- a/src/plugins/legacy/polygonRoi/medTagRoiManager.cpp
+++ b/src/plugins/legacy/polygonRoi/medTagRoiManager.cpp
@@ -128,15 +128,6 @@ QList<polygonRoi *> medTagRoiManager::getRois()
     return d->rois;
 }
 
-void medTagRoiManager::setContourEnabled(bool state)
-{
-    for (polygonRoi *roi : d->rois)
-    {
-        roi->setEnabled(state);
-        manageVisibility();
-    }
-}
-
 void medTagRoiManager::select(bool state)
 {
     polygonRoi *roi = existingRoiInSlice();
@@ -618,11 +609,11 @@ void medTagRoiManager::manageVisibility()
 
 void medTagRoiManager::setEnableInteraction(bool state)
 {
-   polygonRoi *roi = existingRoiInSlice();
-   if ( roi )
-   {
-       roi->setEnableLeftButtonInteraction(state);
-   }
+    polygonRoi *roi = existingRoiInSlice();
+    if ( roi )
+    {
+        roi->setEnableLeftButtonInteraction(state);
+    }
 }
 
 void medTagRoiManager::enableOtherViewVisibility(medAbstractImageView *v, bool state)

--- a/src/plugins/legacy/polygonRoi/medTagRoiManager.h
+++ b/src/plugins/legacy/polygonRoi/medTagRoiManager.h
@@ -49,7 +49,7 @@ public:
 
     void manageTick(medSliderL *slider);
     void manageVisibility();
-    bool mouseIsCloseFromContour(double mousePos[2]);
+    bool mouseIsCloseFromNodes(double mousePos[2]);
     double getMinimumDistanceFromNodesToEventPosition(double eventPos[2]);
     double getMinimumDistanceFromIntermediateNodesToEventPosition(double eventPos[2]);
     void deleteNode(double X, double Y);
@@ -63,7 +63,7 @@ public:
     void select(bool state);
     void loadContours(QVector<medWorldPosContours> contours);
 
-    int findClosestContourFromPoint(QVector3D worldMouseCoord);
+    double findClosestContourFromPoint(QVector3D worldMouseCoord);
     int getClosestSliceFromPoint();
 
     QVector<QVector2D> copyContour();
@@ -71,6 +71,7 @@ public:
     void setName(QString name);
     void removeContourOtherView(medAbstractImageView *v);
     void removeIntermediateContoursOtherView(medAbstractImageView *v);
+    void setEnableInteraction(bool state);
 public slots:
     void interpolateIfNeeded();
     void enableOtherViewVisibility(medAbstractImageView *v, bool state);

--- a/src/plugins/legacy/polygonRoi/medTagRoiManager.h
+++ b/src/plugins/legacy/polygonRoi/medTagRoiManager.h
@@ -44,7 +44,6 @@ public:
     QString getName();
     polygonRoi *appendRoi();
 
-    void setContourEnabled(bool state);
     void setEnableInterpolation(bool state);
 
     void manageTick(medSliderL *slider);

--- a/src/plugins/legacy/polygonRoi/medTagRoiManager.h
+++ b/src/plugins/legacy/polygonRoi/medTagRoiManager.h
@@ -77,7 +77,6 @@ public slots:
 
 signals:
     void enableOtherViewsVisibility(bool state);
-    void toggleRepulsorButton(bool state);
 
 private:
     dtkSmartPointer<medAbstractData> output;

--- a/src/plugins/legacy/polygonRoi/polygonEventFilter.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonEventFilter.cpp
@@ -178,8 +178,11 @@ bool polygonEventFilter::mouseReleaseEvent(medAbstractView *view, QMouseEvent *m
 
             if (interactorStyleRepulsor != nullptr)
             {
-                interactorStyleRepulsor->GetManager()->SetMasterRoi(true);
-                interactorStyleRepulsor->GetManager()->interpolateIfNeeded();
+                if (interactorStyleRepulsor->GetManager() != nullptr )
+                {
+                    interactorStyleRepulsor->GetManager()->SetMasterRoi(true);
+                    interactorStyleRepulsor->GetManager()->interpolateIfNeeded();
+                }
                 enableOtherViewsVisibility(true);
                 manageTick();
             }

--- a/src/plugins/legacy/polygonRoi/polygonEventFilter.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonEventFilter.cpp
@@ -119,8 +119,6 @@ void polygonEventFilter::reset()
 
 bool polygonEventFilter::eventFilter(QObject *obj, QEvent *event)
 {
-    if ( ! activateEventFilter )
-        return false;
 
     QKeyEvent *keyEvent = dynamic_cast<QKeyEvent*>(event);
     QMouseEvent *mouseEvent = dynamic_cast<QMouseEvent*>(event);
@@ -135,6 +133,8 @@ bool polygonEventFilter::eventFilter(QObject *obj, QEvent *event)
         return false;
     }
 
+    if ( ! activateEventFilter )
+        return false;
     if ( keyEvent->type() == QEvent::ShortcutOverride )
     {
         if ( keyEvent->key() == Qt::Key::Key_C )

--- a/src/plugins/legacy/polygonRoi/polygonEventFilter.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonEventFilter.cpp
@@ -319,6 +319,14 @@ QLineEdit * polygonEventFilter::updateNameManager(medTagRoiManager* closestManag
     QString style = "QLineEdit { color: rgb(%1, %2, %3); }";
     renameManager->setStyleSheet(style.arg(mycolor.red()).arg(mycolor.green()).arg(mycolor.blue()));
     connect(renameManager, &QLineEdit::editingFinished, [=](){
+       for (medTagRoiManager *manager : managers)
+       {
+           if (manager->getName()==renameManager->text())
+           {
+               qDebug()<<"forbidden name";
+               return;
+           }
+       }
        closestManager->setName(renameManager->text());
     });
     connect(renameManager, &QLineEdit::returnPressed, [=](){
@@ -915,15 +923,15 @@ void polygonEventFilter::loadContours(medAbstractData *data)
         {
             return;
         }
+        QString labelName = (tagContours.getLabelName() == "undefined")?QString("label-%1").arg(label):tagContours.getLabelName();
         for (medTagRoiManager *manager : managers)
         {
-            if (manager->getName()==tagContours.getLabelName())
+            if (manager->getName()==labelName)
             {
                 qDebug()<<metaObject()->className()<<":: loadContours - unable to create a new manager.";
                 return;
             }
         }
-        QString labelName = (tagContours.getLabelName() == "undefined")?QString("label-%1").arg(label):tagContours.getLabelName();
 
         medTagRoiManager *manager = addManagerToList(label, labelName);
         manager->loadContours(tagContours.getContourNodes());

--- a/src/plugins/legacy/polygonRoi/polygonEventFilter.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonEventFilter.cpp
@@ -302,10 +302,10 @@ bool polygonEventFilter::leftButtonBehaviour(medAbstractView *view, QMouseEvent 
     return false;
 }
 
-
-QWidgetAction * polygonEventFilter::updateNameManager(medTagRoiManager* closestManager, QMenu *mainMenu)
+QLineEdit * polygonEventFilter::updateNameManager(medTagRoiManager* closestManager, QMenu *mainMenu)
 {
     QLineEdit *renameManager = new QLineEdit(closestManager->getName());
+    renameManager->setContextMenuPolicy(Qt::ContextMenuPolicy::NoContextMenu);
     QFont font = renameManager->font();
     font.setWeight(QFont::Black);
     font.setPointSize(15);
@@ -322,10 +322,7 @@ QWidgetAction * polygonEventFilter::updateNameManager(medTagRoiManager* closestM
        mainMenu->close();
     });
 
-    QWidgetAction *renameManagerAction = new QWidgetAction(mainMenu);
-    renameManagerAction->setDefaultWidget(renameManager);
-
-    return renameManagerAction;
+    return renameManager;
 }
 
 medTagRoiManager *polygonEventFilter::getClosestManager(double *mousePos)
@@ -367,6 +364,7 @@ bool polygonEventFilter::rightButtonBehaviour(medAbstractView *view, QMouseEvent
     QMenu *colorMenu = createColorMenu(colors);
     QMenu *roiManagementMenu = new QMenu("Remove: ");
     QMenu *saveMenu = new QMenu("Save as: ");
+    QWidgetAction *renameManagerAction = new QWidgetAction(&mainMenu);
     if (closestManager && closestManager->getMinimumDistanceFromNodesToEventPosition(mousePos) < 10 )
     {
         closestManager->select(true);
@@ -406,7 +404,7 @@ bool polygonEventFilter::rightButtonBehaviour(medAbstractView *view, QMouseEvent
             copyContour(closestManager);
         });
 
-        QWidgetAction *renameManagerAction = updateNameManager(closestManager, &mainMenu);
+        renameManagerAction->setDefaultWidget(updateNameManager(closestManager, &mainMenu));
 
         mainMenu.addAction(renameManagerAction);
         mainMenu.addMenu(roiManagementMenu);
@@ -431,6 +429,7 @@ bool polygonEventFilter::rightButtonBehaviour(medAbstractView *view, QMouseEvent
     delete colorMenu;
     delete roiManagementMenu;
     delete saveMenu;
+    delete renameManagerAction;
 
     return true;
 }

--- a/src/plugins/legacy/polygonRoi/polygonEventFilter.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonEventFilter.cpp
@@ -595,6 +595,7 @@ void polygonEventFilter::Off()
     for (medTagRoiManager *manager : managers)
     {
         manager->setContourEnabled(false);
+        manager->setEnableInteraction(false);
     }
     activateRepulsor(false);
     cursorState = CURSORSTATE::CS_CONTINUE;
@@ -606,6 +607,7 @@ void polygonEventFilter::On()
     for (medTagRoiManager *manager : managers)
     {
         manager->setContourEnabled(true);
+        manager->setEnableInteraction(true);
     }
     cursorState = CURSORSTATE::CS_CONTINUE;
 }

--- a/src/plugins/legacy/polygonRoi/polygonEventFilter.h
+++ b/src/plugins/legacy/polygonRoi/polygonEventFilter.h
@@ -92,6 +92,7 @@ private:
     QList<medDisplayPosContours> copyNodesList;
     bool activateEventFilter;
     bool enableInterpolation;
+    medTagRoiManager *activeManager;
 
     bool leftButtonBehaviour(medAbstractView *view, QMouseEvent *mouseEvent);
     bool rightButtonBehaviour(medAbstractView *view, QMouseEvent *mouseEvent);
@@ -110,4 +111,5 @@ private:
     int findAvailableLabel();
     medTagRoiManager *getManagerFromColor(QColor color);
     QWidgetAction * updateNameManager(medTagRoiManager* closestManager, QMenu *mainMenu);
+    bool isOnlyOneNodeInSlice();
 };

--- a/src/plugins/legacy/polygonRoi/polygonEventFilter.h
+++ b/src/plugins/legacy/polygonRoi/polygonEventFilter.h
@@ -123,4 +123,5 @@ private:
     bool isOnlyOneNodeInSlice();
     medTagRoiManager *getClosestManager(double *mousePos);
     void enableOnlyActiveManager();
+    QMenu *changeLabelActions(medTagRoiManager* closestManager);
 };

--- a/src/plugins/legacy/polygonRoi/polygonEventFilter.h
+++ b/src/plugins/legacy/polygonRoi/polygonEventFilter.h
@@ -28,6 +28,7 @@
 typedef itk::Image<unsigned char, 3> UChar3ImageType;
 
 class medTableWidgetItem;
+class View2DObserver;
 
 class polygonEventFilter : public medViewEventFilter
 {
@@ -37,7 +38,9 @@ public:
     ~polygonEventFilter();
     bool mousePressEvent(medAbstractView * view, QMouseEvent *mouseEvent) override;
     bool mouseReleaseEvent(medAbstractView * view, QMouseEvent *mouseEvent) override;
-    bool eventFilter(QObject *obj, QEvent *event);
+    bool mouseMoveEvent(medAbstractView * view, QMouseEvent *mouseEvent) override;
+
+    bool eventFilter(QObject *obj, QEvent *event) override;
 
     void reset();
     void updateView(medAbstractImageView *view);
@@ -54,6 +57,8 @@ public:
     void loadContours(medAbstractData *data);
 
     void clearCopiedContours();
+    void removeObserver();
+    void addObserver();
 public slots:
     void enableOtherViewsVisibility(bool state);
     void setCursorState(CURSORSTATE state){cursorState = state;}
@@ -66,7 +71,7 @@ public slots:
     void copyContours();
     void pasteContours();
 private slots:
-    void deleteNode(medTagRoiManager *manager, QMouseEvent *mouseEvent);
+    void deleteNode(medTagRoiManager *manager, const double *mousePos);
     void deleteContour(medTagRoiManager *manager);
     void deleteLabel(medTagRoiManager *manager);
     void saveMask(medTagRoiManager *manager);
@@ -93,6 +98,8 @@ private:
     bool activateEventFilter;
     bool enableInterpolation;
     medTagRoiManager *activeManager;
+    vtkSmartPointer<View2DObserver> observer;
+    double savedMousePosition[2];
 
     bool leftButtonBehaviour(medAbstractView *view, QMouseEvent *mouseEvent);
     bool rightButtonBehaviour(medAbstractView *view, QMouseEvent *mouseEvent);
@@ -111,5 +118,7 @@ private:
     int findAvailableLabel();
     medTagRoiManager *getManagerFromColor(QColor color);
     QWidgetAction * updateNameManager(medTagRoiManager* closestManager, QMenu *mainMenu);
+    void deleteNode(double *mousePosition);
     bool isOnlyOneNodeInSlice();
+    medTagRoiManager *getClosestManager(double *mousePos);
 };

--- a/src/plugins/legacy/polygonRoi/polygonEventFilter.h
+++ b/src/plugins/legacy/polygonRoi/polygonEventFilter.h
@@ -16,6 +16,7 @@
 #include <QMenu>
 
 // medInria
+#include <QLineEdit>
 #include <QWidgetAction>
 #include <medDisplayPosContours.h>
 #include <medTagContours.h>
@@ -117,7 +118,7 @@ private:
     bool updateMainViewOnChosenSlice(medAbstractImageView *view, QMouseEvent *mouseEvent);
     int findAvailableLabel();
     medTagRoiManager *getManagerFromColor(QColor color);
-    QWidgetAction * updateNameManager(medTagRoiManager* closestManager, QMenu *mainMenu);
+    QLineEdit *updateNameManager(medTagRoiManager* closestManager, QMenu *mainMenu);
     void deleteNode(double *mousePosition);
     bool isOnlyOneNodeInSlice();
     medTagRoiManager *getClosestManager(double *mousePos);

--- a/src/plugins/legacy/polygonRoi/polygonEventFilter.h
+++ b/src/plugins/legacy/polygonRoi/polygonEventFilter.h
@@ -122,4 +122,5 @@ private:
     void deleteNode(double *mousePosition);
     bool isOnlyOneNodeInSlice();
     medTagRoiManager *getClosestManager(double *mousePos);
+    void enableOnlyActiveManager();
 };

--- a/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
@@ -298,10 +298,11 @@ void polygonRoiToolBox::clickClosePolygon(bool state)
             connect(viewEventFilter, SIGNAL(toggleRepulsorButton(bool)), this, SLOT(activateRepulsor(bool)), Qt::UniqueConnection);
         }
 
-        viewEventFilter->setEnableInterpolation(interpolate->isChecked());
         viewEventFilter->updateView(currentView);
+        viewEventFilter->setEnableInterpolation(interpolate->isChecked());
         viewEventFilter->On();
         viewEventFilter->installOnView(currentView);
+        viewEventFilter->addObserver();
 
         if ( viewEventFilter->isContourInSlice() )
         {
@@ -317,6 +318,8 @@ void polygonRoiToolBox::clickClosePolygon(bool state)
     {
         repulsorTool->setEnabled(state);
         viewEventFilter->Off();
+        viewEventFilter->removeFromAllViews();
+        viewEventFilter->removeObserver();
     }
 }
 
@@ -579,6 +582,8 @@ void polygonRoiToolBox::disableButtons()
     saveBinaryMaskButton->setEnabled(false);
     saveContourButton->setEnabled(false);
     tableViewChooser->setEnabled(false);
+    interpolate->setEnabled(false);
+    interpolate->setChecked(true);
 }
 
 void polygonRoiToolBox::saveContours()

--- a/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
@@ -105,9 +105,10 @@ polygonRoiToolBox::polygonRoiToolBox(QWidget *parent ) :
     QString underlineStyle = "<br><br><span style=\" text-decoration: underline;\">%1</span>";
     QLabel *explanation = new QLabel(QString(underlineStyle).arg("Define a Contour: ") + " Activate the toolbox, then click on the data set."
                                      + QString(underlineStyle).arg("Define new Label: ") + " Right-click on the image then choose color"
-                                     + QString(underlineStyle).arg("Remove node/contour/label: ") + " Put the cursor on contour then right-click and choose menu \"Remove ...\"."
-                                     + QString(underlineStyle).arg("Save segmentation: ") + " Put the cursor on contour then right-click and choose menu \"Save ...\"."
-                                     + QString(underlineStyle).arg("Copy ROIs in current slice: ") + " CTRL/CMD + c."
+                                     + QString(underlineStyle).arg("Rename a Label: ") + " Put the cursor on a node then right-click and set a new label name"
+                                     + QString(underlineStyle).arg("Remove node/contour/label: ") + " BackSpace or put the cursor on a node then right-click and choose menu\"Remove ...\"."
+                                     + QString(underlineStyle).arg("Save segmentation: ") + " Put the cursor on a node then right-click and choose menu \"Save ...\"."
+                                     + QString(underlineStyle).arg("Copy ROIs in current slice: ") + " CTRL/CMD + c. or put the cursor on a node then right-click and choose menu\"Copy ...\""
                                      + QString(underlineStyle).arg("Paste ROIs:") + " CTRL/CMD + v.");
 
     explanation->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);

--- a/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
@@ -328,7 +328,6 @@ void polygonRoiToolBox::clickClosePolygon(bool state)
     {
         repulsorTool->setEnabled(state);
         viewEventFilter->Off();
-        viewEventFilter->removeFromAllViews();
     }
 }
 

--- a/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
@@ -109,7 +109,8 @@ polygonRoiToolBox::polygonRoiToolBox(QWidget *parent ) :
                                      + QString(underlineStyle).arg("Remove node/contour/label: ") + " BackSpace or put the cursor on a node then right-click and choose menu\"Remove ...\"."
                                      + QString(underlineStyle).arg("Save segmentation: ") + " Put the cursor on a node then right-click and choose menu \"Save ...\"."
                                      + QString(underlineStyle).arg("Copy ROIs in current slice: ") + " CTRL/CMD + c. or put the cursor on a node then right-click and choose menu\"Copy ...\""
-                                     + QString(underlineStyle).arg("Paste ROIs:") + " CTRL/CMD + v.");
+                                     + QString(underlineStyle).arg("Paste ROIs:") + " CTRL/CMD + v."
+                                     + QString(underlineStyle).arg("Change current label:") + " Put the cursor on a node then right-click and choose menu \"Change label ...\".");
 
     explanation->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
     explanation->setWordWrap(true);

--- a/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
@@ -324,22 +324,8 @@ void polygonRoiToolBox::activateRepulsor(bool state)
 {
     if (currentView && viewEventFilter)
     {
-        if (state)
-        {
-            if ( viewEventFilter->isContourInSlice())
-            {
-                viewEventFilter->activateRepulsor(state);
-            }
-            else
-            {
-                repulsorTool->setChecked(false);
-            }
-        }
-        else
-        {
-            repulsorTool->setChecked(false);
-            viewEventFilter->activateRepulsor(state);
-        }
+        repulsorTool->setChecked(state);
+        viewEventFilter->activateRepulsor(state);
     }
 }
 
@@ -425,7 +411,6 @@ void polygonRoiToolBox::updateTableWidgetView(unsigned int row, unsigned int col
         });
         connect(container, &medViewContainer::containerSelected, [=](){
             viewEventFilter->Off();
-            repulsorTool->setChecked(false);
             repulsorTool->setEnabled(false);
         });
         medTableWidgetItem * item = static_cast<medTableWidgetItem*>(tableViewChooser->selectedItems().at(nbItem));
@@ -439,6 +424,10 @@ void polygonRoiToolBox::updateTableWidgetView(unsigned int row, unsigned int col
         {
             viewEventFilter->On();
             repulsorTool->setEnabled(true);
+            if (repulsorTool->isChecked())
+            {
+                activateRepulsor(true);
+            }
         }
     });
     mainContainer->setClosingMode(medViewContainer::CLOSE_BUTTON_HIDDEN);

--- a/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
@@ -150,8 +150,20 @@ void polygonRoiToolBox::loadContoursIfPresent(medAbstractImageView *v, unsigned 
     medAbstractData *data = v->layerData(layer);
     if (data->identifier().contains("medContours") && v==currentView)
     {
+        if (addNewCurve->isChecked()==false)
+        {
+            addNewCurve->setChecked(true);
+        }
         viewEventFilter->loadContours(data);
-        addNewCurve->setChecked(true);
+        if (viewEventFilter->isContourInSlice())
+        {
+            repulsorTool->setEnabled(true);
+            if (repulsorTool->isChecked())
+            {
+                    viewEventFilter->activateRepulsor(true);
+            }
+        }
+
         v->removeLayer(layer);
     }
 }
@@ -261,10 +273,6 @@ void polygonRoiToolBox::onLayerClosed(uint index)
 {
     medAbstractView *view = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainerView();
     medAbstractImageView *v = qobject_cast<medAbstractImageView*>(view);
-    // We enter here only if onLayerClosed has not been called during a view removal
-    addNewCurve->blockSignals(true);
-    addNewCurve->setChecked(false);
-    addNewCurve->blockSignals(false);
     if (!v || (v && v->layersCount()==0))
     {
         if (viewEventFilter)
@@ -319,7 +327,6 @@ void polygonRoiToolBox::clickClosePolygon(bool state)
         repulsorTool->setEnabled(state);
         viewEventFilter->Off();
         viewEventFilter->removeFromAllViews();
-        viewEventFilter->removeObserver();
     }
 }
 

--- a/src/plugins/legacy/polygonRoi/repulsor/vtkInriaInteractorStylePolygonRepulsor.cxx
+++ b/src/plugins/legacy/polygonRoi/repulsor/vtkInriaInteractorStylePolygonRepulsor.cxx
@@ -41,6 +41,7 @@ vtkInriaInteractorStylePolygonRepulsor::vtkInriaInteractorStylePolygonRepulsor()
     this->RepulsorActor = vtkCircleActor2D::New();
     this->RepulsorActor->SetVisibility(0);
     this->RepulsorActor->SetProperty(this->RepulsorProperty);
+    this->manager = nullptr;
 }
 
 //----------------------------------------------------------------------------
@@ -78,7 +79,10 @@ void vtkInriaInteractorStylePolygonRepulsor::OnLeftButtonDown()
     {
         return;
     }
-
+    if (!manager)
+    {
+        return;
+    }
     this->Position[0] = this->Interactor->GetEventPosition()[0];
     this->Position[1] = this->Interactor->GetEventPosition()[1]; 
     this->FindPokedRenderer(this->Position[0], this->Position[1]);
@@ -123,14 +127,14 @@ void vtkInriaInteractorStylePolygonRepulsor::OnLeftButtonUp()
 //----------------------------------------------------------------------------
 void vtkInriaInteractorStylePolygonRepulsor::SetCurrentView(medAbstractView *view)
 {
-    OnLeftButtonUp();
     this->CurrentView = view;
+    OnLeftButtonUp();
 }
 
 void vtkInriaInteractorStylePolygonRepulsor::SetManager(medTagRoiManager *closestManagerInSlice)
 {
-    OnLeftButtonUp();
     this->manager = closestManagerInSlice;
+    OnLeftButtonUp();
 }
 
 //----------------------------------------------------------------------------
@@ -150,6 +154,10 @@ bool vtkInriaInteractorStylePolygonRepulsor::IsInRepulsorDisk(double *pt)
 
 void vtkInriaInteractorStylePolygonRepulsor::RedefinePolygons()
 {
+    if (!manager)
+    {
+        return;
+    }
     for (polygonRoi * roi : manager->getRois())
     {
         bool contourChanged = false;


### PR DESCRIPTION
- Fix: Crash 
   - Open data in tb, create a contour, close tb, then reopen a data, activate tb ==> crash
- Fix: Open a contour file (.ctrb) saved on disk
- Ability to create a contour very closed to another one without modifying it.
- Enhancement: rename a label and validate with Enter Key
- Fix: No events are possible on contours while tb is deactivated
- Fix: contextual menu superposition on windows
- Enhancement: Keep repulsor after changing slice
- Enhancmeent: Keep label active after changing slice