### PR TITLE
[Browser] View, Index, dbl-click, Bookmark cleaning

### DIFF
--- a/src/app/medInria/medDataSourceManager.cpp
+++ b/src/app/medInria/medDataSourceManager.cpp
@@ -97,9 +97,6 @@ void medDataSourceManager::connectDataSource(medAbstractDataSource *dataSource)
 
     connect(dataSource, SIGNAL(dataToImportReceived(QString)),
             this, SLOT(importFile(QString)));
-
-    connect(dataSource, SIGNAL(dataToIndexReceived(QString)),
-            this, SLOT(indexFile(QString)));
 }
 
 //TODO: Maybe it is not the best place to put it (medDataManager?)
@@ -139,12 +136,6 @@ void medDataSourceManager::importFile(QString path)
     medDataManager::instance()->importPath(path, false, true);
 }
 
-void medDataSourceManager::indexFile(QString path)
-{
-    medDataManager::instance()->importPath(path, true, true);
-}
-
-
 void medDataSourceManager::emitDataReceivingFailed(QString fileName)
 {
   medMessageController::instance()->showError(tr("Unable to get from source the data named ") + fileName, 3000);
@@ -165,12 +156,12 @@ medDataSourceManager::~medDataSourceManager( void )
 
 void medDataSourceManager::openFromPath(QString path)
 {
-    //qobject_cast<medApplication*>(qApp)->open(path);
+    qobject_cast<medApplication*>(qApp)->open(path);
 }
 
 void medDataSourceManager::openFromIndex(medDataIndex index)
 {
-    //qobject_cast<medApplication*>(qApp)->open(index);
+    qobject_cast<medApplication*>(qApp)->open(index);
 }
 
 void medDataSourceManager::loadFromPath(QString path)

--- a/src/app/medInria/medDataSourceManager.h
+++ b/src/app/medInria/medDataSourceManager.h
@@ -41,9 +41,7 @@ protected slots:
     void exportData(const medDataIndex &index);
     void importData(medAbstractData *data);
     void importFile(QString path);
-    void indexFile(QString path);
     void emitDataReceivingFailed(QString fileName);
-
 
 signals:
     void open(const medDataIndex&);

--- a/src/app/medInria/medFileSystemDataSource.cpp
+++ b/src/app/medInria/medFileSystemDataSource.cpp
@@ -68,28 +68,25 @@ medFileSystemDataSource::medFileSystemDataSource( QWidget* parent ): medAbstract
 
     d->side = new dtkFinderSideView;
 
-    QAction *importAction = new QAction(tr("Import"), this);
-    importAction->setIconVisibleInMenu(true);
-    importAction->setIcon(QIcon(":icons/import.png"));
-    QAction *indexAction = new QAction(tr("Index"), this);
-    indexAction->setIconVisibleInMenu(true);
-    indexAction->setIcon(QIcon(":icons/finger.png"));
-    QAction *loadAction = new QAction(tr("Temporary Import"), this);
-    loadAction->setIconVisibleInMenu(true);
-    loadAction->setIcon(QIcon(":icons/document-open.png"));
     QAction *viewAction = new QAction(tr("View"), this);
     viewAction->setIconVisibleInMenu(true);
     viewAction->setIcon(QIcon(":icons/eye.png"));
 
-    d->finder->addContextMenuAction(importAction);
-    d->finder->addContextMenuAction(indexAction);
-    d->finder->addContextMenuAction(loadAction);
-    d->finder->addContextMenuAction(viewAction);
+    QAction *tempoImportAction = new QAction(tr("Temporary Import"), this);
+    tempoImportAction->setIconVisibleInMenu(true);
+    tempoImportAction->setIcon(QIcon(":icons/document-open.png"));
 
-    connect(importAction, SIGNAL(triggered()), this, SLOT(onFileSystemImportRequested()));
-    connect(indexAction, SIGNAL(triggered()), this, SLOT(onFileSystemIndexRequested()));
-    connect( loadAction, SIGNAL(triggered()), this, SLOT(onFileSystemLoadRequested()));
-    connect( viewAction, SIGNAL(triggered()), this, SLOT(onFileSystemViewRequested()));
+    QAction *importAction = new QAction(tr("Import"), this);
+    importAction->setIconVisibleInMenu(true);
+    importAction->setIcon(QIcon(":icons/import.png"));
+
+    d->finder->addContextMenuAction(viewAction);
+    d->finder->addContextMenuAction(tempoImportAction);
+    d->finder->addContextMenuAction(importAction);
+
+    connect(viewAction,        SIGNAL(triggered()), this, SLOT(onFileSystemViewRequested()));
+    connect(tempoImportAction, SIGNAL(triggered()), this, SLOT(onFileSystemLoadRequested()));
+    connect(importAction,      SIGNAL(triggered()), this, SLOT(onFileSystemImportRequested()));
 
     QVBoxLayout *filesystem_layout = new QVBoxLayout(d->filesystemWidget);
     QHBoxLayout *toolbar_layout = new QHBoxLayout();
@@ -141,10 +138,9 @@ medFileSystemDataSource::medFileSystemDataSource( QWidget* parent ): medAbstract
     connect(d->finder, SIGNAL(selectionChanged(const QStringList&)), d->actionsToolBox, SLOT(selectedPathsChanged(const QStringList&)));
 
     connect(d->actionsToolBox, SIGNAL(bookmarkClicked()), d->finder, SLOT(onBookmarkSelectedItemsRequested()));
-    connect(d->actionsToolBox, SIGNAL(viewClicked()), this, SLOT(onFileSystemViewRequested()));
+    connect(d->actionsToolBox, SIGNAL(viewClicked()),   this, SLOT(onFileSystemViewRequested()));
     connect(d->actionsToolBox, SIGNAL(importClicked()), this, SLOT(onFileSystemImportRequested()));
-    connect(d->actionsToolBox, SIGNAL(indexClicked()), this, SLOT(onFileSystemIndexRequested()));
-    connect(d->actionsToolBox, SIGNAL(loadClicked()), this, SLOT(onFileSystemLoadRequested()));
+    connect(d->actionsToolBox, SIGNAL(loadClicked()),   this, SLOT(onFileSystemLoadRequested()));
 
     connect (d->toolbar, SIGNAL(showHiddenFiles(bool)), d->finder, SLOT(onShowHiddenFiles(bool)));
     connect (d->toolbar, SIGNAL(showHiddenFiles(bool)), this, SLOT(saveHiddenFilesSettings(bool)));
@@ -192,7 +188,7 @@ QString medFileSystemDataSource::description(void) const
 return tr("Browse the file system");
 }
 
-void medFileSystemDataSource::onFileSystemImportRequested(void)
+void medFileSystemDataSource::onFileSystemImportRequested()
 {
     // remove paths that are subpaths of some other path in the list
     QStringList purgedList = removeNestedPaths(d->finder->selectedPaths());
@@ -201,18 +197,6 @@ void medFileSystemDataSource::onFileSystemImportRequested(void)
     {
         QFileInfo info(path);
         emit dataToImportReceived(info.absoluteFilePath());
-    }
-}
-
-void medFileSystemDataSource::onFileSystemIndexRequested(void)
-{
-    // remove paths that are subpaths of some other path in the list
-    QStringList purgedList = removeNestedPaths(d->finder->selectedPaths());
-
-    foreach(QString path, purgedList)
-    {
-        QFileInfo info(path);
-        emit dataToIndexReceived(info.absoluteFilePath());
     }
 }
 
@@ -244,7 +228,9 @@ void medFileSystemDataSource::onFileDoubleClicked(const QString& filename)
 {
     QFileInfo info(filename);
     if (info.isFile())
+    {
         emit open(info.absoluteFilePath());
+    }
 }
 
 QStringList medFileSystemDataSource::removeNestedPaths(const QStringList& paths)

--- a/src/app/medInria/medFileSystemDataSource.h
+++ b/src/app/medInria/medFileSystemDataSource.h
@@ -58,7 +58,6 @@ signals:
 
 private slots:
     void onFileSystemImportRequested();
-    void onFileSystemIndexRequested();
     void onFileSystemLoadRequested();
     void onFileSystemViewRequested();
     void onFileDoubleClicked(const QString& filename);

--- a/src/layers/legacy/medCoreLegacy/gui/database/medDatabaseView.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/database/medDatabaseView.cpp
@@ -280,7 +280,7 @@ void medDatabaseView::onItemDoubleClicked(const QModelIndex& index)
 }
 
 /** Opens the currently selected item. */
-void medDatabaseView::onViewSelectedItemRequested(void)
+void medDatabaseView::onViewSelectedItemRequested()
 {
     // Called when the user right click->View in DB on a series/study
 

--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medActionsToolBox.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medActionsToolBox.cpp
@@ -27,10 +27,8 @@ public:
     QPushButton* removeBt;
     QPushButton* viewBt;
     QPushButton* exportBt;
-    QPushButton* bookmarkBt;
     QPushButton* importBt;
     QPushButton* loadBt;
-    QPushButton* indexBt;
     QPushButton* saveBt;
     QPushButton* newPatientBt;
     QPushButton* newStudyBt;
@@ -69,7 +67,6 @@ medActionsToolBox::medActionsToolBox( QWidget *parent /*= 0*/, bool FILE_SYSTEM 
 
     initializeItemToActionsMap();
 
-
     d->viewBt = new QPushButton(d->buttonsWidget);
     d->viewBt->setAccessibleName("View");
     d->viewBt->setText(tr("View"));
@@ -91,25 +88,11 @@ medActionsToolBox::medActionsToolBox( QWidget *parent /*= 0*/, bool FILE_SYSTEM 
         d->importBt->setToolTip(tr("Import (copy) item(s) into the database."));
         d->importBt->setIcon(QIcon(":/icons/import.png"));
 
-        d->indexBt = new QPushButton(d->buttonsWidget);
-        d->indexBt->setAccessibleName("Index");
-        d->indexBt->setText(tr("Index"));
-        d->indexBt->setToolTip(tr("Include the item(s) into the database but do not import (copy) them."));
-        d->indexBt->setIcon(QIcon(":/icons/finger.png"));
-
-        d->bookmarkBt = new QPushButton(d->buttonsWidget);
-        d->bookmarkBt->setAccessibleName("Bookmark");
-        d->bookmarkBt->setText(tr("Bookmark"));
-        d->bookmarkBt->setToolTip(tr("Bookmark selected folder/resource."));
-        d->bookmarkBt->setIcon(QIcon(":/icons/star.svg"));
-
-        connect(d->bookmarkBt, SIGNAL(clicked()), this, SIGNAL(bookmarkClicked()));
         connect(d->importBt, SIGNAL(clicked()), this, SIGNAL(importClicked()));
         connect(d->loadBt, SIGNAL(clicked()), this, SIGNAL(loadClicked()));
-        connect(d->indexBt, SIGNAL(clicked()), this, SIGNAL(indexClicked()));
 
-        // the order of the buttons in this list determines the order used to place them in the grid layout
-        d->buttonsList << d->viewBt << d->loadBt << d->importBt << d->indexBt << d->bookmarkBt;
+        // The order of the buttons in this list determines the order used to place them in the grid layout
+        d->buttonsList << d->viewBt << d->loadBt << d->importBt;
 
         d->informationWidget->setVisible(true);
     }
@@ -358,17 +341,14 @@ void medActionsToolBox::initializeItemToActionsMap()
 
     d->itemToActions.insert("Folders", "Bookmark");
     d->itemToActions.insert("Folders", "Import");
-    d->itemToActions.insert("Folders", "Index");
     d->itemToActions.insert("Folders", "Temporary Import");
     d->itemToActions.insert("Folders", "View");
 
     d->itemToActions.insert("Files", "Import");
-    d->itemToActions.insert("Files", "Index");
     d->itemToActions.insert("Files", "Temporary Import");
     d->itemToActions.insert("Files", "View");
 
     d->itemToActions.insert("Files & Folders", "Import");
-    d->itemToActions.insert("Files & Folders", "Index");
     d->itemToActions.insert("Files & Folders", "Temporary Import");
     d->itemToActions.insert("Files & Folders", "View");
 }

--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medActionsToolBox.h
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medActionsToolBox.h
@@ -40,9 +40,6 @@ signals:
     /** Emitted when the 'Import' button is clicked. */
     void importClicked();
 
-    /** Emitted when the 'Index' button is clicked. */
-    void indexClicked();
-
     /** Emitted when the 'Bookmark' button is clicked. */
     void bookmarkClicked();
 

--- a/src/layers/legacy/medCoreLegacy/medAbstractDataSource.h
+++ b/src/layers/legacy/medCoreLegacy/medAbstractDataSource.h
@@ -62,9 +62,6 @@ signals:
     /** A source data may emit a signal to a file on disk when it successfully received the data and is ready for importing*/
     void dataToImportReceived(QString pathToData);
 
-    /** A source data may emit a signal to a file on disk when it successfully received the data and is ready for indexing*/
-    void dataToIndexReceived(QString pathToData);
-
     /** A source data may emit a signal to a medAbstractData in memory when it successfully received the data and is ready for importing*/
     void dataReceived(medAbstractData *data);
 


### PR DESCRIPTION
fix https://github.com/medInria/medInria-public/issues/580

 * Remove the Bookmark button on the left panel, and keep it in right-click.
 * Remove the Index button and right-click action.
 * Debug double-click and View button, which does the same thing. The code was just commented, it was so weird XD.
 * Right-click actions have the same order as the buttons in left panel, to avoid to lost the user.

I'm going to do the same PR on master branch.

:m: