### PR TITLE
Correction of very low windowLevel images (range < 10^-2)

### DIFF
--- a/src/layers/legacy/medCoreLegacy/parameters/medDoubleParameterL.cpp
+++ b/src/layers/legacy/medCoreLegacy/parameters/medDoubleParameterL.cpp
@@ -174,7 +174,6 @@ QDoubleSpinBox* medDoubleParameterL::getSpinBox()
     {
         d->spinBox = new medDoubleSpinBox;
         d->spinBox->setRange(d->min, d->max);
-        d->spinBox->setValue(m_value);
         d->spinBox->setSingleStep(d->step);
         d->spinBox->setKeyboardTracking(false);
 
@@ -197,6 +196,7 @@ QDoubleSpinBox* medDoubleParameterL::getSpinBox()
         }
 
         d->spinBox->setDecimals(d->decimals);
+        d->spinBox->setValue(m_value);
 
         this->addToInternWidgets(d->spinBox);
         connect(d->spinBox, SIGNAL(destroyed()), this, SLOT(removeInternSpinBox()));

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
@@ -337,7 +337,7 @@ void medVtkViewItkDataImageInteractor::initWindowLevelParameters(double *range)
     if(d->isFloatImage)
     {
         int iDecimalCount = 2;
-        if(std::fabsl(d->intensityStep)<1)
+        if(d->intensityStep<1)
         {
             iDecimalCount = 1 + std::ceill(std::fabsl(std::log10l(d->intensityStep)));
         }

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
@@ -336,8 +336,13 @@ void medVtkViewItkDataImageInteractor::initWindowLevelParameters(double *range)
 
     if(d->isFloatImage)
     {
-        d->minIntensityParameter->setDecimals(2);
-        d->maxIntensityParameter->setDecimals(2);
+        int iDecimalCount = 2;
+        if(std::fabsl(d->intensityStep)<1)
+        {
+            iDecimalCount = 1 + std::ceill(std::fabsl(std::log10l(d->intensityStep)));
+        }
+        d->minIntensityParameter->setDecimals(iDecimalCount);
+        d->maxIntensityParameter->setDecimals(iDecimalCount);
     }
     else
     {


### PR DESCRIPTION
Fix #621 Very Low Range image not usable (eg 0 to 0.005)
On 3.1.x 