### PR TITLE
remove QGLWidget used to create a valide context since it is deprecated class

### DIFF
--- a/src/app/medInria/main.cpp
+++ b/src/app/medInria/main.cpp
@@ -75,12 +75,12 @@ int main(int argc,char* argv[])
     fmt.setVersion(3, 2);
     fmt.setProfile(QSurfaceFormat::CoreProfile);
     fmt.setSwapBehavior(QSurfaceFormat::DoubleBuffer);
-    fmt.setRedBufferSize(1);
-    fmt.setGreenBufferSize(1);
-    fmt.setBlueBufferSize(1);
-    fmt.setDepthBufferSize(1);
+    fmt.setRedBufferSize(8);
+    fmt.setGreenBufferSize(8);
+    fmt.setBlueBufferSize(8);
+    fmt.setDepthBufferSize(24);
     fmt.setStencilBufferSize(0);
-    fmt.setAlphaBufferSize(1);
+    fmt.setAlphaBufferSize(8);
     fmt.setStereo(false);
     fmt.setSamples(0);
 

--- a/src/layers/legacy/medCoreLegacy/data/medAbstractData.cpp
+++ b/src/layers/legacy/medCoreLegacy/data/medAbstractData.cpp
@@ -216,6 +216,8 @@ QImage medAbstractData::generateThumbnailInGuiThread(QSize size)
     // we're currently using, and if it is one of the crashy ones, render to a
     // proper window instead, that we try to hide behind the main medInria one.
 
+   dtkSmartPointer<medAbstractImageView> view = medViewFactory::instance()->createView<medAbstractImageView>("medVtkView");
+
     bool offscreenCapable = false;
     med::GPUInfo gpu = med::gpuModel();
 
@@ -234,8 +236,7 @@ QImage medAbstractData::generateThumbnailInGuiThread(QSize size)
     }
 #endif
 
-    dtkSmartPointer<medAbstractImageView> view = medViewFactory::instance()->createView<medAbstractImageView>("medVtkView");
-
+ 
     if(offscreenCapable)
     {
         view->setOffscreenRendering(true);

--- a/src/layers/legacy/medCoreLegacy/medGlobalDefs.cpp
+++ b/src/layers/legacy/medCoreLegacy/medGlobalDefs.cpp
@@ -15,6 +15,7 @@
 
 #include <QFileInfo>
 #include <QtOpenGL/QtOpenGL>
+#include <QOpenGLContext>
 
 namespace med {
 
@@ -37,13 +38,14 @@ GPUInfo gpuModel()
     // just fill it once, we are not going to change GPU on the fly
     static GPUInfo gpu;
     if (gpu.renderer.isEmpty()) {
-        // glGetString requires a valid OpenGL context, the easiest way is to
-        // create a bogus QGLWidget and force a render.
-        QGLWidget glw;
-        glw.makeCurrent();
-        gpu.renderer = QString::fromLocal8Bit(reinterpret_cast<const char*>(glGetString(GL_RENDERER)));
-        gpu.version = QString::fromLocal8Bit(reinterpret_cast<const char*>(glGetString(GL_VERSION)));
-        gpu.vendor = QString::fromLocal8Bit(reinterpret_cast<const char*>(glGetString(GL_VENDOR)));
+        QOffscreenSurface surf;
+        surf.create();
+        QOpenGLContext ctx;
+        ctx.create();
+        ctx.makeCurrent(&surf);
+        gpu.renderer = QString::fromLocal8Bit(reinterpret_cast<const char*>(ctx.functions()->glGetString(GL_RENDERER)));
+        gpu.version = QString::fromLocal8Bit(reinterpret_cast<const char*>(ctx.functions()->glGetString(GL_VERSION)));
+        gpu.vendor = QString::fromLocal8Bit(reinterpret_cast<const char*>(ctx.functions()->glGetString(GL_VENDOR)));
     }
     return gpu;
 }


### PR DESCRIPTION
A way to call glGetString that do not need to construct a QGLWidget. 
Also increase format buffer size.  