### PR TITLE
prevent crash after loading : 1st nrrd image, 2: nhdr, 3 : nrrd, 

### DIFF
--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -531,7 +531,8 @@ void vtkImageView3D::InternalUpdate()
         // append all scalar buffer into the same image
         for (auto it : this->LayerInfoVec)
         {
-            appender->AddInputConnection(it.ImageDisplay->GetInputProducer()->GetOutputPort());
+            if(it.ImageDisplay->GetInputProducer()!=nullptr)
+                appender->AddInputConnection(it.ImageDisplay->GetInputProducer()->GetOutputPort());
         }
         if (this->LayerInfoVec.size()>1)
         {

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -531,8 +531,9 @@ void vtkImageView3D::InternalUpdate()
         // append all scalar buffer into the same image
         for (auto it : this->LayerInfoVec)
         {
-            if(it.ImageDisplay->GetInputProducer()!=nullptr)
+            if(it.ImageDisplay->GetInputProducer()!=nullptr) {
                 appender->AddInputConnection(it.ImageDisplay->GetInputProducer()->GetOutputPort());
+            }
         }
         if (this->LayerInfoVec.size()>1)
         {


### PR DESCRIPTION
I do not knwo why there this issue. 
Because if  you load first nhdr image then you do not this pb. 
I may hide a bug by preventing this crash. (smthing related LayerInfoVec in vtkImageView3D) 