### PR TITLE
minor memory leak : Qlist do not delete it's pointer member, so as do…

### DIFF
--- a/src/layers/legacy/medCoreLegacy/views/medAbstractLayeredView.cpp
+++ b/src/layers/legacy/medCoreLegacy/views/medAbstractLayeredView.cpp
@@ -62,6 +62,10 @@ medAbstractLayeredView::~medAbstractLayeredView()
     int c = layersCount()-1;
     for(int i=c; i>=0; i--)
         removeLayer(i);
+
+    qDeleteAll(d->extraNavigators);
+    d->extraNavigators.clear();
+
     delete d;
 }
 


### PR DESCRIPTION
As done it other part of medinria source code, in order to delete a QList which pointers  it is better to call qDeleteAll. (prevent memory leak by calling delete on each pointer) 