### PR TITLE
memory leak in vtkMetaDataSet

### DIFF
--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSet.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSet.cxx
@@ -100,6 +100,11 @@ vtkMetaDataSet::~vtkMetaDataSet()
     this->Property->Delete();
   }
 
+  if (this->LookupTable)
+  {
+    this->LookupTable->Delete();
+  }
+
   this->ActorList->Delete();
   this->ArrayCollection->Delete();
 }
@@ -605,6 +610,7 @@ void vtkMetaDataSet::ReadCSVData(const char* filename)
             }
             delete tuple;
             this->GetDataSet()->GetPointData()->AddArray(array);
+            array->Delete(); // ref count is increased in AddArray
         }
     }
 
@@ -626,6 +632,7 @@ void vtkMetaDataSet::ReadCSVData(const char* filename)
             }
             delete tuple;
             this->GetDataSet()->GetCellData()->AddArray (array);
+            array->Delete(); // ref count is increased in AddArray
         }
     }
 

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSet.h
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSet.h
@@ -57,7 +57,7 @@ class MEDVTKDATAMESHBASE_EXPORT vtkMetaDataSet: public vtkDataObject
 
   static vtkMetaDataSet* New();
   vtkTypeMacro(vtkMetaDataSet,vtkDataObject)
-  virtual void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   virtual vtkMetaDataSet* Clone();
 


### PR DESCRIPTION
In AddArray a register is called to increase the reference count on the vtkObject. 

LookUpTable is never deleted. 
