### PR TITLE
[MASTER] 2 Layers Volume Rendering Crash Fix #603

### DIFF
--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -378,6 +378,9 @@ void vtkImageView3D::UnInstallPipeline()
 {
   if (this->Renderer)
   {
+    this->VolumeMapper->RemoveAllInputs();
+    this->VolumeMapper->RemoveAllInputConnections(0);
+    this->Renderer->RemoveViewProp (this->VolumeActor);
     this->Renderer->RemoveViewProp (this->ActorX);
     this->Renderer->RemoveViewProp (this->ActorY);
     this->Renderer->RemoveViewProp (this->ActorZ);
@@ -1039,6 +1042,15 @@ void vtkImageView3D::RemoveLayer (int layer)
         // Delete is handled by SmartPointers.
         this->LayerInfoVec.erase(this->LayerInfoVec.begin() + layer);
 
+        if (layer == 0 && GetNumberOfLayers() > 0)
+        {
+            vtkImage3DDisplay *imageDisplay = this->GetImage3DDisplayForLayer(0);
+            if (imageDisplay)
+            {
+            	this->Superclass::SetInput(imageDisplay->GetInputProducer()->GetOutputPort(), GetOrientationMatrix(), 0);
+                imageDisplay->SetInputData(m_poInternalImageFromInput);
+            }
+        }
 
         // ////////////////////////////////////////////////////////////////////////
         // Rebuild a layer if necessary


### PR DESCRIPTION
Remove Inputs and InputConnections of VolumeMapper during UnInstallPipeline phase.
From 2_Layer_VolumeRendering_Crash patch branch for v3.1.x branch.
fix issue #603