### PR TITLE
[4D mesh] Fix attribute intensity problem

### DIFF
--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSet.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSet.cxx
@@ -34,12 +34,12 @@ vtkStandardNewMacro( vtkMetaDataSet )
 //----------------------------------------------------------------------------
 vtkMetaDataSet::vtkMetaDataSet()
 {
-  this->DataSet          = 0;
+  this->DataSet = nullptr;
   this->WirePolyData = nullptr;
 
   this->ActorList = vtkActorCollection::New();
   this->ArrayCollection = vtkDataArrayCollection::New();
-  this->CurrentScalarArray = 0;
+  this->CurrentScalarArray = nullptr;
 
   this->Time             = -1;
   this->Property         = 0;
@@ -96,12 +96,12 @@ vtkMetaDataSet::~vtkMetaDataSet()
   }
 
   if (this->Property)
+  {
     this->Property->Delete();
+  }
 
   this->ActorList->Delete();
   this->ArrayCollection->Delete();
-
-
 }
 
 vtkMetaDataSet* vtkMetaDataSet::Clone()

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSetSequence.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSetSequence.cxx
@@ -496,7 +496,7 @@ void vtkMetaDataSetSequence::UpdateToIndex (unsigned int id)
 //----------------------------------------------------------------------------
 double*vtkMetaDataSetSequence::GetCurrentScalarRange()
 {
-    static double *val = new double[2];
+    double *val = new double[2];
     val[0] = VTK_DOUBLE_MAX;
     val[1] = VTK_DOUBLE_MIN;
 

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSetSequence.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSetSequence.cxx
@@ -722,3 +722,26 @@ void vtkMetaDataSetSequence::ComputeTimesFromDuration()
         this->GetMetaDataSet(i)->SetTime((double) ( i )/ (double)(this->GetNumberOfMetaDataSets() ) );
     }
 }
+
+double* vtkMetaDataSetSequence::GetScalarRange(QString attribute)
+{
+    static double* val = new double[2];
+    val[0] = VTK_DOUBLE_MAX;
+    val[1] = VTK_DOUBLE_MIN;
+
+    for (unsigned int i = 0; i < this->MetaDataSetList.size(); i++)
+    {
+        double* range = this->MetaDataSetList[i]->GetScalarRange(attributeName);
+        if (val[0] > range[0])
+        {
+            val[0] = range[0];
+        }
+        if (val[1] < range[1])
+        {
+            val[1] = range[1];
+        }
+    }
+
+    return val;
+}
+

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSetSequence.h
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSetSequence.h
@@ -210,6 +210,8 @@ class MEDVTKDATAMESHBASE_EXPORT vtkMetaDataSetSequence: public vtkMetaDataSet
 
   virtual double* GetCurrentScalarRange();
 
+  double* GetScalarRange(QString attributeName) override;
+
   vtkGetMacro (CurrentId, int);
   
 protected:

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaSurfaceMesh.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaSurfaceMesh.cxx
@@ -54,6 +54,7 @@ vtkStandardNewMacro( vtkMetaSurfaceMesh );
 
 //----------------------------------------------------------------------------
 vtkMetaSurfaceMesh::vtkMetaSurfaceMesh()
+    : vtkMetaDataSet()
 {
   this->Type = vtkMetaDataSet::VTK_META_SURFACE_MESH;
 }

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.cxx
@@ -40,6 +40,7 @@ vtkStandardNewMacro( vtkMetaVolumeMesh );
 
 //----------------------------------------------------------------------------
 vtkMetaVolumeMesh::vtkMetaVolumeMesh()
+  : vtkMetaDataSet()
 {
   this->Type = vtkMetaDataSet::VTK_META_VOLUME_MESH;
 }

--- a/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
+++ b/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
@@ -428,6 +428,7 @@ void vtkDataMeshInteractor::setAttribute(const QString & attributeName)
 
             d->attribute = attributes->GetArray(qPrintable(attributeName));
             attributes->SetActiveScalars(qPrintable(attributeName));
+            d->metaDataSet->SetCurrentActiveArray(d->attribute);
 
             d->LUTParam->show();
         }
@@ -436,11 +437,10 @@ void vtkDataMeshInteractor::setAttribute(const QString & attributeName)
         mapper3d->SelectColorArray(qPrintable(attributeName));
 
         d->poLutWidget->show();
-        double range[2];
-        d->attribute->GetRange(range);
+        double* range = d->metaDataSet->GetScalarRange(attributeName);
 
-        initWindowLevelParameters(range);
-
+        int dataType = d->attribute->GetDataType();
+        initWindowLevelParameters(range, dataType);
         
         this->setLut(d->lut.first);
 
@@ -466,24 +466,33 @@ void vtkDataMeshInteractor::setAttribute(const QString & attributeName)
 }
 
 
-void vtkDataMeshInteractor::initWindowLevelParameters(double * range)
+void vtkDataMeshInteractor::initWindowLevelParameters(double * range, int dataType)
 {
-    double window = range[1] - range[0];
-
-    double halfWidth = 0.5 * window;
-    double levelMin = range[0] - halfWidth;
-    double levelMax = range[1] + halfWidth;
-    double intensityStep = qMin(0.1, (levelMax - levelMin) / 1000);
+    // default for integer values
+    double intensityStep = 1.0;
+    int nbDecimals = 0;
+    // if the arrays contains decimal values, compute a
+    // proper intensity step
+    if (dataType == VTK_FLOAT || dataType == VTK_DOUBLE)
+    {
+        double window = range[1] - range[0];
+        double halfWidth = 0.5 * window;
+        double levelMin = range[0] - halfWidth;
+        double levelMax = range[1] + halfWidth;
+        intensityStep = qMin(0.1, (levelMax - levelMin) / 1000);
+        nbDecimals = 6;
+    }
 
     d->minIntensityParameter->blockSignals(true);
     d->maxIntensityParameter->blockSignals(true);
 
     d->minIntensityParameter->setSingleStep(intensityStep);
-    d->minIntensityParameter->setDecimals(6);
     d->maxIntensityParameter->setSingleStep(intensityStep);
-    d->maxIntensityParameter->setDecimals(6);
-    d->minIntensityParameter->setRange(levelMin, levelMax);
-    d->maxIntensityParameter->setRange(levelMin, levelMax);
+    d->minIntensityParameter->setDecimals(nbDecimals);
+    d->maxIntensityParameter->setDecimals(nbDecimals);
+
+    d->minIntensityParameter->setRange(range[0], range[1]);
+    d->maxIntensityParameter->setRange(range[0], range[1]);
     d->minIntensityParameter->setValue(range[0]);
     d->maxIntensityParameter->setValue(range[1]);
 

--- a/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.h
+++ b/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.h
@@ -63,7 +63,7 @@ public slots:
     void setRenderingType(const QString &type);
     void setAttribute(const QString & attribute);
 
-    void initWindowLevelParameters(double * range);
+    void initWindowLevelParameters(double * range, int dataType);
 
     void setLut(const QString &lutName);
 


### PR DESCRIPTION
- Fix the displayed attribute's range (called intensity in the code). The min and max values are now computed across the whole sequence.
- For integer arrays, intensity step will be 1 and number of decimals 0.