### PR TITLE
[medInria-4.0] Add support for medit .mesh file format

### DIFF
--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaSurfaceMesh.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaSurfaceMesh.cxx
@@ -334,9 +334,15 @@ bool vtkMetaSurfaceMesh::IsOBJExtension (const char* ext)
 //----------------------------------------------------------------------------
 unsigned int vtkMetaSurfaceMesh::CanReadFile (const char* filename)
 {
-
   if (vtkMetaSurfaceMesh::IsMeshExtension(vtksys::SystemTools::GetFilenameLastExtension(filename).c_str()))
+    {
+        // medit .mesh format must have 'MeshVersionFormatted' as header
+        if (vtkMetaDataSet::IsMeditFormat(filename))
+        {
     return vtkMetaSurfaceMesh::FILE_IS_MESH;
+        }
+        return 0;
+    }
 
   if (vtkMetaSurfaceMesh::IsOBJExtension(vtksys::SystemTools::GetFilenameLastExtension(filename).c_str()))
   {

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.cxx
@@ -211,30 +211,17 @@ unsigned int vtkMetaVolumeMesh::CanReadFile (const char* filename)
 {
     if (vtkMetaVolumeMesh::IsMeshExtension(vtksys::SystemTools::GetFilenameLastExtension(filename).c_str()))
     {
-        // check if there is any tetrahedron...
-
-        std::ifstream file (filename );
-        char str[256];
-        file >> str;
-
-        if(file.fail())
+        // medit .mesh format must have 'MeshVersionFormatted' as header
+        if (vtkMetaDataSet::IsMeditFormat(filename))
         {
+            // Additionally, check if there are any tetrahedra
+            std::ifstream file(filename);
+            if (vtkMetaDataSet::PlaceStreamCursor(file, "Tetrahedra"))
+        {
+                return vtkMetaVolumeMesh::FILE_IS_MESH;
+        }
+        }
             return 0;
-        }
-
-        while( (!file.fail()) && (strcmp (str, "Tetrahedra") != 0) && (strcmp (str, "End") != 0) && (strcmp (str, "END") != 0) )
-        {
-            file >> str;
-        }
-
-        if (strcmp (str, "Tetrahedra") == 0)
-        {
-            return vtkMetaVolumeMesh::FILE_IS_MESH;
-        }
-        else
-        {
-            return 0;
-        }
     }
 
     if (vtkMetaVolumeMesh::IsGMeshExtension(vtksys::SystemTools::GetFilenameLastExtension(filename).c_str()))

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -501,15 +501,13 @@ bool vtkImageView3D::is3D()
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetInputLayer(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix /*= 0*/, int layer /*= 0*/)
 {
-    pi_poVtkAlgoOutput = this->ResliceImageToInput(pi_poVtkAlgoOutput, matrix);
-
-    vtkAlgorithmOutput *poVtkAlgoOutputTmp = pi_poVtkAlgoOutput;
+    vtkAlgorithmOutput *poVtkAlgoOutputTmp = this->ResliceImageToInput(pi_poVtkAlgoOutput, matrix);
     // cast it if needed
-    if (static_cast<vtkImageAlgorithm*>(pi_poVtkAlgoOutput->GetProducer())->GetOutput()->GetScalarType()
-            != this->GetMedVtkImageInfo()->scalarType)
+    int inputImgScalarType = static_cast<vtkImageAlgorithm*>(poVtkAlgoOutputTmp->GetProducer())->GetOutput()->GetScalarType();
+    if (inputImgScalarType != this->GetMedVtkImageInfo()->scalarType)
     {
         vtkImageCast *cast = vtkImageCast::New();
-        cast->SetInputConnection(pi_poVtkAlgoOutput);
+        cast->SetInputConnection(poVtkAlgoOutputTmp);
         cast->SetOutputScalarType (this->GetMedVtkImageInfo()->scalarType);
         cast->Update();
 
@@ -669,10 +667,16 @@ void vtkImageView3D::SetOpacity (double opacity, int layer)
 //----------------------------------------------------------------------------
 double vtkImageView3D::GetOpacity(int layer) const
 {
+    double dfRes = 0.0;
     if (this->HasLayer(layer))
-    return this->GetImage3DDisplayForLayer(layer)->GetOpacity();
-
-  return 0.0;
+    {
+        vtkImage3DDisplay *imageDisplay = GetImage3DDisplayForLayer(layer);
+        if (imageDisplay)
+        {
+            dfRes = imageDisplay->GetOpacity();
+        }
+    }
+    return dfRes;
 }
 
 //----------------------------------------------------------------------------
@@ -961,6 +965,33 @@ vtkActor* vtkImageView3D::AddDataSet (vtkPointSet* arg, vtkProperty* prop)
   // been referenced in the renderer, so we can
   // safely return it. well hopefully.
   return actor;
+}
+
+//----------------------------------------------------------------------------
+vtkActor* vtkImageView3D::DataSetToActor(vtkPointSet* arg, vtkProperty* prop)
+{
+    vtkDataSetSurfaceFilter* geometryextractor = vtkDataSetSurfaceFilter::New();
+    vtkPolyDataNormals* normalextractor = vtkPolyDataNormals::New();
+    vtkPolyDataMapper* mapper = vtkPolyDataMapper::New();
+    vtkActor* actor = vtkActor::New();
+
+    normalextractor->SetFeatureAngle(90);
+    ///\todo try to skip the normal extraction filter in order to
+    // enhance the visualization speed when the data is time sequence.
+    geometryextractor->SetInputData(arg);
+    normalextractor->SetInputConnection(geometryextractor->GetOutputPort());
+    mapper->SetInputConnection(normalextractor->GetOutputPort());
+    actor->SetMapper(mapper);
+    if (prop)
+    {
+        actor->SetProperty(prop);
+    }
+
+    mapper->Delete();
+    normalextractor->Delete();
+    geometryextractor->Delete();
+
+    return actor;
 }
 
 //----------------------------------------------------------------------------

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
@@ -142,6 +142,7 @@ public:
 
     virtual void SetInput      (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = nullptr, int layer = 0);
     virtual bool is3D();
+    static vtkActor* DataSetToActor(vtkPointSet* arg, vtkProperty* prop = nullptr);
     virtual void SetInputLayer (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = nullptr, int layer = 0);
     void SetFirstLayer(vtkAlgorithmOutput *pi_poInputAlgoImg, vtkMatrix4x4 *matrix= nullptr, int layer = 0);
 


### PR DESCRIPTION
- Medit surface and volume mesh are now properly read
- Implements a more robust check for medit file format, as the '.mesh' extension also exists for other file formats (i.e. Biosense Webster CARTO)

Cf   [#611](https://github.com/medInria/medInria-public/pull/611)