### PR TITLE
[nrrd/nhrd/nrrd] debug crash opening Nordine data

### DIFF
--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -447,9 +447,17 @@ void vtkImageView3D::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4
         if(layer == 0)
         {
             SetFirstLayer(pi_poVtkAlgoOutput, matrix, layer);
-        }
 
-        if (is3D())
+            if (is3D())
+            {
+                this->InternalUpdate();
+            }
+            else
+            {
+                vtkErrorMacro( <<"Only 3D layers are supported in 3D orientation" );
+            }
+        }
+        else if (is3D())
         {
             if (layer > 0 && layer < 4)
             {
@@ -458,10 +466,11 @@ void vtkImageView3D::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4
             else if (layer >= 4)
             {
                 vtkErrorMacro( <<"Only 4 layers are supported in 3D fusion" );
-                return;
             }
-
-            this->InternalUpdate();
+        }
+        else
+        {
+            vtkErrorMacro( <<"Only 3D layers are supported in 3D orientation" );
         }
     }
 }


### PR DESCRIPTION
Suggestion to have a deeper debug to the problem found by @nbaraka in https://github.com/medInria/medInria-public/pull/602

InternalUpdate is already called after SetOtherLayer, so, no need to called it again. And the second call created the crash.

:m: