### PR TITLE
Glyph3d  to Glyph3dMapper 

### DIFF
--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkVectorFieldInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkVectorFieldInteractor.cpp
@@ -464,7 +464,20 @@ void medVtkViewItkVectorFieldInteractor::updateSlicingParam()
 
 void medVtkViewItkVectorFieldInteractor::updatePlaneVisibility()
 {
-    // this is a temp sol : not optimal,without this the screen is black
-    this->update();
-    d->manager->SetGlyphScale(1.0);
+    markMapperModified();
 }
+
+void medVtkViewItkVectorFieldInteractor::markMapperModified() {
+
+    if(d->manager->GetVectorVisuManagerAxial()) {
+        d->manager->GetVectorVisuManagerAxial()->GetGlyphMapper()->Modified();
+    }
+    if(d->manager->GetVectorVisuManagerSagittal()) {
+        d->manager->GetVectorVisuManagerSagittal()->GetGlyphMapper()->Modified();
+    }
+    if(d->manager->GetVectorVisuManagerCoronal()) {
+        d->manager->GetVectorVisuManagerCoronal()->GetGlyphMapper()->Modified();
+    }
+}
+
+

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkVectorFieldInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkVectorFieldInteractor.cpp
@@ -100,7 +100,6 @@ medVtkViewItkVectorFieldInteractor::medVtkViewItkVectorFieldInteractor(medAbstra
 medVtkViewItkVectorFieldInteractor::~medVtkViewItkVectorFieldInteractor()
 {
     delete d;
-    d = nullptr;
 }
 
 QString medVtkViewItkVectorFieldInteractor::description() const
@@ -178,6 +177,7 @@ void medVtkViewItkVectorFieldInteractor::setInputData(medAbstractData *data)
 
         vtkImageData *vtkImage = d->floatFilter->GetOutput();
         d->manager->SetInput(vtkImage);
+
     }
     else if( identifier.compare("itkDataImageVectorDouble3") == 0 )
     {
@@ -230,6 +230,8 @@ void medVtkViewItkVectorFieldInteractor::setInputData(medAbstractData *data)
     d->manager->GetVectorVisuManagerAxial()->GetActor()->SetProperty( d->actorProperty );
     d->manager->GetVectorVisuManagerSagittal()->GetActor()->SetProperty( d->actorProperty );
     d->manager->GetVectorVisuManagerCoronal()->GetActor()->SetProperty( d->actorProperty );
+
+    mat->Delete();
 
     setupParameters();
     update();

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkVectorFieldInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkVectorFieldInteractor.cpp
@@ -462,4 +462,7 @@ void medVtkViewItkVectorFieldInteractor::updateSlicingParam()
 
 void medVtkViewItkVectorFieldInteractor::updatePlaneVisibility()
 {
+    // this is a temp sol : not optimal,without this the screen is black
+    this->update();
+    d->manager->SetGlyphScale(1.0);
 }

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkVectorFieldInteractor.h
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkVectorFieldInteractor.h
@@ -43,6 +43,8 @@ public:
 
     void removeData() override;
 
+    void markMapperModified();
+
 public slots:
 
     void setScale(double scale);

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkVectorFieldInteractor.h
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkVectorFieldInteractor.h
@@ -26,22 +26,22 @@ public:
     medVtkViewItkVectorFieldInteractor(medAbstractView* parent);
     ~medVtkViewItkVectorFieldInteractor();
 
-    virtual QString description() const;
-    virtual QString identifier() const;
-    virtual QStringList handled() const;
+    QString description() const override;
+    QString identifier() const override;
+    QStringList handled() const override;
 
     static bool registered();
 
-    virtual void setInputData(medAbstractData * data);
+    void setInputData(medAbstractData * data) override;
 
-    virtual QWidget* buildLayerWidget();
-    virtual QWidget* buildToolBoxWidget();
-    virtual QWidget* buildToolBarWidget();
+    QWidget* buildLayerWidget() override;
+    QWidget* buildToolBoxWidget() override;
+    QWidget* buildToolBarWidget() override;
 
-    virtual QList<medAbstractParameterL*> linkableParameters();
-    virtual QList<medBoolParameterL*> mouseInteractionParameters();
+    QList<medAbstractParameterL*> linkableParameters() override;
+    QList<medBoolParameterL*> mouseInteractionParameters() override;
 
-    virtual void removeData();
+    void removeData() override;
 
 public slots:
 
@@ -63,7 +63,7 @@ public slots:
 
     virtual void setUpViewForThumbnail();
 
-    virtual void updateWidgets();
+    void updateWidgets() override;
 
 protected:
     void setupParameters();

--- a/src/plugins/legacy/itkDataImage/manager/vtkPolydataNormalsOrienter.cpp
+++ b/src/plugins/legacy/itkDataImage/manager/vtkPolydataNormalsOrienter.cpp
@@ -26,7 +26,7 @@ vtkStandardNewMacro(vtkPolyDataNormalsOrienter)
 
 vtkPolyDataNormalsOrienter::vtkPolyDataNormalsOrienter()
 {
-    Matrix = 0;
+    Matrix = nullptr;
 }
 
 

--- a/src/plugins/legacy/itkDataImage/manager/vtkPolydataNormalsOrienter.h
+++ b/src/plugins/legacy/itkDataImage/manager/vtkPolydataNormalsOrienter.h
@@ -30,7 +30,7 @@ protected:
 
     virtual int RequestData(vtkInformation* request,
                             vtkInformationVector** inputVector,
-                            vtkInformationVector* outputVector);
+                            vtkInformationVector* outputVector) override;
 
 private:
     vtkMatrix4x4      *Matrix;

--- a/src/plugins/legacy/itkDataImage/manager/vtkVectorOrienter.h
+++ b/src/plugins/legacy/itkDataImage/manager/vtkVectorOrienter.h
@@ -26,6 +26,8 @@ public:
         ProjectOnXZ,
         ProjectOnXY
     };
+  vtkVectorOrienter(const vtkVectorOrienter&) = delete;
+  void operator=(const vtkVectorOrienter&) = delete;
 
   vtkTypeMacro(vtkVectorOrienter,vtkImageAlgorithm);
   void PrintSelf(ostream& os, vtkIndent indent);
@@ -55,13 +57,11 @@ protected:
 
   virtual int RequestData(vtkInformation* request,
                           vtkInformationVector** inputVector,
-                          vtkInformationVector* outputVector);
+                          vtkInformationVector* outputVector) override;
 
 
 
 private:
-  vtkVectorOrienter(const vtkVectorOrienter&);  // Not implemented.
-  void operator=(const vtkVectorOrienter&);  // Not implemented.
 
   ProjectionMode    ProjMode;
 

--- a/src/plugins/legacy/itkDataImage/manager/vtkVectorVisuManager.cxx
+++ b/src/plugins/legacy/itkDataImage/manager/vtkVectorVisuManager.cxx
@@ -50,6 +50,8 @@ vtkVectorVisuManager::vtkVectorVisuManager()
     this->GlyphMapper->SetInputConnection( this->Orienter->GetOutputPort() );
     this->GlyphMapper->SetSourceConnection(arrowSource->GetOutputPort());
     this->GlyphMapper->SetScaleModeToScaleByVectorComponents();
+    this->GlyphMapper->SetOrientationModeToDirection();
+    this->GlyphMapper->SetStatic(false);
 
     this->GlyphMapper->OrientOn();
     this->GlyphMapper->ScalingOn();
@@ -95,7 +97,7 @@ void vtkVectorVisuManager::SetInput(vtkImageData* data, vtkMatrix4x4 *matrix)
 
     this->VOI->SetInputData ( this->Input );
     this->Orienter->SetOrientationMatrix(matrix);
-     this->GlyphMapper->Modified(); // a voir
+    this->GlyphMapper->Modified(); // a voir
 }
 
 void vtkVectorVisuManager::SetVOI(const int& imin, const int& imax,

--- a/src/plugins/legacy/itkDataImage/manager/vtkVectorVisuManager.h
+++ b/src/plugins/legacy/itkDataImage/manager/vtkVectorVisuManager.h
@@ -18,6 +18,7 @@
 #include <vtkPolyDataMapper.h>
 #include <vtkPolyDataNormals.h>
 #include <vtkGlyph3D.h>
+#include <vtkGlyph3DMapper.h>
 #include <vtkExtractVOI.h>
 #include <vtkPolyDataAlgorithm.h>
 #include <vtkUnsignedIntArray.h>
@@ -26,6 +27,7 @@
 #include <vtkImageData.h>
 #include <vtkVectorOrienter.h>
 #include <vtkAssignAttribute.h>
+
 
 #include <vtkPolydataNormalsOrienter.h>
 
@@ -73,11 +75,8 @@ class vtkVectorVisuManager : public vtkObject
   void SetSampleRate(const int&,const int&,const int&);
   int* GetSampleRate(){return this->VOI->GetSampleRate();}
 
-  /** Get the vtkMapper. */
-  vtkGetObjectMacro (Mapper, vtkMapper)
-
-  /** Get the vtkGlyph3D. */
-  vtkGetObjectMacro (Glyph, vtkGlyph3D)
+  /** Get the vtkGlyph3DMapper. */
+  vtkGetObjectMacro (GlyphMapper, vtkGlyph3DMapper)
 
   void SetColorMode(ColorMode mode);
   ColorMode GetColorMode(){return this->CurrentColorMode;}
@@ -103,11 +102,10 @@ class vtkVectorVisuManager : public vtkObject
   vtkExtractVOI*            VOI;
   vtkAssignAttribute *      Assign;
   vtkVectorOrienter*        Orienter;
-  vtkGlyph3D*               Glyph;
-  vtkPolyDataMapper*        Mapper;
+  vtkGlyph3DMapper*         GlyphMapper;
+
   vtkActor*                 Actor;
   vtkPolyDataNormals*       Normals;
-  vtkPolyDataNormalsOrienter* NormalsOrienter;
 
   vtkImageData*             Input;
 


### PR DESCRIPTION
changes Glyph3d to Glyph3dMapper in order to benefit from GPU perf. 

Other benefits : 
     
- The rendering seems meaningfull with a test data. 
- no crash in 3D when changing orientation 

Disadvantages : 

- arrow are smaller in 3D 


