### PR TITLE
[Q_OS_X11] changes from Qt4->5, code was not used

### DIFF
--- a/src/app/medInria/QSingleApplication/qtsingleapplication.cpp
+++ b/src/app/medInria/QSingleApplication/qtsingleapplication.cpp
@@ -168,47 +168,6 @@ QtSingleApplication::QtSingleApplication(const QString &appId, int &argc, char *
     sysInit(appId);
 }
 
-#if defined(Q_OS_X11)
-/*!
-  Special constructor for X11, ref. the documentation of
-  QApplication's corresponding constructor. The application identifier
-  will be QCoreApplication::applicationFilePath(). \a dpy, \a visual,
-  and \a cmap are passed on to the QApplication constructor.
-*/
-QtSingleApplication::QtSingleApplication(Display* dpy, Qt::HANDLE visual, Qt::HANDLE cmap)
-    : QApplication(dpy, visual, cmap)
-{
-    sysInit();
-}
-
-/*!
-  Special constructor for X11, ref. the documentation of
-  QApplication's corresponding constructor. The application identifier
-  will be QCoreApplication::applicationFilePath(). \a dpy, \a argc, \a
-  argv, \a visual, and \a cmap are passed on to the QApplication
-  constructor.
-*/
-QtSingleApplication::QtSingleApplication(Display *dpy, int &argc, char **argv, Qt::HANDLE visual, Qt::HANDLE cmap)
-    : QApplication(dpy, argc, argv, visual, cmap)
-{
-    sysInit();
-}
-
-/*!
-  Special constructor for X11, ref. the documentation of
-  QApplication's corresponding constructor. The application identifier
-  will be \a appId. \a dpy, \a argc, \a
-  argv, \a visual, and \a cmap are passed on to the QApplication
-  constructor.
-*/
-QtSingleApplication::QtSingleApplication(Display* dpy, const QString &appId, int argc, char **argv, Qt::HANDLE visual, Qt::HANDLE cmap)
-    : QApplication(dpy, argc, argv, visual, cmap)
-{
-    sysInit(appId);
-}
-#endif
-
-
 /*!
     Returns true if another instance of this application is running;
     otherwise false.

--- a/src/app/medInria/QSingleApplication/qtsingleapplication.h
+++ b/src/app/medInria/QSingleApplication/qtsingleapplication.h
@@ -67,11 +67,6 @@ class QT_QTSINGLEAPPLICATION_EXPORT QtSingleApplication : public QApplication
 public:
     QtSingleApplication(int &argc, char **argv, bool GUIenabled = true);
     QtSingleApplication(const QString &id, int &argc, char **argv);
-#if defined(Q_OS_X11)
-    QtSingleApplication(Display* dpy, Qt::HANDLE visual = 0, Qt::HANDLE colormap = 0);
-    QtSingleApplication(Display *dpy, int &argc, char **argv, Qt::HANDLE visual = 0, Qt::HANDLE cmap= 0);
-    QtSingleApplication(Display* dpy, const QString &appId, int argc, char **argv, Qt::HANDLE visual = 0, Qt::HANDLE colormap = 0);
-#endif
 
     bool isRunning();
     QString id() const;

--- a/src/app/medInria/medSplashScreen.cpp
+++ b/src/app/medInria/medSplashScreen.cpp
@@ -104,7 +104,7 @@ void medSplashScreen::finish(QWidget *mainWin)
 {
     if (mainWin)
     {
-#if defined(Q_OS_UNIX)
+#if defined(Q_OS_LINUX)
         QTest::qWaitForWindowExposed(mainWin);
 #endif
     }

--- a/src/app/medInria/medSplashScreen.cpp
+++ b/src/app/medInria/medSplashScreen.cpp
@@ -11,6 +11,8 @@
 
 =========================================================================*/
 
+#include <QTest>
+
 #include <medSplashScreen.h>
 #include <dtkCoreSupport/dtkPlugin.h>
 #include <medPluginManager.h>
@@ -102,9 +104,8 @@ void medSplashScreen::finish(QWidget *mainWin)
 {
     if (mainWin)
     {
-#if defined(Q_OS_X11)
-        extern void qt_x11_wait_for_window_manager(QWidget *mainWin);
-        qt_x11_wait_for_window_manager(mainWin);
+#if defined(Q_OS_UNIX)
+        QTest::qWaitForWindowExposed(mainWin);
 #endif
     }
     close();

--- a/src/layers/legacy/medCoreLegacy/CMakeLists.txt
+++ b/src/layers/legacy/medCoreLegacy/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries(${TARGET_NAME}
   Qt5::OpenGL
   Qt5::Gui
   Qt5::Sql
+  Qt5::Test
   ${OPENGL_LIBRARIES}
   dtkCoreSupport
   dtkGuiSupport

--- a/src/layers/legacy/medCoreLegacy/data/medAbstractData.cpp
+++ b/src/layers/legacy/medCoreLegacy/data/medAbstractData.cpp
@@ -23,10 +23,7 @@
 
 #include <QApplication>
 #include <QMainWindow>
-
-#ifdef Q_OS_X11
-void qt_x11_wait_for_window_manager(QWidget*);
-#endif
+#include <QTest>
 
 class medAbstractDataPrivate
 {
@@ -253,11 +250,12 @@ QImage medAbstractData::generateThumbnailInGuiThread(QSize size)
             viewWidget->move(aMainWindow->geometry().x(), aMainWindow->geometry().y());
             // and raise the main window above the temporary
             aMainWindow->raise();
+
+            // We need to wait for the window manager to finish animating before we can continue.
+#ifdef Q_OS_UNIX
+            QTest::qWaitForWindowExposed(viewWidget);
+#endif
         }
-        // We need to wait for the window manager to finish animating before we can continue.
-    #ifdef Q_OS_X11
-        qt_x11_wait_for_window_manager(viewWidget);
-    #endif
     }
 
     view->addLayer(this);

--- a/src/layers/legacy/medCoreLegacy/data/medAbstractData.cpp
+++ b/src/layers/legacy/medCoreLegacy/data/medAbstractData.cpp
@@ -252,7 +252,7 @@ QImage medAbstractData::generateThumbnailInGuiThread(QSize size)
             aMainWindow->raise();
 
             // We need to wait for the window manager to finish animating before we can continue.
-#ifdef Q_OS_UNIX
+#ifdef Q_OS_LINUX
             QTest::qWaitForWindowExposed(viewWidget);
 #endif
         }

--- a/src/plugins/legacy/medVtkView/medVtkView.cpp
+++ b/src/plugins/legacy/medVtkView/medVtkView.cpp
@@ -456,7 +456,7 @@ QImage medVtkView::buildThumbnail(const QSize &size)
     this->blockSignals(true);//we dont want to send things that would ending up on updating some gui things or whatever. - RDE
     int w(size.width()), h(size.height());
 
-//    // will cause crashes if any calls to renWin->Render() happened before this line
+    // will cause crashes if any calls to renWin->Render() happened before this line
     d->viewWidget->resize(w,h);
     d->viewWidget->show();
     d->renWin->SetSize(w,h);

--- a/src/plugins/legacy/medVtkView/medVtkView.cpp
+++ b/src/plugins/legacy/medVtkView/medVtkView.cpp
@@ -13,8 +13,9 @@
 
 #include "medVtkView.h"
 
-#include <QWidget>
 #include <QHash>
+#include <QTest>
+#include <QWidget>
 
 #include <QVTKOpenGLWidget.h>
 #include <QGLFramebufferObject>
@@ -52,11 +53,6 @@
 #include <medParameterPoolL.h>
 #include <medParameterPoolManagerL.h>
 #include <medSettingsManager.h>
-
-//// declare x11-specific function to prevent the window manager breaking thumbnail generation
-//#ifdef Q_OS_X11
-//void qt_x11_wait_for_window_manager(QWidget*);
-//#endif
 
 class medVtkViewPrivate
 {
@@ -466,14 +462,15 @@ QImage medVtkView::buildThumbnail(const QSize &size)
     d->renWin->SetSize(w,h);
     render();
 
-////#ifdef Q_OS_X11
-////    // X11 likes to animate window creation, which means by the time we grab the
-////    // widget, it might not be fully ready yet, in which case we get artefacts.
-////    // Only necessary if rendering to an actual screen window.
-////    if(d->renWin->GetOffScreenRendering() == 0) {
-////        qt_x11_wait_for_window_manager(d->viewWidget);
-////    }
-////#endif
+#ifdef Q_OS_UNIX
+    // X11 likes to animate window creation, which means by the time we grab the
+    // widget, it might not be fully ready yet, in which case we get artefacts.
+    // Only necessary if rendering to an actual screen window.
+    if(d->renWin->GetOffScreenRendering() == 0)
+    {
+        QTest::qWaitForWindowExposed(d->viewWidget);
+    }
+#endif
 
     QImage thumbnail = d->viewWidget->grabFramebuffer();
     d->viewWidget->hide();

--- a/src/plugins/legacy/medVtkView/medVtkView.cpp
+++ b/src/plugins/legacy/medVtkView/medVtkView.cpp
@@ -462,7 +462,7 @@ QImage medVtkView::buildThumbnail(const QSize &size)
     d->renWin->SetSize(w,h);
     render();
 
-#ifdef Q_OS_UNIX
+#ifdef Q_OS_LINUX
     // X11 likes to animate window creation, which means by the time we grab the
     // widget, it might not be fully ready yet, in which case we get artefacts.
     // Only necessary if rendering to an actual screen window.


### PR DESCRIPTION
Working on an other problem, i found that Q_OS_X11 and qt_x11_wait_for_window_manager were in QT4 but are not in QT5.

I'm going to create the master one also.

:m: