### PR TITLE
[medInria-3.1.x] Add support for medit .mesh file format

### DIFF
--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaSurfaceMesh.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaSurfaceMesh.cxx
@@ -335,7 +335,14 @@ unsigned int vtkMetaSurfaceMesh::CanReadFile (const char* filename)
 {
 
   if (vtkMetaSurfaceMesh::IsMeshExtension(vtksys::SystemTools::GetFilenameLastExtension(filename).c_str()))
-    return vtkMetaSurfaceMesh::FILE_IS_MESH;
+  {
+    // medit .mesh format must have 'MeshVersionFormatted' as header
+    if (vtkMetaDataSet::IsMeditFormat(filename))
+    {
+        return vtkMetaSurfaceMesh::FILE_IS_MESH;
+    }
+    return 0;
+  }
 
   if (vtkMetaSurfaceMesh::IsOBJExtension(vtksys::SystemTools::GetFilenameLastExtension(filename).c_str()))
   {

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaSurfaceMesh.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaSurfaceMesh.cxx
@@ -339,7 +339,7 @@ unsigned int vtkMetaSurfaceMesh::CanReadFile (const char* filename)
     // medit .mesh format must have 'MeshVersionFormatted' as header
     if (vtkMetaDataSet::IsMeditFormat(filename))
     {
-        return vtkMetaSurfaceMesh::FILE_IS_MESH;
+      return vtkMetaSurfaceMesh::FILE_IS_MESH;
     }
     return 0;
   }

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.cxx
@@ -220,30 +220,20 @@ bool vtkMetaVolumeMesh::IsGMeshExtension (const char* ext)
 //----------------------------------------------------------------------------
 unsigned int vtkMetaVolumeMesh::CanReadFile (const char* filename)
 {
-
   if (vtkMetaVolumeMesh::IsMeshExtension(vtksys::SystemTools::GetFilenameLastExtension(filename).c_str()))
   {
-    // check if there is any tetrahedron...
-    
-    std::ifstream file (filename );
-    char str[256];
-    file >> str;
-    
-    if(file.fail())
+    // medit .mesh format must have 'MeshVersionFormatted' as header
+    if (vtkMetaDataSet::IsMeditFormat(filename))
     {
-      return 0;
+      // Additionally, check if there are any tetrahedra
+      std::ifstream file(filename);
+      if (vtkMetaDataSet::PlaceStreamCursor(file, "Tetrahedra"))
+      {
+        return vtkMetaVolumeMesh::FILE_IS_MESH;
+      }
     }
-    
-  
-    while( (!file.fail()) && (strcmp (str, "Tetrahedra") != 0) && (strcmp (str, "End") != 0) && (strcmp (str, "END") != 0) )
-    {
-      file >> str;
-    }
-    
-    if (strcmp (str, "Tetrahedra") == 0)
-      return vtkMetaVolumeMesh::FILE_IS_MESH;
-    else
-      return 0;
+
+    return 0;
   }
 
 


### PR DESCRIPTION
- Medit surface and volume mesh are now properly read
- Implements a more robust check for medit file format, as the '.mesh' extension also exists for other file formats (i.e. Biosense Webster CARTO)