### PR TITLE
Aphp feedback 

### DIFF
--- a/src/plugins/legacy/polygonRoi/data/polygonRoi.cpp
+++ b/src/plugins/legacy/polygonRoi/data/polygonRoi.cpp
@@ -506,26 +506,3 @@ bool polygonRoi::pasteContour(QVector<QVector2D> nodes)
 
     return true;
 }
-
-double polygonRoi::findClosestContourFromPoint(QVector3D worldMouseCoord)
-{
-    if (!d->polyData)
-    {
-        d->polyData = createPolyDataFromContour();
-    }
-
-    double coords[3] = {worldMouseCoord.x(), worldMouseCoord.y(), worldMouseCoord.z()};
-    vtkSmartPointer<vtkCellLocator> cellLocator =
-        vtkSmartPointer<vtkCellLocator>::New();
-    cellLocator->SetDataSet(d->polyData);
-    cellLocator->BuildLocator();
-
-    //Find the closest points to TestPoint
-    double closestPoint[3];//the coordinates of the closest point will be returned here
-    double closestPointDist2; //the squared distance to the closest point will be returned here
-    vtkIdType cellId; //the cell id of the cell containing the closest point will be returned here
-    int subId; //this is rarely used (in triangle strips only, I believe)
-    cellLocator->FindClosestPoint(coords, closestPoint, cellId, subId, closestPointDist2);
-    return closestPointDist2;
-}
-

--- a/src/plugins/legacy/polygonRoi/data/polygonRoi.cpp
+++ b/src/plugins/legacy/polygonRoi/data/polygonRoi.cpp
@@ -119,8 +119,7 @@ polygonRoi::polygonRoi(vtkImageView2D *view, QColor color, medAbstractRoi *paren
 {
     vtkSmartPointer<vtkContourOverlayRepresentation> contourRep = vtkSmartPointer<vtkContourOverlayRepresentation>::New();
     contourRep->GetLinesProperty()->SetLineWidth(4);
-    contourRep->GetProperty()->SetPointSize(5);
-    contourRep->GetProperty()->SetColor(1.0, 0.0, 0.0);
+    contourRep->GetProperty()->SetPointSize(8);
     contourRep->GetActiveProperty()->SetOpacity(0);
     contourRep->SetPixelTolerance(20);
     d->contour = vtkContourWidget::New();
@@ -154,15 +153,27 @@ polygonRoi::~polygonRoi()
 
 void polygonRoi::setEnableLeftButtonInteraction(bool state)
 {
+    vtkContourOverlayRepresentation *contourRep =
+            dynamic_cast<vtkContourOverlayRepresentation*>(d->contour->GetContourRepresentation());
     if (state)
     {
         d->contour->GetEventTranslator()->SetTranslation(vtkCommand::LeftButtonPressEvent, vtkWidgetEvent::Select);
         d->contour->GetEventTranslator()->SetTranslation(vtkCommand::MouseMoveEvent, vtkWidgetEvent::Move);
+        setRightColor();
     }
     else
     {
         d->contour->GetEventTranslator()->SetTranslation(vtkCommand::LeftButtonPressEvent, vtkWidgetEvent::NoEvent);
         d->contour->GetEventTranslator()->SetTranslation(vtkCommand::MouseMoveEvent, vtkWidgetEvent::NoEvent);
+        QColor tr = Qt::transparent;
+        double color[3];
+        color[0] = tr.redF();
+        color[1] = tr.greenF();
+        color[2] = tr.blueF();
+        contourRep->GetLinesProperty()->SetColor(color);
+        contourRep->GetProperty()->SetColor(color);
+        contourRep->GetLinesProperty()->SetOpacity(0.2);
+        contourRep->GetProperty()->SetOpacity(0.2);
     }
 }
 
@@ -188,7 +199,6 @@ vtkPolyData *polygonRoi::createPolyDataFromContour()
             contourRep->GetIntermediatePointWorldPosition(j, k, pos);
             vec_ids.push_back(points->InsertNextPoint(pos));
         }
-
     }
     polygon->Initialize(points->GetNumberOfPoints(), &vec_ids[0], points);
 
@@ -257,7 +267,6 @@ void polygonRoi::loadNodes(QVector<QVector3D> coordinates)
     polydata->SetLines(lines);
     d->contour->Initialize(polydata);
     d->contour->GetContourRepresentation()->SetClosedLoop(1);
-
 
     emit updateCursorState(CURSORSTATE::CS_MOUSE_EVENT);
     emit interpolate();
@@ -410,13 +419,17 @@ void polygonRoi::setRightColor()
     color[2] = d->roiColor.blueF();
     vtkContourOverlayRepresentation *contourRep = dynamic_cast<vtkContourOverlayRepresentation*>(d->contour->GetContourRepresentation());
     contourRep->GetLinesProperty()->SetColor(color);
+    contourRep->GetProperty()->SetColor(1., 0., 0.);
+
     if(isMasterRoi())
     {
         contourRep->GetLinesProperty()->SetOpacity(1.);
+        contourRep->GetProperty()->SetOpacity(1.);
     }
     else
     {
         contourRep->GetLinesProperty()->SetOpacity(0.2);
+        contourRep->GetProperty()->SetOpacity(0.2);
     }
 }
 

--- a/src/plugins/legacy/polygonRoi/data/polygonRoi.h
+++ b/src/plugins/legacy/polygonRoi/data/polygonRoi.h
@@ -65,7 +65,6 @@ public:
 
     medWorldPosContours getContourAsNodes();
     void manageTick(medSliderL *slider);
-    double findClosestContourFromPoint(QVector3D coords);
 
     QVector<QVector2D> copyContour();
     bool pasteContour(QVector<QVector2D> nodes);

--- a/src/plugins/legacy/polygonRoi/medTagRoiManager.cpp
+++ b/src/plugins/legacy/polygonRoi/medTagRoiManager.cpp
@@ -243,7 +243,6 @@ void medTagRoiManager::removeAllTick()
             slicingParameter->getSlider()->update();
         }
     }
-
 }
 
 void medTagRoiManager::initializeMaskData( medAbstractData * imageData, medAbstractData * maskData )
@@ -572,8 +571,10 @@ polygonRoi *medTagRoiManager::existingRoiInSlice()
     int slice = view2d->GetSlice();
 
     if (!isSameOrientation(view2d->GetViewOrientation()))
-        emit displayErrorMessage(getName() + ": has not the same orientation as 2D view");
+    {
+        emit sendErrorMessage(getName() + ": has not the same orientation as 2D view");
         return nullptr;
+    }
 
     for (polygonRoi* roi : d->rois)
     {
@@ -648,7 +649,7 @@ bool medTagRoiManager::pasteContour(QVector<QVector2D> nodes)
     polygonRoi *roi = existingRoiInSlice();
     if ( roi )
     {
-        emit displayErrorMessage(getName + " already exists in current slice.");
+        emit sendErrorMessage(getName() + " already exists in current slice.");
         return false;
     }
     vtkImageView2D *view2d = static_cast<medVtkViewBackend*>(d->view->backend())->view2D;
@@ -656,7 +657,7 @@ bool medTagRoiManager::pasteContour(QVector<QVector2D> nodes)
 
     if (!isSameOrientation(view2d->GetViewOrientation()))
     {
-        emit displayErrorMessage(getName() + ": has not the same orientation as 2D view");
+        emit sendErrorMessage(getName() + ": has not the same orientation as 2D view");
         return false;
     }
 
@@ -700,7 +701,9 @@ double medTagRoiManager::getMinimumDistanceFromNodesToMouse(double eventPos[2], 
             contourRep->GetNthNodeDisplayPosition(j, contourPos);
             dist = getDistance(eventPos, contourPos);
             if ( dist < minDist )
+            {
                 minDist = dist;
+            }
 
             if (allNodes)
             {
@@ -821,7 +824,7 @@ void medTagRoiManager::interpolateIfNeeded()
     {
         if ( roi->getContour()->GetContourRepresentation()->GetClosedLoop() == false )
         {
-            emit displayErrorMessage(getName() + ": Non-closed polygon at slice: " + QString::number(roi->getIdSlice()+1) + ". Operation aborted");
+            emit sendErrorMessage(getName() + ": Non-closed polygon at slice: " + QString::number(roi->getIdSlice()+1) + ". Operation aborted");
             return;
         }
     }
@@ -865,7 +868,7 @@ QList<polygonRoi *> medTagRoiManager::interpolateBetween2Slices(polygonRoi *firs
     QList<QVector<QVector3D>> listOfNodes = generateIntermediateCurves(curveMax,curveMin,maxSlice-minSlice-1);
     if ( listOfNodes.size() != (maxSlice-minSlice-1) )
     {
-        emit displayErrorMessage(getName() + ": Unable to interpolate between slice: " + QString::number(minSlice+1) + " and " + QString::number(maxSlice-1) + ". Operation aborted");
+        emit sendErrorMessage(getName() + ": Unable to interpolate between slice: " + QString::number(minSlice+1) + " and " + QString::number(maxSlice-1) + ". Operation aborted");
     }
 
     vtkImageView2D *view2d = static_cast<medVtkViewBackend*>(d->view->backend())->view2D;

--- a/src/plugins/legacy/polygonRoi/medTagRoiManager.cpp
+++ b/src/plugins/legacy/polygonRoi/medTagRoiManager.cpp
@@ -1071,21 +1071,6 @@ void medTagRoiManager::resampleCurve(vtkPolyData *poly,int nbPoints)
     points->Delete();
 }
 
-double medTagRoiManager::findClosestContourFromPoint(QVector3D worldMouseCoord)
-{
-    double minDist = DBL_MAX;
-    for (polygonRoi *roi : d->rois)
-    {
-        double dist = roi->findClosestContourFromPoint(worldMouseCoord);
-        if ( dist < minDist)
-        {
-            minDist = dist;
-            d->closestSlice = roi->getIdSlice();
-        }
-    }
-    return minDist;
-}
-
 int medTagRoiManager::getClosestSliceFromPoint()
 {
     return d->closestSlice;

--- a/src/plugins/legacy/polygonRoi/medTagRoiManager.cpp
+++ b/src/plugins/legacy/polygonRoi/medTagRoiManager.cpp
@@ -235,10 +235,13 @@ void medTagRoiManager::removeAllTick()
             break;
         }
     }
-    for (polygonRoi *roi : d->rois)
+    if (slicingParameter)
     {
-        slicingParameter->getSlider()->removeTick(roi->getIdSlice());
-        slicingParameter->getSlider()->update();
+        for (polygonRoi *roi : d->rois)
+        {
+            slicingParameter->getSlider()->removeTick(roi->getIdSlice());
+            slicingParameter->getSlider()->update();
+        }
     }
 
 }
@@ -547,7 +550,10 @@ void medTagRoiManager::createMaskWithLabel(int label)
 void medTagRoiManager::SetMasterRoi(bool state)
 {
     polygonRoi *roi = existingRoiInSlice();
-    roi->setMasterRoi(true);
+    if (roi)
+    {
+        roi->setMasterRoi(true);
+    }
 }
 
 void medTagRoiManager::manageTick(medSliderL *slider)
@@ -566,6 +572,7 @@ polygonRoi *medTagRoiManager::existingRoiInSlice()
     int slice = view2d->GetSlice();
 
     if (!isSameOrientation(view2d->GetViewOrientation()))
+        emit displayErrorMessage(getName() + ": has not the same orientation as 2D view");
         return nullptr;
 
     for (polygonRoi* roi : d->rois)
@@ -609,11 +616,11 @@ void medTagRoiManager::manageVisibility()
 
 void medTagRoiManager::setEnableInteraction(bool state)
 {
-    polygonRoi *roi = existingRoiInSlice();
-    if ( roi )
+    for (polygonRoi *roi : d->rois)
     {
         roi->setEnableLeftButtonInteraction(state);
     }
+    d->view->render();
 }
 
 void medTagRoiManager::enableOtherViewVisibility(medAbstractImageView *v, bool state)
@@ -641,6 +648,7 @@ bool medTagRoiManager::pasteContour(QVector<QVector2D> nodes)
     polygonRoi *roi = existingRoiInSlice();
     if ( roi )
     {
+        emit displayErrorMessage(getName + " already exists in current slice.");
         return false;
     }
     vtkImageView2D *view2d = static_cast<medVtkViewBackend*>(d->view->backend())->view2D;
@@ -648,6 +656,7 @@ bool medTagRoiManager::pasteContour(QVector<QVector2D> nodes)
 
     if (!isSameOrientation(view2d->GetViewOrientation()))
     {
+        emit displayErrorMessage(getName() + ": has not the same orientation as 2D view");
         return false;
     }
 
@@ -677,29 +686,7 @@ bool medTagRoiManager::mouseIsCloseFromNodes(double mousePos[2])
     return false;
 }
 
-double medTagRoiManager::getMinimumDistanceFromNodesToEventPosition(double eventPos[2])
-{
-    polygonRoi *roi = existingRoiInSlice();
-    double minDist = DBL_MAX;
-    double dist = 0.;
-    double contourPos[2];
-    if (roi)
-    {
-        for (int i = 0; i< roi->getContour()->GetContourRepresentation()->GetNumberOfNodes(); i++)
-        {
-            roi->getContour()->GetContourRepresentation()->GetNthNodeDisplayPosition(i, contourPos);
-            dist = getDistance(eventPos, contourPos);
-            if ( dist < minDist )
-            {
-                minDist = dist;
-            }
-        }
-    }
-    return minDist;
-
-}
-
-double medTagRoiManager::getMinimumDistanceFromIntermediateNodesToEventPosition(double eventPos[2])
+double medTagRoiManager::getMinimumDistanceFromNodesToMouse(double eventPos[2], bool allNodes)
 {
     polygonRoi *roi = existingRoiInSlice();
     double minDist = DBL_MAX;
@@ -714,14 +701,17 @@ double medTagRoiManager::getMinimumDistanceFromIntermediateNodesToEventPosition(
             dist = getDistance(eventPos, contourPos);
             if ( dist < minDist )
                 minDist = dist;
-            for ( int k = 0; k<contourRep->GetNumberOfIntermediatePoints(j); k++ )
-            {
-                contourRep->GetIntermediatePointDisplayPosition(j, k, contourPos);
-                dist = getDistance(eventPos, contourPos);
-                if ( dist < minDist )
-                    minDist = dist;
-            }
 
+            if (allNodes)
+            {
+                for ( int k = 0; k<contourRep->GetNumberOfIntermediatePoints(j); k++ )
+                {
+                    contourRep->GetIntermediatePointDisplayPosition(j, k, contourPos);
+                    dist = getDistance(eventPos, contourPos);
+                    if ( dist < minDist )
+                        minDist = dist;
+                }
+            }
         }
 
     }
@@ -831,7 +821,7 @@ void medTagRoiManager::interpolateIfNeeded()
     {
         if ( roi->getContour()->GetContourRepresentation()->GetClosedLoop() == false )
         {
-            //displayMessageError("Non-closed polygon at slice: " + QString::number(roi->getIdSlice()+1) + ". Operation aborted");
+            emit displayErrorMessage(getName() + ": Non-closed polygon at slice: " + QString::number(roi->getIdSlice()+1) + ". Operation aborted");
             return;
         }
     }
@@ -861,37 +851,34 @@ QList<polygonRoi *> medTagRoiManager::interpolateBetween2Slices(polygonRoi *firs
     vtkContourRepresentation* contour;
     // Contour first ROI
     contour = firstRoi->getContour()->GetContourRepresentation();
+
     vtkSmartPointer<vtkPolyData> curveMin = contour->GetContourRepresentationAsPolyData();
-    int curveMinNbNode = contour->GetNumberOfNodes();
     int minSlice = firstRoi->getIdSlice();
 
     // Contour second ROI
     contour = secondRoi->getContour()->GetContourRepresentation();
     vtkSmartPointer<vtkPolyData> curveMax = contour->GetContourRepresentationAsPolyData();
 
-    int curveMaxNbNode = contour->GetNumberOfNodes();
     int maxSlice = secondRoi->getIdSlice();
 
     // Compute intermediate ROIs between two successive ROIs
-    QList<vtkPolyData *> listPolyData = generateIntermediateCurves(curveMax,curveMin,maxSlice-minSlice-1);
-    double number = ceil(1.8 * (double)(curveMinNbNode));
-    if (curveMaxNbNode > curveMinNbNode)
+    QList<QVector<QVector3D>> listOfNodes = generateIntermediateCurves(curveMax,curveMin,maxSlice-minSlice-1);
+    if ( listOfNodes.size() != (maxSlice-minSlice-1) )
     {
-        number = ceil(1.8 * (double)(curveMaxNbNode));
+        emit displayErrorMessage(getName() + ": Unable to interpolate between slice: " + QString::number(minSlice+1) + " and " + QString::number(maxSlice-1) + ". Operation aborted");
     }
 
     vtkImageView2D *view2d = static_cast<medVtkViewBackend*>(d->view->backend())->view2D;
-
-    for (int i = minSlice+1;i<maxSlice;i++)
+    int idSlice = minSlice+1;
+    for (QVector<QVector3D> nodes : listOfNodes)
     {
         polygonRoi *polyRoi = new polygonRoi(view2d, d->color);
+        polyRoi->loadNodes(nodes);
         vtkContourWidget *contour = polyRoi->getContour();
-        contour->SetEnabled(true);
-
-        int nbPointsPoly = listPolyData[i-(minSlice+1)]->GetNumberOfPoints();
+        vtkSmartPointer<vtkPolyData> poly = vtkSmartPointer<vtkPolyData>::New();
+        contour->GetContourRepresentation()->GetNodePolyData(poly);
+        int nbPointsPoly = contour->GetContourRepresentation()->GetNumberOfNodes();
         int pointToRemove = 0;
-
-        contour->Initialize(listPolyData[i-(minSlice+1)]);
         for (int k = 0; k<nbPointsPoly; k++)
         {
             if (k%5==0)
@@ -903,31 +890,20 @@ QList<polygonRoi *> medTagRoiManager::interpolateBetween2Slices(polygonRoi *firs
                 contour->GetContourRepresentation()->DeleteNthNode(pointToRemove);
             }
         }
-
-        vtkContourRepresentation *contourRep = contour->GetContourRepresentation();
-
-        contourRep->SetClosedLoop(1);
-
-        polyRoi->setIdSlice(i);
+        contour->SetEnabled(true);
+        polyRoi->setIdSlice(idSlice);
+        idSlice++;
         polyRoi->setMasterRoi(false);
-        //addViewsToRoi(polyRoi);
 
         outputRois.append(polyRoi);
     }
-
-    for (vtkPolyData *pd : listPolyData)
-    {
-        pd->Delete();
-    }
-    listPolyData.clear();
-
+    listOfNodes.clear();
     return outputRois;
 }
 
-QList<vtkPolyData* > medTagRoiManager::generateIntermediateCurves(vtkSmartPointer<vtkPolyData> curve1, vtkSmartPointer<vtkPolyData> curve2, int nb)
+QList<QVector<QVector3D>> medTagRoiManager::generateIntermediateCurves(vtkSmartPointer<vtkPolyData> curve1, vtkSmartPointer<vtkPolyData> curve2, int nb)
 {
     int max = curve2->GetNumberOfPoints();
-
     vtkSmartPointer<vtkPolyData> startCurve = curve1, endCurve = curve2;
     bool curve2ToCurve1 = false;
 
@@ -946,17 +922,10 @@ QList<vtkPolyData* > medTagRoiManager::generateIntermediateCurves(vtkSmartPointe
     reorderPolygon(startCurve);
     reorderPolygon(endCurve);
 
-    vtkSmartPointer<vtkPoints> bufferPoints = vtkSmartPointer<vtkPoints>::New();
-    QList<vtkPolyData*> list;
+    QList<QVector<QVector3D>> listOfNodes;
     for(int i=1; i<=nb; i++)
     {
-        vtkPolyData *poly = vtkPolyData::New();
-        vtkCellArray *cells = vtkCellArray::New();
-        vtkPolyLine *polyLine = vtkPolyLine::New();
-
-        polyLine->GetPointIds()->SetNumberOfIds(startCurve->GetNumberOfPoints());
-
-        bufferPoints->Reset();
+        QVector<QVector3D> nodes;
         for(int k=0; k<startCurve->GetNumberOfPoints(); k++)
         {
             double p1[3],p2[3],p3[3];
@@ -974,21 +943,11 @@ QList<vtkPolyData* > medTagRoiManager::generateIntermediateCurves(vtkSmartPointe
                 p3[1]= p2[1] +(p1[1]-p2[1])*((i)/(double)(nb+1));
                 p3[2]= p2[2] +(p1[2]-p2[2])*((i)/(double)(nb+1));
             }
-            bufferPoints->InsertNextPoint(p3);
-            polyLine->GetPointIds()->SetId(k, k);
+            nodes.push_back(QVector3D(p3[0], p3[1], p3[2]));
         }
-        cells->InsertNextCell(polyLine);
-
-        vtkPoints * polyPoints = vtkPoints::New();
-        polyPoints->DeepCopy(bufferPoints);
-        poly->SetPoints(polyPoints);
-        poly->SetLines(cells);
-        list.append(poly);
-        cells->Delete();
-        polyLine->Delete();
-        polyPoints->Delete();
+        listOfNodes.append(nodes);
     }
-    return list;
+    return listOfNodes;
 }
 
 void medTagRoiManager::reorderPolygon(vtkPolyData *poly)

--- a/src/plugins/legacy/polygonRoi/medTagRoiManager.h
+++ b/src/plugins/legacy/polygonRoi/medTagRoiManager.h
@@ -62,7 +62,6 @@ public:
     void select(bool state);
     void loadContours(QVector<medWorldPosContours> contours);
 
-    double findClosestContourFromPoint(QVector3D worldMouseCoord);
     int getClosestSliceFromPoint();
 
     QVector<QVector2D> copyContour();

--- a/src/plugins/legacy/polygonRoi/medTagRoiManager.h
+++ b/src/plugins/legacy/polygonRoi/medTagRoiManager.h
@@ -49,8 +49,7 @@ public:
     void manageTick(medSliderL *slider);
     void manageVisibility();
     bool mouseIsCloseFromNodes(double mousePos[2]);
-    double getMinimumDistanceFromNodesToEventPosition(double eventPos[2]);
-    double getMinimumDistanceFromIntermediateNodesToEventPosition(double eventPos[2]);
+    double getMinimumDistanceFromNodesToMouse(double eventPos[2], bool allNodes = true);
     void deleteNode(double X, double Y);
     void deleteContour();
     void removeAllTick();
@@ -70,13 +69,14 @@ public:
     void removeContourOtherView(medAbstractImageView *v);
     void removeIntermediateContoursOtherView(medAbstractImageView *v);
     void setEnableInteraction(bool state);
+
 public slots:
     void interpolateIfNeeded();
     void enableOtherViewVisibility(medAbstractImageView *v, bool state);
 
 signals:
     void enableOtherViewsVisibility(bool state);
-
+    void displayErrorMessage(QString);
 private:
     dtkSmartPointer<medAbstractData> output;
     dtkSmartPointer<medAbstractData> contourOutput;
@@ -84,7 +84,7 @@ private:
     medTagRoiManagerPrivate* const d;
 
     QList<polygonRoi *> interpolateBetween2Slices(polygonRoi *firstRoi, polygonRoi *secondRoi);
-    QList<vtkPolyData *> generateIntermediateCurves(vtkSmartPointer<vtkPolyData> curve1, vtkSmartPointer<vtkPolyData> curve2, int nb);
+    QList<QVector<QVector3D> > generateIntermediateCurves(vtkSmartPointer<vtkPolyData> curve1, vtkSmartPointer<vtkPolyData> curve2, int nb);
     void resampleCurve(vtkPolyData *poly, int nbPoints);
     void reorderPolygon(vtkPolyData *poly);
     static bool sortRois(const polygonRoi *p1, const polygonRoi *p2);

--- a/src/plugins/legacy/polygonRoi/medTagRoiManager.h
+++ b/src/plugins/legacy/polygonRoi/medTagRoiManager.h
@@ -76,7 +76,7 @@ public slots:
 
 signals:
     void enableOtherViewsVisibility(bool state);
-    void displayErrorMessage(QString);
+    void sendErrorMessage(QString);
 private:
     dtkSmartPointer<medAbstractData> output;
     dtkSmartPointer<medAbstractData> contourOutput;

--- a/src/plugins/legacy/polygonRoi/polygonEventFilter.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonEventFilter.cpp
@@ -166,11 +166,7 @@ bool polygonEventFilter::mouseReleaseEvent(medAbstractView *view, QMouseEvent *m
         return false;
     }
 
-    if (currentView != v )
-    {
-        return updateMainViewOnChosenSlice(v, mouseEvent);
-    }
-    else
+    if (currentView == v )
     {
         if (isRepulsorActivated && activateEventFilter)
         {
@@ -223,21 +219,6 @@ bool polygonEventFilter::mousePressEvent(medAbstractView * view, QMouseEvent *mo
     {
         return rightButtonBehaviour(view, mouseEvent);
     }
-    return false;
-}
-
-bool polygonEventFilter::updateMainViewOnChosenSlice(medAbstractImageView *view, QMouseEvent *mouseEvent)
-{
-    QPointF position;
-    position.setX(mouseEvent->x()*QGuiApplication::screenAt(mouseEvent->pos())->devicePixelRatio());
-    position.setY(mouseEvent->y()*QGuiApplication::screenAt(mouseEvent->pos())->devicePixelRatio());
-    QVector3D clickPosition = view->mapDisplayToWorldCoordinates(position);
-    int slice = findClosestSliceFromMouseClick(clickPosition);
-    if ( slice == -1 )
-        return false;
-    vtkImageView2D *view2D =  static_cast<medVtkViewBackend*>(currentView->backend())->view2D;
-    view2D->SetSlice(slice);
-    view2D->Render();
     return false;
 }
 
@@ -1216,20 +1197,4 @@ medTagRoiManager *polygonEventFilter::closestManagerInSlice(double mousePos[2])
         }
     }
     return managerInSlice;
-}
-
-int polygonEventFilter::findClosestSliceFromMouseClick(QVector3D worldMouseCoord)
-{
-    double minDistance = 1.;
-    medTagRoiManager *closestManager = nullptr;
-    for (medTagRoiManager *manager : managers)
-    {
-        double dist = manager->findClosestContourFromPoint(worldMouseCoord);
-        if ( dist < minDistance)
-        {
-            minDistance = dist;
-            closestManager = manager;
-        }
-    }
-    return (minDistance<1.)?closestManager->getClosestSliceFromPoint():-1;
 }

--- a/src/plugins/legacy/polygonRoi/polygonEventFilter.h
+++ b/src/plugins/legacy/polygonRoi/polygonEventFilter.h
@@ -114,8 +114,6 @@ private:
     medTagRoiManager *addManagerToList(int label, QString labelName);
     void manageButtonsState();
     void saveContoursAsMedAbstractData(vtkMetaDataSet *outputDataSet, QVector<medTagContours> contoursData);
-    int findClosestSliceFromMouseClick(QVector3D worldMouseCoord);
-    bool updateMainViewOnChosenSlice(medAbstractImageView *view, QMouseEvent *mouseEvent);
     int findAvailableLabel();
     medTagRoiManager *getManagerFromColor(QColor color);
     QLineEdit *updateNameManager(medTagRoiManager* closestManager, QMenu *mainMenu);

--- a/src/plugins/legacy/polygonRoi/polygonEventFilter.h
+++ b/src/plugins/legacy/polygonRoi/polygonEventFilter.h
@@ -86,7 +86,7 @@ signals:
     void enableViewChooser(bool state);
     void toggleRepulsorButton(bool);
     void clearLastAlternativeView();
-    void displayErrorMessage(QString);
+    void sendErrorMessage(QString);
 
 private:
     medAbstractImageView *currentView;
@@ -119,8 +119,8 @@ private:
     medTagRoiManager *getManagerFromColor(QColor color);
     QLineEdit *updateNameManager(medTagRoiManager* closestManager, QMenu *mainMenu);
     void deleteNode(double *mousePosition);
-    bool isOnlyOneNodeInSlice();
     medTagRoiManager *getClosestManager(double *mousePos);
     void enableOnlyActiveManager();
     QMenu *changeLabelActions(medTagRoiManager* closestManager);
+    bool isActiveContourInSlice();
 };

--- a/src/plugins/legacy/polygonRoi/polygonEventFilter.h
+++ b/src/plugins/legacy/polygonRoi/polygonEventFilter.h
@@ -71,20 +71,22 @@ public slots:
 
     void copyContours();
     void pasteContours();
+
 private slots:
     void deleteNode(medTagRoiManager *manager, const double *mousePos);
     void deleteContour(medTagRoiManager *manager);
     void deleteLabel(medTagRoiManager *manager);
     void saveMask(medTagRoiManager *manager);
     void saveContour(medTagRoiManager *manager);
-
     void copyContour(medTagRoiManager *manager);
+
 signals:
     void enableRepulsor(bool state);
     void enableGenerateMask(bool state);
     void enableViewChooser(bool state);
     void toggleRepulsorButton(bool);
     void clearLastAlternativeView();
+    void displayErrorMessage(QString);
 
 private:
     medAbstractImageView *currentView;
@@ -109,7 +111,6 @@ private:
     QList<QColor> updateColorsList(QList<QColor> colorsToExclude);
     bool manageRoiWithLabel(QMouseEvent *mouseEvent);
     bool addPointInContourWithLabel(QMouseEvent *mouseEvent);
-    medTagRoiManager *closestManagerInSlice(double mousePos[]);
     void setToolboxButtonsState(bool state);
     medTagRoiManager *addManagerToList(int label, QString labelName);
     void manageButtonsState();

--- a/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
@@ -309,6 +309,7 @@ void polygonRoiToolBox::clickClosePolygon(bool state)
             connect(viewEventFilter, SIGNAL(enableGenerateMask(bool)), saveBinaryMaskButton, SLOT(setEnabled(bool)), Qt::UniqueConnection);
             connect(viewEventFilter, SIGNAL(enableViewChooser(bool)), this, SLOT(enableTableViewChooser(bool)), Qt::UniqueConnection);
             connect(viewEventFilter, SIGNAL(toggleRepulsorButton(bool)), this, SLOT(activateRepulsor(bool)), Qt::UniqueConnection);
+            connect(viewEventFilter, SIGNAL(displayErrorMessage(QString)), this, SLOT(displayErrorMessage(QString)), Qt::UniqueConnection);
         }
 
         viewEventFilter->updateView(currentView);
@@ -353,6 +354,11 @@ void polygonRoiToolBox::resetToolboxBehaviour()
     }
     containersInTabSelected[0]->setClosingMode(medViewContainer::CLOSE_CONTAINER);
     enableTableViewChooser(addNewCurve->isChecked());
+}
+
+void polygonRoiToolBox::displayErrorMessage(QString error)
+{
+    displayMessageError(error);
 }
 
 void polygonRoiToolBox::manageTick()

--- a/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
@@ -309,7 +309,7 @@ void polygonRoiToolBox::clickClosePolygon(bool state)
             connect(viewEventFilter, SIGNAL(enableGenerateMask(bool)), saveBinaryMaskButton, SLOT(setEnabled(bool)), Qt::UniqueConnection);
             connect(viewEventFilter, SIGNAL(enableViewChooser(bool)), this, SLOT(enableTableViewChooser(bool)), Qt::UniqueConnection);
             connect(viewEventFilter, SIGNAL(toggleRepulsorButton(bool)), this, SLOT(activateRepulsor(bool)), Qt::UniqueConnection);
-            connect(viewEventFilter, SIGNAL(displayErrorMessage(QString)), this, SLOT(displayErrorMessage(QString)), Qt::UniqueConnection);
+            connect(viewEventFilter, SIGNAL(sendErrorMessage(QString)), this, SLOT(errorMessage(QString)), Qt::UniqueConnection);
         }
 
         viewEventFilter->updateView(currentView);
@@ -317,7 +317,7 @@ void polygonRoiToolBox::clickClosePolygon(bool state)
         viewEventFilter->On();
         viewEventFilter->installOnView(currentView);
         viewEventFilter->addObserver();
-
+        this->currentView->viewWidget()->setFocus();
         if ( viewEventFilter->isContourInSlice() )
         {
             repulsorTool->setEnabled(state);
@@ -341,6 +341,7 @@ void polygonRoiToolBox::activateRepulsor(bool state)
     {
         repulsorTool->setChecked(state);
         viewEventFilter->activateRepulsor(state);
+        currentView->viewWidget()->setFocus();
     }
 }
 
@@ -356,7 +357,7 @@ void polygonRoiToolBox::resetToolboxBehaviour()
     enableTableViewChooser(addNewCurve->isChecked());
 }
 
-void polygonRoiToolBox::displayErrorMessage(QString error)
+void polygonRoiToolBox::errorMessage(QString error)
 {
     displayMessageError(error);
 }
@@ -458,6 +459,7 @@ void polygonRoiToolBox::updateTableWidgetView(unsigned int row, unsigned int col
     connect(mainContainer, &medViewContainer::containerSelected, [=](){
         if (currentView && addNewCurve->isChecked())
         {
+            currentView->viewWidget()->setFocus();
             viewEventFilter->On();
             repulsorTool->setEnabled(true);
             if (repulsorTool->isChecked())
@@ -594,6 +596,10 @@ void polygonRoiToolBox::interpolateCurve(bool state)
         return;
     }
     viewEventFilter->setEnableInterpolation(state);
+    if ( currentView )
+    {
+        currentView->viewWidget()->setFocus();
+    }
 }
 
 void polygonRoiToolBox::saveBinaryImage()

--- a/src/plugins/legacy/polygonRoi/polygonRoiToolBox.h
+++ b/src/plugins/legacy/polygonRoi/polygonRoiToolBox.h
@@ -70,7 +70,7 @@ public slots:
     void manageRoisVisibility();
     void enableTableViewChooser(bool state);
     void resetToolboxBehaviour();
-    void displayErrorMessage(QString error);
+    void errorMessage(QString error);
 private slots:
 
     void disableButtons();

--- a/src/plugins/legacy/polygonRoi/polygonRoiToolBox.h
+++ b/src/plugins/legacy/polygonRoi/polygonRoiToolBox.h
@@ -70,7 +70,7 @@ public slots:
     void manageRoisVisibility();
     void enableTableViewChooser(bool state);
     void resetToolboxBehaviour();
-
+    void displayErrorMessage(QString error);
 private slots:
 
     void disableButtons();

--- a/src/plugins/legacy/polygonRoi/repulsor/vtkInriaInteractorStylePolygonRepulsor.cxx
+++ b/src/plugins/legacy/polygonRoi/repulsor/vtkInriaInteractorStylePolygonRepulsor.cxx
@@ -96,7 +96,7 @@ void vtkInriaInteractorStylePolygonRepulsor::OnLeftButtonDown()
     double pos[2];
     pos[0] = (double)Position[0];
     pos[1] = (double)Position[1];
-    double dist = manager->getMinimumDistanceFromIntermediateNodesToEventPosition(pos);
+    double dist = manager->getMinimumDistanceFromNodesToMouse(pos);
     this->Radius = (int)((dist+0.5)*0.8);
     this->RepulsorActor->SetRadius(this->Radius);
     this->RepulsorActor->SetCenter(this->Position[0], this->Position[1]);


### PR DESCRIPTION
- Fix Interpolation checkbox always disable
- Add error management.
   Errors are displayed in menu bar (as other tb)
- Activate a label
   When a new label is created, the others become light gray and it is impossible to interact with.
  A contextual menu (right click) allows user to activate another label
- the Cursor becomes an open hand if is close to a node. 
- contextual menu is displayed near a contour (instead of a node)
- left clic color menu is removed