### PR TITLE
memory leak, the caller is the owner 

### DIFF
--- a/src/layers/legacy/medImageIO/vtkItkConversion.tpp
+++ b/src/layers/legacy/medImageIO/vtkItkConversion.tpp
@@ -302,7 +302,7 @@ double * vtkItkConversion<volumeType, imageDim>::getCurrentScalarRange()
 
     if (m_ItkInputImage.IsNotNull() || m_ItkInputImage4D.IsNotNull())
     {
-        dResScalarRange = new double[2]; //FloTODO check potential memory leak
+        dResScalarRange = new double[2]; //FloTODO check potential memory leak // neb : the caller is the owner
         dResScalarRange[0] = VTK_DOUBLE_MAX;
         dResScalarRange[1] = VTK_DOUBLE_MIN;
 

--- a/src/layers/legacy/medImageIO/vtkItkConversion.tpp
+++ b/src/layers/legacy/medImageIO/vtkItkConversion.tpp
@@ -302,7 +302,7 @@ double * vtkItkConversion<volumeType, imageDim>::getCurrentScalarRange()
 
     if (m_ItkInputImage.IsNotNull() || m_ItkInputImage4D.IsNotNull())
     {
-        dResScalarRange = new double[2]; //FloTODO check potential memory leak // neb : the caller is the owner
+        dResScalarRange = new double[2]; //FloTODO check potential memory leak
         dResScalarRange[0] = VTK_DOUBLE_MAX;
         dResScalarRange[1] = VTK_DOUBLE_MIN;
 

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImage4DInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImage4DInteractor.cpp
@@ -126,6 +126,7 @@ void medVtkViewItkDataImage4DInteractor::setInputData(medAbstractData *data)
             double* range = m_poConv->getCurrentScalarRange();
             d->view2d->SetColorRange(range);
             this->initWindowLevelParameters(range);
+            delete [] range;
 
             createSlicingParam();
 
@@ -169,6 +170,7 @@ bool medVtkViewItkDataImage4DInteractor::SetViewInput(medAbstractData* data, int
             {
                 d->view2d->SetInput(poVtkAlgoOutputPort, poMatrix, layer);
                 d->view3d->SetInput(poVtkAlgoOutputPort, poMatrix, layer);
+                poMatrix->Delete();
             }
         }
     }
@@ -201,6 +203,7 @@ bool medVtkViewItkDataImage4DInteractor::SetViewInput(const char* type, medAbstr
                 {
                     d->view2d->SetInput(poVtkAlgoOutputPort, poMatrix, layer);
                     d->view3d->SetInput(poVtkAlgoOutputPort, poMatrix, layer);
+                    poMatrix->Delete();
                 }
             }
         }


### PR DESCRIPTION
Should find a way to make it more obvious (in vtkItkConversion)  to the developer  with a specific pattern in the function name or to use smart pointer (better sol). 

I do not have 4D data. if someone can send me a small data I will be happy to test it. 

I have check that in vtkImageView a deep copy is done the matrix and here it becomes a smart pointer. 