### PR TITLE
improve #326 and solve  #657 

### DIFF
--- a/src/layers/legacy/medCoreLegacy/views/navigators/medAbstractImageViewNavigator.cpp
+++ b/src/layers/legacy/medCoreLegacy/views/navigators/medAbstractImageViewNavigator.cpp
@@ -32,7 +32,6 @@ public:
 medAbstractImageViewNavigator::medAbstractImageViewNavigator(medAbstractView *parent):
     medAbstractLayeredViewNavigator(parent), d(new medAbstractImageViewNavigatorPrivate)
 {
-    d->view = dynamic_cast<medAbstractImageView *>(parent);
     d->positionBeingViewedParameter = nullptr;
     d->cameraParameter = nullptr;
     d->timeLineParameter = nullptr;

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
@@ -657,7 +657,6 @@ void vtkImageView::SetLookupTable (vtkLookupTable* lookuptable,int layer)
         this->SetUseLookupTable(true,layer);
         this->StoreLookupTable(lookuptable,layer);
         this->ScalarBar->SetLookupTable( lookuptable );
-        this->WindowLevel->SetLookupTable( this->LookupTable );
 
         if ( this->GetColorTransferFunction(layer) != nullptr )
         {

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
@@ -240,7 +240,6 @@ void vtkImageView::SetupInteractor(vtkRenderWindowInteractor *arg)
 void vtkImageView::SetRenderWindow(vtkRenderWindow *arg)
 {
     this->UnInstallPipeline();
-
     vtkSetObjectBodyMacro (RenderWindow, vtkRenderWindow, arg);
 
     if (this->RenderWindow && this->RenderWindow->GetInteractor())
@@ -570,9 +569,10 @@ void vtkImageView::SetTransferFunctions (vtkColorTransferFunction *color,
                                          vtkPiecewiseFunction     *opacity,
                                          int layer)
 {
-    if ( color   == nullptr && this->GetColorTransferFunction(layer)   == nullptr &&
-         opacity == nullptr && this->GetOpacityTransferFunction(layer) == nullptr &&
-         this->GetLookupTable(layer) != nullptr )
+    if ( !color   && !this->GetColorTransferFunction(layer)
+         && !opacity
+         && !this->GetOpacityTransferFunction(layer)
+         && this->GetLookupTable(layer) )
     {
         //not sure this line is useful:
         this->SetLookupTable( this->GetLookupTable(layer),layer );
@@ -583,17 +583,17 @@ void vtkImageView::SetTransferFunctions (vtkColorTransferFunction *color,
 
     // color
     vtkColorTransferFunction * rgb = nullptr;
-    if ( color != nullptr )
+    if ( color)
     {
         rgb = vtkColorTransferFunction::New();
         rgb->DeepCopy( color );
     }
-    else if ( this->GetColorTransferFunction(layer) == nullptr )
+    else if ( !this->GetColorTransferFunction(layer) )
     {
         rgb = this->GetDefaultColorTransferFunction();
     }
 
-    if ( rgb != nullptr )
+    if ( rgb )
     {
         this->StoreColorTransferFunction(rgb,layer);
         rgb->Delete();
@@ -601,24 +601,24 @@ void vtkImageView::SetTransferFunctions (vtkColorTransferFunction *color,
 
     // opacity
     vtkPiecewiseFunction * alpha = nullptr;
-    if ( opacity != nullptr )
+    if ( opacity)
     {
         alpha = vtkPiecewiseFunction::New();
         alpha->DeepCopy( opacity );
     }
-    else if ( this->GetOpacityTransferFunction(layer) == nullptr )
+    else if ( !this->GetOpacityTransferFunction(layer) )
     {
         alpha = this->GetDefaultOpacityTransferFunction();
     }
 
-    if ( alpha != nullptr )
+    if ( alpha )
     {
         this->StoreOpacityTransferFunction(alpha,layer );
         alpha->Delete();
     }
 
     // clean up
-    if ( this->GetLookupTable(layer) != nullptr )
+    if ( this->GetLookupTable(layer))
     {
         // remove lookup table not in use
         this->SetLookupTable(nullptr, layer);
@@ -983,8 +983,8 @@ void vtkImageView::SetColorRange( double r[2],int layer )
     double level  = 0.5 * ( r[0] + r[1] );
     double window = r[1] - r[0];
 
-    this->SetColorLevel( level,layer );
-    this->SetColorWindow( window,layer );
+    this->SetColorWindowLevel( window,  level,  layer);
+
 }
 
 //----------------------------------------------------------------------------
@@ -1427,8 +1427,9 @@ void vtkImageView::ResetWindowLevel()
     double window = range[1]-range[0];
     double level = 0.5*(range[1]+range[0]);
 
-    this->SetColorWindow ( window );
-    this->SetColorLevel ( level );
+    int layer = this->GetCurrentLayer();
+    this->SetColorWindowLevel(window, level, layer);
+
 }
 
 //----------------------------------------------------------------------------

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
@@ -1071,7 +1071,7 @@ double vtkImageView::GetValueAtPosition(double worldcoordinates[3], int componen
 
     int indices[3];
     this->GetImageCoordinatesFromWorldCoordinates (worldcoordinates, indices);
-    this->Get2DDisplayMapperInputAlgorithm()->UpdateInformation();
+    this->Get2DDisplayMapperInputAlgorithm(layer)->UpdateInformation();
     vtkImageData* inputImage = poAlgoTmp->GetOutput();
 
     return inputImage->GetScalarComponentAsDouble(indices[0], indices[1], indices[2], component);

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -46,77 +46,77 @@ vtkStandardNewMacro(vtkImageView3D)
 //----------------------------------------------------------------------------
 vtkImageView3D::vtkImageView3D()
 {
-  this->VolumeProperty  = vtkVolumeProperty::New();
-  this->VolumeActor     = vtkVolume::New();
+  VolumeProperty  = vtkVolumeProperty::New();
+  VolumeActor     = vtkVolume::New();
 
-  this->VolumeMapper = vtkSmartVolumeMapper::New();
+  VolumeMapper = vtkSmartVolumeMapper::New();
 
-  this->Callback    = vtkImageView3DCroppingBoxCallback::New();
-  this->BoxWidget   = vtkOrientedBoxWidget::New();
-  this->PlaneWidget = vtkPlaneWidget::New();
-  this->Marker      = vtkOrientationMarkerWidget::New();
-  this->Cube        = vtkAnnotatedCubeActor::New();
+  Callback    = vtkImageView3DCroppingBoxCallback::New();
+  BoxWidget   = vtkOrientedBoxWidget::New();
+  PlaneWidget = vtkPlaneWidget::New();
+  Marker      = vtkOrientationMarkerWidget::New();
+  Cube        = vtkAnnotatedCubeActor::New();
 
-  this->PlanarWindowLevelX = vtkSmartPointer<vtkImageMapToColors>::New();
-  this->PlanarWindowLevelY = vtkSmartPointer<vtkImageMapToColors>::New();
-  this->PlanarWindowLevelZ = vtkSmartPointer<vtkImageMapToColors>::New();
-  this->ActorX = vtkImageActor::New();
-  this->ActorY = vtkImageActor::New();
-  this->ActorZ = vtkImageActor::New();
+  PlanarWindowLevelX = vtkSmartPointer<vtkImageMapToColors>::New();
+  PlanarWindowLevelY = vtkSmartPointer<vtkImageMapToColors>::New();
+  PlanarWindowLevelZ = vtkSmartPointer<vtkImageMapToColors>::New();
+  ActorX = vtkImageActor::New();
+  ActorY = vtkImageActor::New();
+  ActorZ = vtkImageActor::New();
 
-  this->ExtraPlaneCollection = vtkProp3DCollection::New();
-  this->ExtraPlaneInputCollection = vtkProp3DCollection::New();
+  ExtraPlaneCollection = vtkProp3DCollection::New();
+  ExtraPlaneInputCollection = vtkProp3DCollection::New();
 
-  this->LayerInfoVec.resize(1);
-  this->LayerInfoVec[0].ImageDisplay = vtkSmartPointer<vtkImage3DDisplay>::New();
+  LayerInfoVec.resize(1);
+  LayerInfoVec[0].ImageDisplay = vtkSmartPointer<vtkImage3DDisplay>::New();
 
-  this->VolumeActor->SetVisibility (0);
+  VolumeActor->SetVisibility (0);
 
-  this->SetupVolumeRendering();
-  this->SetupWidgets();
+  SetupVolumeRendering();
+  SetupWidgets();
 
-  this->ShowAnnotationsOn();
-  this->TextProperty->SetColor (0,0,0);
+  ShowAnnotationsOn();
+  TextProperty->SetColor (0,0,0);
   double white[3] = {0.9, 0.9, 0.9};
-  this->SetBackground (white);
+  SetBackground (white);
 
-  this->RenderingMode = PLANAR_RENDERING;
-  this->ShowActorX = 1;
-  this->ShowActorY = 1;
-  this->ShowActorZ = 1;
+  RenderingMode = PLANAR_RENDERING;
+  ShowActorX = 1;
+  ShowActorY = 1;
+  ShowActorZ = 1;
 
-  this->Opacity    = 1.0;
-  this->Visibility = 1;
+  Opacity    = 1.0;
+  Visibility = 1;
 
-  this->CroppingMode = CROPPING_OFF;
+  CroppingMode = CROPPING_OFF;
 
   vtkInteractorStyleSwitch* styleswitch = vtkInteractorStyleSwitch::New();
   styleswitch->SetCurrentStyleToTrackballCamera();
-  this->SetInteractorStyle ( styleswitch );
+  SetInteractorStyle ( styleswitch );
   styleswitch->Delete();
 
-  this->Renderer= vtkRenderer::New();
+  Renderer= vtkRenderer::New();
 }
 
 //----------------------------------------------------------------------------
 vtkImageView3D::~vtkImageView3D()
 {
   // delete all vtk objects
-  this->LayerInfoVec.clear();  // Delete handled by smartpointer
+  LayerInfoVec.clear();  // Delete handled by smartpointer
 
-  this->VolumeMapper->Delete();
-  this->VolumeProperty->Delete();
-  this->VolumeActor->Delete();
-  this->BoxWidget->Delete();
-  this->Callback->Delete();
-  this->Cube->Delete();
-  this->Marker->Delete();
-  this->PlaneWidget->Delete();
-  this->ActorX->Delete();
-  this->ActorY->Delete();
-  this->ActorZ->Delete();
-  this->ExtraPlaneCollection->Delete();
-  this->ExtraPlaneInputCollection->Delete();
+  VolumeMapper->Delete();
+  VolumeProperty->Delete();
+  VolumeActor->Delete();
+  BoxWidget->Delete();
+  Callback->Delete();
+  Cube->Delete();
+  Marker->Delete();
+  PlaneWidget->Delete();
+  ActorX->Delete();
+  ActorY->Delete();
+  ActorZ->Delete();
+  ExtraPlaneCollection->Delete();
+  ExtraPlaneInputCollection->Delete();
 
 }
 
@@ -127,19 +127,19 @@ vtkMTimeType vtkImageView3D::GetMTime()
   vtkMTimeType mTime = Superclass::GetMTime();
 
   vtkObject * objectsToInclude[] = {
-    this->VolumeMapper,
-    this->VolumeProperty,
-    this->VolumeActor,
-    this->BoxWidget,
-    this->Cube,
-    this->Marker,
-    this->PlaneWidget,
-    this->PlanarWindowLevelX,
-    this->PlanarWindowLevelY,
-    this->PlanarWindowLevelZ,
-    this->ActorX,
-    this->ActorY,
-    this->ActorZ};
+    VolumeMapper,
+    VolumeProperty,
+    VolumeActor,
+    BoxWidget,
+    Cube,
+    Marker,
+    PlaneWidget,
+    PlanarWindowLevelX,
+    PlanarWindowLevelY,
+    PlanarWindowLevelZ,
+    ActorX,
+    ActorY,
+    ActorZ};
 
   const int numObjects = sizeof(objectsToInclude) / sizeof(vtkObject *);
 
@@ -156,14 +156,14 @@ vtkMTimeType vtkImageView3D::GetMTime()
       }
   }
 
-  this->ExtraPlaneCollection->InitTraversal();
-  vtkObject* item = this->ExtraPlaneCollection->GetNextProp3D();
+  ExtraPlaneCollection->InitTraversal();
+  vtkObject* item = ExtraPlaneCollection->GetNextProp3D();
   while(item)
   {
     const vtkMTimeType testMtime = item->GetMTime();
     if ( testMtime > mTime )
       mTime = testMtime;
-    item = this->ExtraPlaneCollection->GetNextProp3D();
+    item = ExtraPlaneCollection->GetNextProp3D();
   }
 
   return mTime;
@@ -172,192 +172,191 @@ vtkMTimeType vtkImageView3D::GetMTime()
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetVolumeMapperToRayCast()
 {
-  this->VolumeMapper->SetRequestedRenderMode(vtkSmartVolumeMapper::RayCastRenderMode );
+  VolumeMapper->SetRequestedRenderMode(vtkSmartVolumeMapper::RayCastRenderMode );
 }
 
 #ifdef MED_USE_OSPRAY_4_VR_BY_CPU
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetVolumeMapperToOSPRayRenderMode()
 {
-  this->VolumeMapper->SetRequestedRenderMode(vtkSmartVolumeMapper::OSPRayRenderMode);
+  VolumeMapper->SetRequestedRenderMode(vtkSmartVolumeMapper::OSPRayRenderMode);
 }
 #endif // MED_USE_OSPRAY_4_VR_BY_CPU
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetVolumeMapperToGPU()
 {
-  this->VolumeMapper->SetRequestedRenderMode(vtkSmartVolumeMapper::GPURenderMode );
+  VolumeMapper->SetRequestedRenderMode(vtkSmartVolumeMapper::GPURenderMode );
 }
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetVolumeMapperToDefault()
 {
-  this->VolumeMapper->SetRequestedRenderMode(vtkSmartVolumeMapper::DefaultRenderMode );
+  VolumeMapper->SetRequestedRenderMode(vtkSmartVolumeMapper::DefaultRenderMode );
 }
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetVolumeRayCastFunctionToComposite()
 {
-  this->VolumeMapper->SetBlendModeToComposite();
+  VolumeMapper->SetBlendModeToComposite();
 }
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetVolumeRayCastFunctionToMaximumIntensityProjection()
 {
-  this->VolumeMapper->SetBlendModeToMaximumIntensity();
+  VolumeMapper->SetBlendModeToMaximumIntensity();
 }
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetVolumeRayCastFunctionToMinimumIntensityProjection()
 {
-  this->VolumeMapper->SetBlendModeToMinimumIntensity();
+  VolumeMapper->SetBlendModeToMinimumIntensity();
 }
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetInterpolationToNearestNeighbor()
 {
-  this->VolumeProperty->SetInterpolationTypeToNearest();
+  VolumeProperty->SetInterpolationTypeToNearest();
 }
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetInterpolationToLinear()
 {
-  this->VolumeProperty->SetInterpolationTypeToLinear();
+  VolumeProperty->SetInterpolationTypeToLinear();
 }
 
 /** Set the box widget visibility */
 void vtkImageView3D::SetShowBoxWidget (int a)
 {
-    if (this->Interactor)
-        this->BoxWidget->SetEnabled (a);
+    if (Interactor)
+        BoxWidget->SetEnabled (a);
 }
 
 bool vtkImageView3D::GetShowBoxWidget()
 {
-    return this->BoxWidget->GetEnabled();
+    return BoxWidget->GetEnabled();
 }
 
 /** Set the plane widget on */
 void vtkImageView3D::SetShowPlaneWidget (int a)
 {
-    if (this->Interactor)
-        this->PlaneWidget->SetEnabled (a);
+    if (Interactor)
+        PlaneWidget->SetEnabled (a);
 }
 
 bool vtkImageView3D::GetShowPlaneWidget()
 {
-    return this->PlaneWidget->GetEnabled();
+    return PlaneWidget->GetEnabled();
 }
 
 /** Set the cube widget on */
 void vtkImageView3D::SetShowCube (int a)
 {
-    if (this->Interactor)
-        this->Marker->SetEnabled (a);
+    if (Interactor)
+        Marker->SetEnabled (a);
 }
 
 bool vtkImageView3D::GetShowCube()
 {
-    return this->Marker->GetEnabled();
+    return Marker->GetEnabled();
 }
 
 void vtkImageView3D::SetShade (int a)
 {
-    this->VolumeProperty->SetShade (a);
+    VolumeProperty->SetShade (a);
 }
 bool vtkImageView3D::GetShade()
 {
-    return this->VolumeProperty->GetShade();
+    return VolumeProperty->GetShade();
 }
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetupVolumeRendering()
 {
 #ifdef __APPLE__
-  this->VolumeMapper->SetRequestedRenderMode( vtkSmartVolumeMapper::RayCastRenderMode );
+  VolumeMapper->SetRequestedRenderMode( vtkSmartVolumeMapper::RayCastRenderMode );
 #else
-  this->VolumeMapper->SetRequestedRenderMode( vtkSmartVolumeMapper::DefaultRenderMode );
+  VolumeMapper->SetRequestedRenderMode( vtkSmartVolumeMapper::DefaultRenderMode );
 #endif
   this->SetCroppingModeToInside();
 
-  this->VolumeProperty->IndependentComponentsOn();
-  this->VolumeProperty->SetInterpolationTypeToLinear();
-  this->VolumeProperty->ShadeOff();
-  this->VolumeProperty->SetDiffuse (0.9);
-  this->VolumeProperty->SetAmbient (0.15);
-  this->VolumeProperty->SetSpecular (0.3);
-  this->VolumeProperty->SetSpecularPower (15.0);
+  VolumeProperty->IndependentComponentsOn();
+  VolumeProperty->SetInterpolationTypeToLinear();
+  VolumeProperty->ShadeOff();
+  VolumeProperty->SetDiffuse (0.9);
+  VolumeProperty->SetAmbient (0.15);
+  VolumeProperty->SetSpecular (0.3);
+  VolumeProperty->SetSpecularPower (15.0);
   //Warning circular reasonning here
-  if ( !this->GetUseLookupTable(0)  &&
-       this->VolumeProperty->GetIndependentComponents())
+  if ( !GetUseLookupTable(0)  &&
+       VolumeProperty->GetIndependentComponents())
   {
-    this->VolumeProperty->SetScalarOpacity(0, this->GetOpacityTransferFunction(0) );
-    auto colortransferfunction = this->GetColorTransferFunction(0);
-    this->VolumeProperty->SetColor(0, colortransferfunction);
-    this->PlanarWindowLevelX->SetLookupTable(colortransferfunction);
-    this->PlanarWindowLevelY->SetLookupTable(colortransferfunction);
-    this->PlanarWindowLevelZ->SetLookupTable(colortransferfunction);
+    VolumeProperty->SetScalarOpacity(0, GetOpacityTransferFunction(0) );
+    auto colortransferfunction = GetColorTransferFunction(0);
+    VolumeProperty->SetColor(0, colortransferfunction);
+    PlanarWindowLevelX->SetLookupTable(colortransferfunction);
+    PlanarWindowLevelY->SetLookupTable(colortransferfunction);
+    PlanarWindowLevelZ->SetLookupTable(colortransferfunction);
   }
-  else if (!this->VolumeProperty->GetIndependentComponents())
+  else if (!VolumeProperty->GetIndependentComponents())
   {
-    this->VolumeProperty->SetScalarOpacity(
-          this->GetOpacityTransferFunction(0));
-    this->VolumeProperty->SetColor(this->GetColorTransferFunction(0));
+    VolumeProperty->SetScalarOpacity(GetOpacityTransferFunction(0));
+    VolumeProperty->SetColor(GetColorTransferFunction(0));
   }
 
-  this->VolumeActor->SetProperty ( this->VolumeProperty );
-  this->VolumeActor->SetMapper ( this->VolumeMapper );
-  this->VolumeActor->PickableOff();
-  this->VolumeActor->DragableOff();
+  VolumeActor->SetProperty ( VolumeProperty );
+  VolumeActor->SetMapper ( VolumeMapper );
+  VolumeActor->PickableOff();
+  VolumeActor->DragableOff();
 
-  this->Callback->SetVolumeMapper ( this->VolumeMapper );
+  Callback->SetVolumeMapper ( VolumeMapper );
 }
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetupWidgets()
 {
   // Create an annotated cube actor (directions)
-  this->Cube->SetXPlusFaceText ("L");
-  this->Cube->SetXMinusFaceText ("R");
-  this->Cube->SetYPlusFaceText ("P");
-  this->Cube->SetYMinusFaceText ("A");
-  this->Cube->SetZPlusFaceText ("S");
-  this->Cube->SetZMinusFaceText ("I");
-  this->Cube->SetZFaceTextRotation (90);
-  this->Cube->SetFaceTextScale (0.65);
-  this->Cube->GetCubeProperty()->SetColor (0.5, 1, 1);
-  this->Cube->GetTextEdgesProperty()->SetLineWidth (1);
-  this->Cube->GetTextEdgesProperty()->SetDiffuse (0);
-  this->Cube->GetTextEdgesProperty()->SetAmbient (1);
-  this->Cube->GetTextEdgesProperty()->SetColor (0.18, 0.28, 0.23);
+  Cube->SetXPlusFaceText ("L");
+  Cube->SetXMinusFaceText ("R");
+  Cube->SetYPlusFaceText ("P");
+  Cube->SetYMinusFaceText ("A");
+  Cube->SetZPlusFaceText ("S");
+  Cube->SetZMinusFaceText ("I");
+  Cube->SetZFaceTextRotation (90);
+  Cube->SetFaceTextScale (0.65);
+  Cube->GetCubeProperty()->SetColor (0.5, 1, 1);
+  Cube->GetTextEdgesProperty()->SetLineWidth (1);
+  Cube->GetTextEdgesProperty()->SetDiffuse (0);
+  Cube->GetTextEdgesProperty()->SetAmbient (1);
+  Cube->GetTextEdgesProperty()->SetColor (0.18, 0.28, 0.23);
 
-  this->Cube->SetTextEdgesVisibility (1);
-  this->Cube->SetCubeVisibility(1);
-  this->Cube->SetFaceTextVisibility(1);
+  Cube->SetTextEdgesVisibility (1);
+  Cube->SetCubeVisibility(1);
+  Cube->SetFaceTextVisibility(1);
 
-  this->Cube->GetXPlusFaceProperty()->SetColor (1, 0, 0);
-  this->Cube->GetXPlusFaceProperty()->SetInterpolationToFlat();
-  this->Cube->GetXMinusFaceProperty()->SetColor (1, 0, 0);
-  this->Cube->GetXMinusFaceProperty()->SetInterpolationToFlat();
-  this->Cube->GetYPlusFaceProperty()->SetColor (0, 1, 0);
-  this->Cube->GetYPlusFaceProperty()->SetInterpolationToFlat();
-  this->Cube->GetYMinusFaceProperty()->SetColor (0, 1, 0);
-  this->Cube->GetYMinusFaceProperty()->SetInterpolationToFlat();
-  this->Cube->GetZPlusFaceProperty()->SetColor (0, 0, 1);
-  this->Cube->GetZPlusFaceProperty()->SetInterpolationToFlat();
-  this->Cube->GetZMinusFaceProperty()->SetColor (0, 0, 1);
-  this->Cube->GetZMinusFaceProperty()->SetInterpolationToFlat();
+  Cube->GetXPlusFaceProperty()->SetColor (1, 0, 0);
+  Cube->GetXPlusFaceProperty()->SetInterpolationToFlat();
+  Cube->GetXMinusFaceProperty()->SetColor (1, 0, 0);
+  Cube->GetXMinusFaceProperty()->SetInterpolationToFlat();
+  Cube->GetYPlusFaceProperty()->SetColor (0, 1, 0);
+  Cube->GetYPlusFaceProperty()->SetInterpolationToFlat();
+  Cube->GetYMinusFaceProperty()->SetColor (0, 1, 0);
+  Cube->GetYMinusFaceProperty()->SetInterpolationToFlat();
+  Cube->GetZPlusFaceProperty()->SetColor (0, 0, 1);
+  Cube->GetZPlusFaceProperty()->SetInterpolationToFlat();
+  Cube->GetZMinusFaceProperty()->SetColor (0, 0, 1);
+  Cube->GetZMinusFaceProperty()->SetInterpolationToFlat();
 
-  this->Marker->SetOutlineColor (0.93, 0.57, 0.13);
-  this->Marker->SetOrientationMarker (this->Cube);
-  this->Marker->SetViewport (0.0, 0.05, 0.15, 0.15);
+  Marker->SetOutlineColor (0.93, 0.57, 0.13);
+  Marker->SetOrientationMarker (Cube);
+  Marker->SetViewport (0.0, 0.05, 0.15, 0.15);
 
-  this->BoxWidget->RotationEnabledOff();
-  this->BoxWidget->SetPlaceFactor (0.5);
-  this->BoxWidget->SetKeyPressActivationValue ('b');
-  this->BoxWidget->AddObserver (vtkCommand::InteractionEvent, this->Callback);
+  BoxWidget->RotationEnabledOff();
+  BoxWidget->SetPlaceFactor (0.5);
+  BoxWidget->SetKeyPressActivationValue ('b');
+  BoxWidget->AddObserver (vtkCommand::InteractionEvent, Callback);
 
-  this->PlaneWidget->SetKeyPressActivationValue ('p');
+  PlaneWidget->SetKeyPressActivationValue ('p');
 }
 
 //----------------------------------------------------------------------------
@@ -365,23 +364,23 @@ void vtkImageView3D::InstallPipeline()
 {
   this->Superclass::InstallPipeline();
 
-  if (this->Renderer)
+  if (Renderer)
   {
-    this->Renderer->AddViewProp (this->VolumeActor);
-    this->Renderer->AddViewProp (this->ActorX);
-    this->Renderer->AddViewProp (this->ActorY);
-    this->Renderer->AddViewProp (this->ActorZ);
+    Renderer->AddViewProp (VolumeActor);
+    Renderer->AddViewProp (ActorX);
+    Renderer->AddViewProp (ActorY);
+    Renderer->AddViewProp (ActorZ);
   }
 }
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::UnInstallPipeline()
 {
-  if (this->Renderer)
+  if (Renderer)
   {
-    this->Renderer->RemoveViewProp (this->ActorX);
-    this->Renderer->RemoveViewProp (this->ActorY);
-    this->Renderer->RemoveViewProp (this->ActorZ);
+    Renderer->RemoveViewProp (ActorX);
+    Renderer->RemoveViewProp (ActorY);
+    Renderer->RemoveViewProp (ActorZ);
   }
 
   this->Superclass::UnInstallPipeline();
@@ -392,23 +391,21 @@ void vtkImageView3D::UnInstallPipeline()
 //----------------------------------------------------------------------------
 void vtkImageView3D::InstallInteractor()
 {
-    if (this->Interactor)
+    if (Interactor)
     {
-        if (this->InteractorStyle)
+        if (InteractorStyle)
         {
-            this->Interactor->SetInteractorStyle (this->InteractorStyle);
+            Interactor->SetInteractorStyle (InteractorStyle);
         }
 
         if (this->RenderWindow)
         {
-            this->Interactor->SetRenderWindow(this->RenderWindow);
-
-            this->BoxWidget->SetInteractor ( this->Interactor );
-            this->PlaneWidget->SetInteractor ( this->Interactor );
-            this->Marker->SetInteractor ( this->Interactor );
-
-            this->Marker->On();
-            this->Marker->InteractiveOff ();
+            Interactor->SetRenderWindow(this->RenderWindow);
+            BoxWidget->SetInteractor ( Interactor );
+            PlaneWidget->SetInteractor ( Interactor );
+            Marker->SetInteractor ( Interactor );
+            Marker->On();
+            Marker->InteractiveOff ();
         }
     }
     this->IsInteractorInstalled = 1;
@@ -417,25 +414,25 @@ void vtkImageView3D::InstallInteractor()
 //----------------------------------------------------------------------------
 void vtkImageView3D::UnInstallInteractor()
 {
-    this->BoxWidget->SetInteractor (nullptr);
-    this->PlaneWidget->SetInteractor (nullptr);
-    this->Marker->SetInteractor (nullptr);
+    BoxWidget->SetInteractor (nullptr);
+    PlaneWidget->SetInteractor (nullptr);
+    Marker->SetInteractor (nullptr);
 
     // Happening for instance switching from 2D->3D->2D
-    if (this->Interactor)
+    if (Interactor)
     {
-        if (this->Interactor->GetRenderWindow())
+        if (Interactor->GetRenderWindow())
         {
-            auto poRenderer = this->Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer();
+            auto poRenderer = Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer();
             while (poRenderer)
             {
                 this->RenderWindow->RemoveRenderer(poRenderer);
-                poRenderer = this->Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer();
+                poRenderer = Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer();
             }
-            this->Interactor->SetRenderWindow (nullptr);
+            Interactor->SetRenderWindow (nullptr);
         }
 
-        this->Interactor->SetInteractorStyle (nullptr);
+        Interactor->SetInteractorStyle (nullptr);
 
         this->IsInteractorInstalled = 0;
     }
@@ -449,7 +446,6 @@ void vtkImageView3D::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4
         {
             SetFirstLayer(pi_poVtkAlgoOutput, matrix, layer);
             initializeTransferFunctions(layer);
-
             if (is3D())
             {
                 this->InternalUpdate();
@@ -483,19 +479,19 @@ bool vtkImageView3D::is3D()
 {
     bool isTheData3D = true;
 
-    int * w_extent = this->GetMedVtkImageInfo()->extent;
+    int * w_extent = GetMedVtkImageInfo()->extent;
     int size [3] = { w_extent [1] - w_extent[0], w_extent [3] - w_extent[2], w_extent [5] - w_extent[4] };
 
     if ( (size[0] < 2) ||(size[1] < 2) || (size[2] < 2) )
     {
         vtkWarningMacro ( <<"Cannot do volume rendering for a single slice, skipping"<<endl);
-        this->ActorX->GetMapper()->SetInputConnection (nullptr);
-        this->ActorY->GetMapper()->SetInputConnection (nullptr);
-        this->ActorZ->GetMapper()->SetInputConnection (nullptr);
+        ActorX->GetMapper()->SetInputConnection (nullptr);
+        ActorY->GetMapper()->SetInputConnection (nullptr);
+        ActorZ->GetMapper()->SetInputConnection (nullptr);
 
-        this->VolumeMapper->SetInputConnection(nullptr);
-        this->BoxWidget->SetInputConnection (nullptr);
-        this->PlaneWidget->SetInputConnection(nullptr);
+        VolumeMapper->SetInputConnection(nullptr);
+        BoxWidget->SetInputConnection (nullptr);
+        PlaneWidget->SetInputConnection(nullptr);
 
         isTheData3D = false;
     }
@@ -505,36 +501,34 @@ bool vtkImageView3D::is3D()
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetInputLayer(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix /*= 0*/, int layer /*= 0*/)
 {
-    vtkAlgorithmOutput *poVtkAlgoOutputTmp = this->ResliceImageToInput(pi_poVtkAlgoOutput, matrix);
+    auto *poVtkAlgoOutputTmp = this->ResliceImageToInput(pi_poVtkAlgoOutput, matrix);
     // cast it if needed
     int inputImgScalarType = static_cast<vtkImageAlgorithm*>(poVtkAlgoOutputTmp->GetProducer())->GetOutput()->GetScalarType();
-    if (inputImgScalarType != this->GetMedVtkImageInfo()->scalarType)
+    if (inputImgScalarType != GetMedVtkImageInfo()->scalarType)
     {
-        vtkImageCast *cast = vtkImageCast::New();
+        auto *cast = vtkImageCast::New();
         cast->SetInputConnection(poVtkAlgoOutputTmp);
-        cast->SetOutputScalarType (this->GetMedVtkImageInfo()->scalarType);
+        cast->SetOutputScalarType (GetMedVtkImageInfo()->scalarType);
         cast->Update();
-
         poVtkAlgoOutputTmp = cast->GetOutputPort();
     }
 
     this->AddLayer(layer);
-    this->GetImage3DDisplayForLayer(layer)->SetInputProducer(poVtkAlgoOutputTmp);
+    GetImage3DDisplayForLayer(layer)->SetInputProducer(poVtkAlgoOutputTmp);
     auto image = static_cast<vtkImageAlgorithm*>(poVtkAlgoOutputTmp->GetProducer())->GetOutput();
     double *range = image->GetScalarRange();
     this->SetColorRange(range, layer);
-    this->GetImage3DDisplayForLayer(layer)->SetInputData(image);
+    GetImage3DDisplayForLayer(layer)->SetInputData(image);
 }
 
 void vtkImageView3D::SetFirstLayer(vtkAlgorithmOutput *pi_poInputAlgoImg, vtkMatrix4x4 *matrix, int layer)
 {
-    vtkImage3DDisplay *imageDisplay = this->GetImage3DDisplayForLayer(0);
+    auto *imageDisplay = GetImage3DDisplayForLayer(0);
     if (imageDisplay)
     {
         imageDisplay->SetInputProducer(pi_poInputAlgoImg);
         this->Superclass::SetInput(pi_poInputAlgoImg, matrix, layer);
         imageDisplay->SetInputData(m_poInternalImageFromInput);
-
         //The code below is useful for Volume rendering and more precisely for LUT
         double *range = m_poInternalImageFromInput->GetScalarRange();
         this->SetColorRange(range, 0);
@@ -544,73 +538,74 @@ void vtkImageView3D::SetFirstLayer(vtkAlgorithmOutput *pi_poInputAlgoImg, vtkMat
 //----------------------------------------------------------------------------
 void vtkImageView3D::InternalUpdate()
 {
-
-
     bool multiLayers = false;
-    bool multichannelInput = (this->m_poInternalImageFromInput->GetScalarType() == VTK_UNSIGNED_CHAR &&
-                              (this->m_poInternalImageFromInput->GetNumberOfScalarComponents() == 3 ||
-                               this->m_poInternalImageFromInput->GetNumberOfScalarComponents() == 4 ));
+    bool multichannelInput = (m_poInternalImageFromInput->GetScalarType() == VTK_UNSIGNED_CHAR &&
+                              (m_poInternalImageFromInput->GetNumberOfScalarComponents() == 3 ||
+                               m_poInternalImageFromInput->GetNumberOfScalarComponents() == 4 ));
 
     auto *appender = vtkImageAppendComponents::New();
-    if (this->LayerInfoVec.size()>0 && !multichannelInput)
+    if (LayerInfoVec.size()>0 && !multichannelInput)
     {
         // append all scalar buffer into the same image
-        for (auto it : this->LayerInfoVec)
+        for (auto it : LayerInfoVec)
         {
             appender->AddInputConnection(it.ImageDisplay->GetInputProducer()->GetOutputPort());
         }
-        if (this->LayerInfoVec.size()>1)
+        if (LayerInfoVec.size()>1)
         {
             multiLayers = true;
         }
     }
     appender->Update();
     appender->GetOutput();
-    this->VolumeMapper->SetInputConnection( appender->GetOutputPort());
-    this->VolumeMapper->Update();
-    this->VolumeMapper->Modified();
+    VolumeMapper->SetInputConnection( appender->GetOutputPort());
+    VolumeMapper->Update();
+    VolumeMapper->Modified();
 
     // If an image is already of type unsigned char, there is no need to
     // map it through a lookup table
     if ( !multiLayers && multichannelInput )
     {
-        this->VolumeProperty->IndependentComponentsOff();
+        VolumeProperty->IndependentComponentsOff();
         //shading and more than one dependent component (rgb) don't work well...
         //as vtk stands now in debug mode an assert makes this crash.
-        this->VolumeProperty->ShadeOff();
-        this->ActorX->GetMapper()->SetInputConnection(appender->GetOutputPort());
-        this->ActorY->GetMapper()->SetInputConnection(appender->GetOutputPort());
-        this->ActorZ->GetMapper()->SetInputConnection(appender->GetOutputPort());
+        VolumeProperty->ShadeOff();
+        ActorX->GetMapper()->SetInputConnection(appender->GetOutputPort());
+        ActorY->GetMapper()->SetInputConnection(appender->GetOutputPort());
+        ActorZ->GetMapper()->SetInputConnection(appender->GetOutputPort());
     }
-    else if(this->LayerInfoVec.size()>0)
+    else if(LayerInfoVec.size()>0)
     {
-        this->VolumeProperty->IndependentComponentsOn();
-        this->VolumeProperty->ShadeOn();
-        auto imDisplay = this->GetImage3DDisplayForLayer(0);
-        this->PlanarWindowLevelX->SetInputConnection(imDisplay->GetInputProducer()->GetOutputPort());
-        this->PlanarWindowLevelX->SetOutputFormatToRGB();
-        this->PlanarWindowLevelX->UpdateInformation();
-        this->PlanarWindowLevelX->Update();
+        VolumeProperty->IndependentComponentsOn();
+        VolumeProperty->ShadeOn();
+        auto imDisplay = GetImage3DDisplayForLayer(0);
+        if(imDisplay && imDisplay->GetInputProducer())
+        {
+            PlanarWindowLevelX->SetInputConnection(imDisplay->GetInputProducer()->GetOutputPort());
+            PlanarWindowLevelX->SetOutputFormatToRGB();
+            PlanarWindowLevelX->UpdateInformation();
+            PlanarWindowLevelX->Update();
 
-        this->PlanarWindowLevelY->SetInputConnection(imDisplay->GetInputProducer()->GetOutputPort());
-        this->PlanarWindowLevelY->SetOutputFormatToRGB();
-        this->PlanarWindowLevelY->UpdateInformation();
-        this->PlanarWindowLevelY->Update();
+            PlanarWindowLevelY->SetInputConnection(imDisplay->GetInputProducer()->GetOutputPort());
+            PlanarWindowLevelY->SetOutputFormatToRGB();
+            PlanarWindowLevelY->UpdateInformation();
+            PlanarWindowLevelY->Update();
 
-        this->PlanarWindowLevelZ->SetInputConnection(imDisplay->GetInputProducer()->GetOutputPort());
-        this->PlanarWindowLevelZ->SetOutputFormatToRGB();
-        this->PlanarWindowLevelZ->UpdateInformation();
-        this->PlanarWindowLevelZ->Update();
+            PlanarWindowLevelZ->SetInputConnection(imDisplay->GetInputProducer()->GetOutputPort());
+            PlanarWindowLevelZ->SetOutputFormatToRGB();
+            PlanarWindowLevelZ->UpdateInformation();
+            PlanarWindowLevelZ->Update();
+        }
 
-        vtkScalarsToColors* lut = this->VolumeProperty->GetRGBTransferFunction(0);
+        vtkScalarsToColors* lut = VolumeProperty->GetRGBTransferFunction(0);
         if (lut)
         {
-            this->PlanarWindowLevelX->SetLookupTable(lut);
-            this->PlanarWindowLevelY->SetLookupTable(lut);
-            this->PlanarWindowLevelZ->SetLookupTable(lut);
-            this->ActorX->GetMapper()->SetInputConnection(this->PlanarWindowLevelX->GetOutputPort());
-            this->ActorY->GetMapper()->SetInputConnection(this->PlanarWindowLevelY->GetOutputPort());
-            this->ActorZ->GetMapper()->SetInputConnection(this->PlanarWindowLevelZ->GetOutputPort());
+            PlanarWindowLevelX->SetLookupTable(lut);
+            PlanarWindowLevelY->SetLookupTable(lut);
+            PlanarWindowLevelZ->SetLookupTable(lut);
+            ActorX->GetMapper()->SetInputConnection(PlanarWindowLevelX->GetOutputPort());
+            ActorY->GetMapper()->SetInputConnection(PlanarWindowLevelY->GetOutputPort());
+            ActorZ->GetMapper()->SetInputConnection(PlanarWindowLevelZ->GetOutputPort());
         }
     }
     // Read bounds and use these to place widget, rather than force whole dataset to be read.
@@ -618,12 +613,12 @@ void vtkImageView3D::InternalUpdate()
     auto image = appender->GetOutput();
     double * bounds = image->GetBounds();
 
-    this->BoxWidget->SetInputConnection(appender->GetOutputPort());
-    this->BoxWidget->PlaceWidget (bounds);
-    this->Callback->Execute (this->BoxWidget, 0, bounds);
-    this->PlaneWidget->SetInputConnection(appender->GetOutputPort());
-    this->PlaneWidget->PlaceWidget(bounds);
-    this->UpdateDisplayExtent();
+    BoxWidget->SetInputConnection(appender->GetOutputPort());
+    BoxWidget->PlaceWidget (bounds);
+    Callback->Execute (BoxWidget, 0, bounds);
+    PlaneWidget->SetInputConnection(appender->GetOutputPort());
+    PlaneWidget->PlaceWidget(bounds);
+    UpdateDisplayExtent();
 
     appender->Delete();
 }
@@ -632,11 +627,11 @@ void vtkImageView3D::InternalUpdate()
 void vtkImageView3D::SetOrientationMatrix (vtkMatrix4x4* matrix)
 {
   this->Superclass::SetOrientationMatrix (matrix);
-  this->VolumeActor->SetUserMatrix (this->OrientationMatrix);
-  this->BoxWidget->SetOrientationMatrix (this->OrientationMatrix);
-  this->ActorX->SetUserMatrix (this->OrientationMatrix);
-  this->ActorY->SetUserMatrix (this->OrientationMatrix);
-  this->ActorZ->SetUserMatrix (this->OrientationMatrix);
+  VolumeActor->SetUserMatrix (this->OrientationMatrix);
+  BoxWidget->SetOrientationMatrix (this->OrientationMatrix);
+  ActorX->SetUserMatrix (this->OrientationMatrix);
+  ActorY->SetUserMatrix (this->OrientationMatrix);
+  ActorZ->SetUserMatrix (this->OrientationMatrix);
 }
 
 //----------------------------------------------------------------------------
@@ -644,7 +639,7 @@ void vtkImageView3D::SetOrientationMatrix (vtkMatrix4x4* matrix)
 void vtkImageView3D::SetLookupTable (vtkLookupTable* lookuptable,int layer)
 {
   this->Superclass::SetLookupTable (lookuptable,layer);
-  this->UpdateVolumeFunctions(layer);
+  UpdateVolumeFunctions(layer);
 }
 
 //----------------------------------------------------------------------------
@@ -656,22 +651,22 @@ void vtkImageView3D::SetTransferFunctions (vtkColorTransferFunction * color,
                                            vtkPiecewiseFunction * opacity,
                                            int layer)
 {
-    if (this->HasLayer (layer))
+    if (HasLayer (layer))
     {
-        if (this->GetImage3DDisplayForLayer(layer)->GetMedVtkImageInfo())
+        if (GetImage3DDisplayForLayer(layer)->GetMedVtkImageInfo())
         {
-            double *range = this->GetImage3DDisplayForLayer(layer)->GetMedVtkImageInfo()->scalarRange;
+            double *range = GetImage3DDisplayForLayer(layer)->GetMedVtkImageInfo()->scalarRange;
             this->SetTransferFunctionRangeFromWindowSettings(color, opacity, range[0], range[1]);
 
-            this->VolumeProperty->SetColor(layer, color );
-            this->VolumeProperty->SetScalarOpacity(layer, opacity );
+            VolumeProperty->SetColor(layer, color );
+            VolumeProperty->SetScalarOpacity(layer, opacity );
 
             if (layer == 0)
             {
                 //update planar window level only if we change layer 0
-                this->PlanarWindowLevelX->SetLookupTable(color);
-                this->PlanarWindowLevelY->SetLookupTable(color);
-                this->PlanarWindowLevelZ->SetLookupTable(color);
+                PlanarWindowLevelX->SetLookupTable(color);
+                PlanarWindowLevelY->SetLookupTable(color);
+                PlanarWindowLevelZ->SetLookupTable(color);
             }
         }
     }
@@ -680,10 +675,10 @@ void vtkImageView3D::SetTransferFunctions (vtkColorTransferFunction * color,
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetOpacity (double opacity, int layer)
 {
-  if (this->HasLayer(layer))
+  if (HasLayer(layer))
   {
-    this->VolumeProperty->SetComponentWeight(layer, opacity);
-    this->GetImage3DDisplayForLayer(layer)->SetOpacity(opacity);
+    VolumeProperty->SetComponentWeight(layer, opacity);
+    GetImage3DDisplayForLayer(layer)->SetOpacity(opacity);
   }
 }
 
@@ -691,7 +686,7 @@ void vtkImageView3D::SetOpacity (double opacity, int layer)
 double vtkImageView3D::GetOpacity(int layer) const
 {
     double dfRes = 0.0;
-    if (this->HasLayer(layer))
+    if (HasLayer(layer))
     {
         vtkImage3DDisplay *imageDisplay = GetImage3DDisplayForLayer(layer);
         if (imageDisplay)
@@ -705,63 +700,61 @@ double vtkImageView3D::GetOpacity(int layer) const
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetVisibility (int visibility, int layer)
 {
-  if (layer == 0 && this->RenderingMode == vtkImageView3D::PLANAR_RENDERING)
+  if (layer == 0 && RenderingMode == vtkImageView3D::PLANAR_RENDERING)
   {
-    this->ActorX->SetVisibility(visibility);
-    this->ActorY->SetVisibility(visibility);
-    this->ActorZ->SetVisibility(visibility);
+    ActorX->SetVisibility(visibility);
+    ActorY->SetVisibility(visibility);
+    ActorZ->SetVisibility(visibility);
   }
-  if (this->HasLayer(layer))
+  if (HasLayer(layer))
   {
     if (visibility)
     {
-      if (this->RenderingMode != vtkImageView3D::PLANAR_RENDERING)
+      if (RenderingMode != vtkImageView3D::PLANAR_RENDERING)
       {
         //ensure the volumeActor is visible
         //(if there is one layer, or used to have only one layer)
-        this->VolumeActor->SetVisibility(1);
+        VolumeActor->SetVisibility(1);
       }
-      this->VolumeProperty->SetComponentWeight(layer, this->GetOpacity(layer));
+      VolumeProperty->SetComponentWeight(layer, this->GetOpacity(layer));
     }
     else
     {
-      if (this->GetNumberOfLayers() ==1 )
+      if (GetNumberOfLayers() ==1 )
       {
         //setting just the weight for a single component does nothing.
-        this->VolumeActor->SetVisibility(0);
+        VolumeActor->SetVisibility(0);
       }
       //still set the component weight to 0 even if only 1 layer
       //if we add new layers later the first one will stay hidden
-      this->VolumeProperty->SetComponentWeight(layer, 0);
+      VolumeProperty->SetComponentWeight(layer, 0);
     }
-    this->GetImage3DDisplayForLayer(layer)->SetVisibility(visibility);
+    GetImage3DDisplayForLayer(layer)->SetVisibility(visibility);
   }
 }
 
 //----------------------------------------------------------------------------
 int vtkImageView3D::GetVisibility (int layer) const
 {
-    if (this->HasLayer(layer)) {return this->GetImage3DDisplayForLayer(layer)->GetVisibility();
-    }
-  return 0;
+    return HasLayer(layer)?GetImage3DDisplayForLayer(layer)->GetVisibility() : 0;
 }
 
 void vtkImageView3D::SetColorWindow (double s,int layer)
 {
-  if (this->VolumeProperty->GetIndependentComponents())
+  if (VolumeProperty->GetIndependentComponents())
   {
     this->Superclass::SetColorWindow (s,layer);
-    this->UpdateVolumeFunctions(layer);
+    UpdateVolumeFunctions(layer);
   }
 }
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetColorLevel (double s,int layer)
 {
-  if (this->VolumeProperty->GetIndependentComponents())
+  if (VolumeProperty->GetIndependentComponents())
   {
     this->Superclass::SetColorLevel (s,layer);
-    this->UpdateVolumeFunctions(layer);
+    UpdateVolumeFunctions(layer);
   }
 }
 
@@ -769,11 +762,11 @@ void vtkImageView3D::SetColorLevel (double s,int layer)
 void vtkImageView3D::UpdateVolumeFunctions(int layer)
 {
   auto* lookuptable = this->GetLookupTable(layer);
-  if ( !this->GetUseLookupTable(layer) || lookuptable == nullptr )
+  if ( !GetUseLookupTable(layer) || lookuptable == nullptr )
     return;
 
-  auto * color   = this->VolumeProperty->GetRGBTransferFunction(layer);
-  auto * opacity = this->VolumeProperty->GetScalarOpacity(layer);
+  auto * color   = VolumeProperty->GetRGBTransferFunction(layer);
+  auto * opacity = VolumeProperty->GetScalarOpacity(layer);
 
   const double * range = lookuptable->GetRange();
   double width = range[1] - range[0];
@@ -786,7 +779,6 @@ void vtkImageView3D::UpdateVolumeFunctions(int layer)
   for ( int i = 0; i < numColors; ++i )
   {
     double x = range[0] + factor * static_cast< double >( i ) * width;
-
     double * val = lookuptable->GetTableValue( i );
     color->AddRGBPoint( x, val[0], val[1], val[2]);
     opacity->AddPoint( x, val[3] );
@@ -796,100 +788,98 @@ void vtkImageView3D::UpdateVolumeFunctions(int layer)
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetShowActorX(unsigned int arg)
 {
-  this->ShowActorX = arg;
-  this->ActorX->SetVisibility (arg);
+  ShowActorX = arg;
+  ActorX->SetVisibility (arg);
 }
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetShowActorY(unsigned int arg)
 {
-  this->ShowActorY = arg;
-  this->ActorY->SetVisibility (arg);
+  ShowActorY = arg;
+  ActorY->SetVisibility (arg);
 }
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::SetShowActorZ(unsigned int arg)
 {
-  this->ShowActorZ = arg;
-  this->ActorZ->SetVisibility (arg);
+  ShowActorZ = arg;
+  ActorZ->SetVisibility (arg);
 }
 
 //----------------------------------------------------------------------------
 /** Set the rendering mode. */
 void vtkImageView3D::SetRenderingMode(int arg)
 {
-  this->RenderingMode = arg;
-  this->VolumeActor->SetVisibility (arg == vtkImageView3D::VOLUME_RENDERING);
-  this->ActorX->SetVisibility ((arg == vtkImageView3D::PLANAR_RENDERING) && this->ShowActorX);
-  this->ActorY->SetVisibility ((arg == vtkImageView3D::PLANAR_RENDERING) && this->ShowActorY);
-  this->ActorZ->SetVisibility ((arg == vtkImageView3D::PLANAR_RENDERING) && this->ShowActorZ);
+  RenderingMode = arg;
+  VolumeActor->SetVisibility (arg == vtkImageView3D::VOLUME_RENDERING);
+  ActorX->SetVisibility ((arg == vtkImageView3D::PLANAR_RENDERING) && ShowActorX);
+  ActorY->SetVisibility ((arg == vtkImageView3D::PLANAR_RENDERING) && ShowActorY);
+  ActorZ->SetVisibility ((arg == vtkImageView3D::PLANAR_RENDERING) && ShowActorZ);
 
-  this->ExtraPlaneCollection->InitTraversal();
-  vtkProp3D* item = this->ExtraPlaneCollection->GetNextProp3D();
+  ExtraPlaneCollection->InitTraversal();
+  vtkProp3D* item = ExtraPlaneCollection->GetNextProp3D();
   while(item)
   {
     item->SetVisibility(arg == vtkImageView3D::PLANAR_RENDERING);
-    item = this->ExtraPlaneCollection->GetNextProp3D();
+    item = ExtraPlaneCollection->GetNextProp3D();
   }
 }
 
 //---------------------------------------------------------------------------
 void vtkImageView3D::SetOrientationMarker(vtkActor *actor)
 {
-  this->Marker->SetOrientationMarker( actor );
+  Marker->SetOrientationMarker( actor );
 }
 
 //---------------------------------------------------------------------------
 void vtkImageView3D::SetOrientationMarkerViewport(double x1, double x2, double x3, double x4)
 {
-  this->Marker->SetViewport(x1, x2, x3, x4);
+  Marker->SetViewport(x1, x2, x3, x4);
 }
 
 //---------------------------------------------------------------------------
 void vtkImageView3D::SetCroppingModeToOff()
 {
-  this->SetCroppingMode( CROPPING_OFF );
+  SetCroppingMode( CROPPING_OFF );
 }
 
 //---------------------------------------------------------------------------
 void vtkImageView3D::SetCroppingModeToInside()
 {
-  this->SetCroppingMode( CROPPING_INSIDE );
+  SetCroppingMode( CROPPING_INSIDE );
 }
 
 //---------------------------------------------------------------------------
 void vtkImageView3D::SetCroppingModeToOutside()
 {
-  this->SetCroppingMode( CROPPING_OUTSIDE );
+  SetCroppingMode( CROPPING_OUTSIDE );
 }
 
 //---------------------------------------------------------------------------
 void vtkImageView3D::SetCroppingMode( unsigned int mode )
 {
-  this->CroppingMode = mode;
+  CroppingMode = mode;
 
   switch ( mode )
   {
     case CROPPING_OFF:
-      this->VolumeMapper->CroppingOff();
-
+      VolumeMapper->CroppingOff();
       break;
     case CROPPING_OUTSIDE:
-      this->VolumeMapper->CroppingOn();
-      this->VolumeMapper->SetCroppingRegionFlagsToSubVolume();
-
+      VolumeMapper->CroppingOn();
+      VolumeMapper->SetCroppingRegionFlagsToSubVolume();
       break;
     case CROPPING_INSIDE:         // fall through to default
     default:                      // default is CROPPING_INSIDE
-      this->VolumeMapper->CroppingOn();
-      this->VolumeMapper->SetCroppingRegionFlags( 0x7ffdfff );
+      VolumeMapper->CroppingOn();
+      VolumeMapper->SetCroppingRegionFlags( 0x7ffdfff );
   }
 }
 
 //---------------------------------------------------------------------------
 unsigned int vtkImageView3D::GetCroppingMode()
 {
-  return this->CroppingMode;
+  return CroppingMode;
 }
 
 //----------------------------------------------------------------------------
@@ -905,18 +895,18 @@ void vtkImageView3D::SetCurrentPoint (double pos[3])
 {
   this->Superclass::SetCurrentPoint (pos);
 
-  this->UpdateDisplayExtent();
+  UpdateDisplayExtent();
 }
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::UpdateDisplayExtent()
 {
-  if (!this->GetMedVtkImageInfo() || !this->GetMedVtkImageInfo()->initialized)
+  if (!GetMedVtkImageInfo() || !GetMedVtkImageInfo()->initialized)
   {
     return;
   }
 
-  int *w_ext = this->GetMedVtkImageInfo()->extent;
+  int *w_ext = GetMedVtkImageInfo()->extent;
 
   int slices[3];
   this->GetImageCoordinatesFromWorldCoordinates (this->CurrentPoint, slices);
@@ -929,20 +919,17 @@ void vtkImageView3D::UpdateDisplayExtent()
   }
 
   // Set the image actors
-  this->ActorX->SetDisplayExtent(
-                                 slices[0], slices[0],
-                                 w_ext[2],  w_ext[3],
-                                 w_ext[4],  w_ext[5] );
+  ActorX->SetDisplayExtent(slices[0], slices[0],
+                            w_ext[2],  w_ext[3],
+                            w_ext[4],  w_ext[5] );
 
-  this->ActorY->SetDisplayExtent(
-                                 w_ext[0],  w_ext[1],
-                                 slices[1], slices[1],
-                                 w_ext[4],  w_ext[5] );
+  ActorY->SetDisplayExtent(w_ext[0],  w_ext[1],
+                            slices[1], slices[1],
+                            w_ext[4],  w_ext[5] );
 
-  this->ActorZ->SetDisplayExtent(
-                                 w_ext[0],  w_ext[1],
-                                 w_ext[2],  w_ext[3],
-                                 slices[2], slices[2]);
+  ActorZ->SetDisplayExtent(w_ext[0],  w_ext[1],
+                            w_ext[2],  w_ext[3],
+                            slices[2], slices[2]);
 
   // this->Modified(); // not in UpdateXXX() methods
 }
@@ -950,10 +937,10 @@ void vtkImageView3D::UpdateDisplayExtent()
 //----------------------------------------------------------------------------
 vtkActor* vtkImageView3D::AddDataSet (vtkPointSet* arg, vtkProperty* prop)
 {
-  vtkDataSetSurfaceFilter* geometryextractor = vtkDataSetSurfaceFilter::New();
-  vtkPolyDataNormals* normalextractor = vtkPolyDataNormals::New();
-  vtkPolyDataMapper* mapper = vtkPolyDataMapper::New();
-  vtkActor* actor = vtkActor::New();
+  auto geometryextractor = vtkDataSetSurfaceFilter::New();
+  auto normalextractor = vtkPolyDataNormals::New();
+  auto mapper = vtkPolyDataMapper::New();
+  auto actor = vtkActor::New();
 
   normalextractor->SetFeatureAngle (90);
   ///\todo try to skip the normal extraction filter in order to
@@ -965,7 +952,7 @@ vtkActor* vtkImageView3D::AddDataSet (vtkPointSet* arg, vtkProperty* prop)
   if (prop)
     actor->SetProperty (prop);
 
-  this->Renderer->AddViewProp(actor);
+  Renderer->AddViewProp(actor);
 
   mapper->Delete();
   normalextractor->Delete();
@@ -973,7 +960,7 @@ vtkActor* vtkImageView3D::AddDataSet (vtkPointSet* arg, vtkProperty* prop)
   actor->Delete();
 
   // If this is the first widget to be added, reset camera
-  if ( ! this->GetMedVtkImageInfo() || !this->GetMedVtkImageInfo()->initialized)
+  if ( ! GetMedVtkImageInfo() || !GetMedVtkImageInfo()->initialized)
   {
       this->ResetCamera(arg);
   }
@@ -990,10 +977,10 @@ vtkActor* vtkImageView3D::AddDataSet (vtkPointSet* arg, vtkProperty* prop)
 //----------------------------------------------------------------------------
 vtkActor* vtkImageView3D::DataSetToActor(vtkPointSet* arg, vtkProperty* prop)
 {
-    vtkDataSetSurfaceFilter* geometryextractor = vtkDataSetSurfaceFilter::New();
-    vtkPolyDataNormals* normalextractor = vtkPolyDataNormals::New();
-    vtkPolyDataMapper* mapper = vtkPolyDataMapper::New();
-    vtkActor* actor = vtkActor::New();
+    auto geometryextractor = vtkDataSetSurfaceFilter::New();
+    auto normalextractor = vtkPolyDataNormals::New();
+    auto mapper = vtkPolyDataMapper::New();
+    auto actor = vtkActor::New();
 
     normalextractor->SetFeatureAngle(90);
     ///\todo try to skip the normal extraction filter in order to
@@ -1019,7 +1006,7 @@ void vtkImageView3D::RemoveDataSet(vtkPointSet* arg)
 {
   vtkProp3D* actor = this->FindDataSetActor (arg);
   if (actor)
-    this->Renderer->RemoveViewProp (actor);
+    Renderer->RemoveViewProp (actor);
 
   this->Superclass::RemoveDataSet (arg);
 }
@@ -1027,25 +1014,25 @@ void vtkImageView3D::RemoveDataSet(vtkPointSet* arg)
 //----------------------------------------------------------------------------
 void vtkImageView3D::AddLayer (int layer)
 {
-  if (this->HasLayer(layer) || (layer < 0) )
+  if (HasLayer(layer) || (layer < 0) )
   {
     return;
   }
-  if ( static_cast<size_t>(layer) >= this->LayerInfoVec.size() )
+  if ( static_cast<size_t>(layer) >= LayerInfoVec.size() )
   {
-      this->LayerInfoVec.resize(layer + 1);
+      LayerInfoVec.resize(layer + 1);
   }
 
   // needs to instantiate objects for layers being created
-  for ( size_t i(0); i<this->LayerInfoVec.size(); ++i )
+  for ( size_t i(0); i<LayerInfoVec.size(); ++i )
   {
-      if (!this->LayerInfoVec[i].ImageDisplay)
+      if (!LayerInfoVec[i].ImageDisplay)
       {
-          this->LayerInfoVec[i].ImageDisplay = vtkSmartPointer<vtkImage3DDisplay>::New();
+          LayerInfoVec[i].ImageDisplay = vtkSmartPointer<vtkImage3DDisplay>::New();
       }
   }
-  this->VolumeProperty->SetShade(layer, 1);
-  this->VolumeProperty->SetComponentWeight(layer, 1.0);
+  VolumeProperty->SetShade(layer, 1);
+  VolumeProperty->SetComponentWeight(layer, 1.0);
 }
 
 
@@ -1054,31 +1041,24 @@ int vtkImageView3D::GetNumberOfLayers() const
 {
     // I don't really know why, but LayerInfoVec size is set to 1 at initialization time,
     // so we need one more check to know the real number of layer
-    if( this->LayerInfoVec.size() == 1)
+    if( LayerInfoVec.size() == 1)
     {
-        if( this->LayerInfoVec.at(0).ImageDisplay->GetMedVtkImageInfo() == nullptr)
-        {
-            return 0;
-        }
-        else
-        {
-            return 1;
-        }
+        return (LayerInfoVec.at(0).ImageDisplay->GetMedVtkImageInfo())? 1 : 0;
     }
     else
     {
-        return static_cast<int>(this->LayerInfoVec.size());
+        return static_cast<int>(LayerInfoVec.size());
     }
 }
 
 //----------------------------------------------------------------------------
 void vtkImageView3D::RemoveLayer (int layer)
 {
-    if (this->HasLayer(layer))
+    if (HasLayer(layer))
     {
         // ////////////////////////////////////////////////////////////////////////
         // Remove layer
-        vtkRenderer *renderer = this->Renderer;
+        vtkRenderer *renderer = Renderer;
         vtkImageView::RemoveLayer(layer);
         std::vector<vtkActor*> vActorsBackup;
         if (renderer)
@@ -1098,11 +1078,11 @@ void vtkImageView3D::RemoveLayer (int layer)
         }
 
         // Delete is handled by SmartPointers.
-        this->LayerInfoVec.erase(this->LayerInfoVec.begin() + layer);
+        LayerInfoVec.erase(LayerInfoVec.begin() + layer);
 
-        if( this->LayerInfoVec.size()>0 && layer == 0)
+        if( LayerInfoVec.size()>0 && layer == 0)
         {
-            auto imDisplay = this->GetImage3DDisplayForLayer(0);
+            auto imDisplay = GetImage3DDisplayForLayer(0);
             if(imDisplay && imDisplay->GetInputProducer())
             {
                 this->Superclass::SetInput(imDisplay->GetInputProducer()->GetOutputPort(), VolumeActor->GetUserMatrix(), layer);
@@ -1111,21 +1091,20 @@ void vtkImageView3D::RemoveLayer (int layer)
             this->SetColorRange(range, 0);
             initializeTransferFunctions(0);
         }
-        if(this->LayerInfoVec.size()>0 && this->GetImage3DDisplayForLayer(0))
+        if(LayerInfoVec.size()>0 && GetImage3DDisplayForLayer(0))
         {
            SetRenderWindow( this->GetRenderWindow());
-
         }
 
         InternalUpdate();
         // //////////////////////////////////////////////////////////////////////
         // Rebuild a layer if necessary
-        if (this->LayerInfoVec.size() == 0)
+        if (LayerInfoVec.size() == 0)
         {
             AddLayer(0);
             for (auto pActor : vActorsBackup)
             {
-                this->Renderer->AddViewProp(pActor);
+                Renderer->AddViewProp(pActor);
                 pActor->VisibilityOn();
                 this->Modified();
             }
@@ -1136,21 +1115,15 @@ void vtkImageView3D::RemoveLayer (int layer)
 //----------------------------------------------------------------------------
 void vtkImageView3D::RemoveAllLayers()
 {
-  while (this->LayerInfoVec.size() > 1)
+  while (LayerInfoVec.size() > 1)
   {
-    this->RemoveLayer (static_cast<int>(this->LayerInfoVec.size() -1));
+    RemoveLayer (static_cast<int>(LayerInfoVec.size() -1));
   }
 }
 
-
-//! Get layer specific info
 vtkImage3DDisplay * vtkImageView3D::GetImage3DDisplayForLayer( int layer ) const
 {
-  if ( layer > -1 && (unsigned int)layer < this->LayerInfoVec.size())
-  {
-      return this->LayerInfoVec.at(layer).ImageDisplay;
-  }
-  else return nullptr;
+   return  ( layer > -1 && (unsigned int)layer < LayerInfoVec.size())? LayerInfoVec.at(layer).ImageDisplay:nullptr;
 }
 
 void vtkImageView3D::ApplyColorTransferFunction(vtkScalarsToColors * colors, int layer)
@@ -1160,31 +1133,25 @@ void vtkImageView3D::ApplyColorTransferFunction(vtkScalarsToColors * colors, int
 
 vtkColorTransferFunction * vtkImageView3D::GetColorTransferFunction(int layer) const
 {
-  if (this->HasLayer(layer))
-    //warning if it does not exist, a default one is created.
-    return this->VolumeProperty->GetRGBTransferFunction(layer);
-  else return nullptr;
+  return  HasLayer(layer)? VolumeProperty->GetRGBTransferFunction(layer):nullptr;
 }
 
 vtkPiecewiseFunction * vtkImageView3D::GetOpacityTransferFunction(int layer) const
 {
-  if (this->HasLayer(layer))
-    //warning if it does not exist, a default one is created.
-    return this->VolumeProperty->GetScalarOpacity(layer);
-  else return nullptr;
+   return  HasLayer(layer)? VolumeProperty->GetScalarOpacity(layer):nullptr;
 }
 
 void vtkImageView3D::StoreColorTransferFunction(vtkColorTransferFunction *ctf, int layer)
 {
-  if(this->HasLayer(layer) &&  this->VolumeProperty->GetIndependentComponents())
+  if(HasLayer(layer) &&  VolumeProperty->GetIndependentComponents())
   {
-    this->VolumeProperty->SetColor(layer,ctf);
+    VolumeProperty->SetColor(layer,ctf);
     if (layer ==0)
     {
        //only update multiplanar windowlevel if layer 0 changes
-       this->PlanarWindowLevelX->SetLookupTable(this->VolumeProperty->GetRGBTransferFunction());
-       this->PlanarWindowLevelY->SetLookupTable(this->VolumeProperty->GetRGBTransferFunction());
-       this->PlanarWindowLevelZ->SetLookupTable(this->VolumeProperty->GetRGBTransferFunction());
+       PlanarWindowLevelX->SetLookupTable(VolumeProperty->GetRGBTransferFunction());
+       PlanarWindowLevelY->SetLookupTable(VolumeProperty->GetRGBTransferFunction());
+       PlanarWindowLevelZ->SetLookupTable(VolumeProperty->GetRGBTransferFunction());
     }
   }
 
@@ -1192,31 +1159,27 @@ void vtkImageView3D::StoreColorTransferFunction(vtkColorTransferFunction *ctf, i
 
 void vtkImageView3D::StoreOpacityTransferFunction(vtkPiecewiseFunction *otf, int layer)
 {
-  if(this->HasLayer(layer))
+  if(HasLayer(layer))
   {
-    this->VolumeProperty->SetScalarOpacity(layer,otf);
+    VolumeProperty->SetScalarOpacity(layer,otf);
   }
 }
 
 vtkLookupTable * vtkImageView3D::GetLookupTable(int layer) const
 {
-  auto * imageDisplay = this->GetImage3DDisplayForLayer(layer);
-  if (!imageDisplay)
-    return nullptr;
-  return imageDisplay->GetLookupTable();
+  auto * imageDisplay = GetImage3DDisplayForLayer(layer);
+  return imageDisplay?imageDisplay->GetLookupTable():nullptr;
 }
 
 bool vtkImageView3D::GetUseLookupTable(int layer) const
 {
-  auto * imageDisplay = this->GetImage3DDisplayForLayer(layer);
-  if (!imageDisplay)
-    return false;
-  return imageDisplay->GetUseLookupTable();
+  auto * imageDisplay = GetImage3DDisplayForLayer(layer);
+  return imageDisplay?imageDisplay->GetUseLookupTable():false;
 }
 
 void vtkImageView3D::SetUseLookupTable(bool use, int layer)
 {
-  auto * imageDisplay = this->GetImage3DDisplayForLayer(layer);
+  auto * imageDisplay = GetImage3DDisplayForLayer(layer);
   if (!imageDisplay)
     return;
   imageDisplay->SetUseLookupTable( use );
@@ -1224,15 +1187,13 @@ void vtkImageView3D::SetUseLookupTable(bool use, int layer)
 
 double vtkImageView3D::GetColorWindow(int layer)const
 {
-  auto * imageDisplay = this->GetImage3DDisplayForLayer(layer);
-  if (!imageDisplay)
-    return 0;
-  return imageDisplay->GetColorWindow();
+  auto * imageDisplay = GetImage3DDisplayForLayer(layer);
+  return imageDisplay? imageDisplay->GetColorWindow(): 0;
 }
 
 void vtkImageView3D::StoreColorWindow(double s, int layer)
 {
-  auto * imageDisplay = this->GetImage3DDisplayForLayer(layer);
+  auto * imageDisplay = GetImage3DDisplayForLayer(layer);
   if (!imageDisplay)
     return;
   imageDisplay->SetColorWindow( s );
@@ -1240,7 +1201,7 @@ void vtkImageView3D::StoreColorWindow(double s, int layer)
 
 double vtkImageView3D::GetColorLevel(int layer)const
 {
-  auto * imageDisplay = this->GetImage3DDisplayForLayer(layer);
+  auto * imageDisplay = GetImage3DDisplayForLayer(layer);
   if (!imageDisplay)
     return 0;
   return imageDisplay->GetColorLevel();
@@ -1248,7 +1209,7 @@ double vtkImageView3D::GetColorLevel(int layer)const
 
 void vtkImageView3D::StoreColorLevel(double s, int layer)
 {
-  auto * imageDisplay = this->GetImage3DDisplayForLayer(layer);
+  auto * imageDisplay = GetImage3DDisplayForLayer(layer);
   if (!imageDisplay)
       return;
   imageDisplay->SetColorLevel(s);
@@ -1256,7 +1217,7 @@ void vtkImageView3D::StoreColorLevel(double s, int layer)
 
 void vtkImageView3D::StoreLookupTable(vtkLookupTable *lookuptable, int layer)
 {
-  auto * imageDisplay = this->GetImage3DDisplayForLayer(layer);
+  auto * imageDisplay = GetImage3DDisplayForLayer(layer);
   if (!imageDisplay)
     return;
   return imageDisplay->SetLookupTable(lookuptable);
@@ -1264,27 +1225,22 @@ void vtkImageView3D::StoreLookupTable(vtkLookupTable *lookuptable, int layer)
 
 medVtkImageInfo* vtkImageView3D::GetMedVtkImageInfo(int layer /*= 0*/) const
 {
-    auto * imageDisplay = this->GetImage3DDisplayForLayer(layer);
-    medVtkImageInfo *imageInfo = nullptr;
+    auto * imageDisplay = GetImage3DDisplayForLayer(layer);
 
-    if (imageDisplay)
-    {
-        imageInfo = imageDisplay->GetMedVtkImageInfo();
-    }
+    return imageDisplay? imageDisplay->GetMedVtkImageInfo() : nullptr;
 
-    return imageInfo;
 }
 
 //The code below is useful for Volume rendering and more precisely for LUT
 void  vtkImageView3D::initializeTransferFunctions(int pi_iLayer)
 {
-    this->VolumeProperty->SetShade(pi_iLayer, 1);
-    this->VolumeProperty->SetComponentWeight(pi_iLayer, 1.0);
+    VolumeProperty->SetShade(pi_iLayer, 1);
+    VolumeProperty->SetComponentWeight(pi_iLayer, 1.0);
     auto *rgb = this->GetDefaultColorTransferFunction();
     auto     *alpha = this->GetDefaultOpacityTransferFunction();
 
-    this->SetTransferFunctions(rgb, alpha, pi_iLayer);
-    this->UpdateVolumeFunctions(pi_iLayer);
+    SetTransferFunctions(rgb, alpha, pi_iLayer);
+    UpdateVolumeFunctions(pi_iLayer);
     rgb->Delete();
     alpha->Delete();
 }

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -672,8 +672,16 @@ void vtkImageView3D::SetOpacity (double opacity, int layer)
 //----------------------------------------------------------------------------
 double vtkImageView3D::GetOpacity(int layer) const
 {
-    vtkImage3DDisplay * imageDisplay;
-    return (imageDisplay=GetImage3DDisplayForLayer(layer))? imageDisplay->GetOpacity() : 0.0;
+    double dfRes = 0.0;
+    if (this->HasLayer(layer))
+    {
+        vtkImage3DDisplay *imageDisplay = GetImage3DDisplayForLayer(layer);
+        if (imageDisplay)
+        {
+            dfRes = imageDisplay->GetOpacity();
+        }
+    }
+    return dfRes;
 }
 
 //----------------------------------------------------------------------------
@@ -1020,14 +1028,12 @@ int vtkImageView3D::GetNumberOfLayers() const
 {
     // I don't really know why, but LayerInfoVec size is set to 1 at initialization time,
     // so we need one more check to know the real number of layer
+    int result = static_cast<int>(LayerInfoVec.size());
     if( LayerInfoVec.size() == 1)
     {
-        return (LayerInfoVec.at(0).ImageDisplay->GetMedVtkImageInfo())? 1 : 0;
+         result = (LayerInfoVec.at(0).ImageDisplay->GetMedVtkImageInfo())? 1 : 0;
     }
-    else
-    {
-        return static_cast<int>(LayerInfoVec.size());
-    }
+    return result;
 }
 
 //----------------------------------------------------------------------------
@@ -1102,7 +1108,11 @@ void vtkImageView3D::RemoveAllLayers()
 
 vtkImage3DDisplay * vtkImageView3D::GetImage3DDisplayForLayer( int layer ) const
 {
-   return  ( layer > -1 && (unsigned int)layer < LayerInfoVec.size())? LayerInfoVec.at(layer).ImageDisplay : nullptr;
+  if ( layer > -1 && (unsigned int)layer < this->LayerInfoVec.size())
+  {
+      return this->LayerInfoVec.at(layer).ImageDisplay;
+  }
+  else return nullptr;
 }
 
 void vtkImageView3D::ApplyColorTransferFunction(vtkScalarsToColors * colors, int layer)

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -466,6 +466,7 @@ void vtkImageView3D::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4
             {
                 SetInputLayer(pi_poVtkAlgoOutput, matrix, layer);
                 initializeTransferFunctions(layer);
+                this->InternalUpdate();
             }
             else if (layer >= 4)
             {
@@ -611,6 +612,7 @@ void vtkImageView3D::InternalUpdate()
     // Read bounds and use these to place widget, rather than force whole dataset to be read.
     double bounds [6];
     this->GetInputBounds (bounds);
+
     this->BoxWidget->SetInputConnection(appender->GetOutputPort());
     this->BoxWidget->PlaceWidget (bounds);
     this->Callback->Execute (this->BoxWidget, 0, bounds);
@@ -767,9 +769,9 @@ void vtkImageView3D::UpdateVolumeFunctions(int layer)
     return;
 
   vtkColorTransferFunction * color   =
-  this->VolumeProperty->GetRGBTransferFunction(0);
+  this->VolumeProperty->GetRGBTransferFunction(layer);
   vtkPiecewiseFunction     * opacity =
-  this->VolumeProperty->GetScalarOpacity(0);
+  this->VolumeProperty->GetScalarOpacity(layer);
 
   const double * range = lookuptable->GetRange();
   double width = range[1] - range[0];

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -551,7 +551,7 @@ void vtkImageView3D::InternalUpdate()
                               (this->m_poInternalImageFromInput->GetNumberOfScalarComponents() == 3 ||
                                this->m_poInternalImageFromInput->GetNumberOfScalarComponents() == 4 ));
 
-    vtkImageAppendComponents *appender = vtkImageAppendComponents::New();
+    auto *appender = vtkImageAppendComponents::New();
     if (this->LayerInfoVec.size()>0 && !multichannelInput)
     {
         // append all scalar buffer into the same image
@@ -741,9 +741,8 @@ void vtkImageView3D::SetVisibility (int visibility, int layer)
 //----------------------------------------------------------------------------
 int vtkImageView3D::GetVisibility (int layer) const
 {
-    if (this->HasLayer(layer))
-    return this->GetImage3DDisplayForLayer(layer)->GetVisibility();
-
+    if (this->HasLayer(layer)) {return this->GetImage3DDisplayForLayer(layer)->GetVisibility();
+    }
   return 0;
 }
 
@@ -769,14 +768,12 @@ void vtkImageView3D::SetColorLevel (double s,int layer)
 //----------------------------------------------------------------------------
 void vtkImageView3D::UpdateVolumeFunctions(int layer)
 {
-  vtkLookupTable* lookuptable = this->GetLookupTable(layer);
+  auto* lookuptable = this->GetLookupTable(layer);
   if ( !this->GetUseLookupTable(layer) || lookuptable == nullptr )
     return;
 
-  vtkColorTransferFunction * color   =
-  this->VolumeProperty->GetRGBTransferFunction(layer);
-  vtkPiecewiseFunction     * opacity =
-  this->VolumeProperty->GetScalarOpacity(layer);
+  auto * color   = this->VolumeProperty->GetRGBTransferFunction(layer);
+  auto * opacity = this->VolumeProperty->GetScalarOpacity(layer);
 
   const double * range = lookuptable->GetRange();
   double width = range[1] - range[0];
@@ -1079,7 +1076,6 @@ void vtkImageView3D::RemoveLayer (int layer)
 {
     if (this->HasLayer(layer))
     {
-
         // ////////////////////////////////////////////////////////////////////////
         // Remove layer
         vtkRenderer *renderer = this->Renderer;
@@ -1097,21 +1093,28 @@ void vtkImageView3D::RemoveLayer (int layer)
             if (this->GetRenderWindow())
             {
                 this->GetRenderWindow()->RemoveRenderer(renderer);
-
             }
-
             this->Modified();
         }
 
         // Delete is handled by SmartPointers.
         this->LayerInfoVec.erase(this->LayerInfoVec.begin() + layer);
 
-        if( this->LayerInfoVec.size()>0 && layer == 0) {
+        if( this->LayerInfoVec.size()>0 && layer == 0)
+        {
             auto imDisplay = this->GetImage3DDisplayForLayer(0);
-            this->Superclass::SetInput(imDisplay->GetInputProducer()->GetOutputPort(), VolumeActor->GetUserMatrix(), layer);
+            if(imDisplay && imDisplay->GetInputProducer())
+            {
+                this->Superclass::SetInput(imDisplay->GetInputProducer()->GetOutputPort(), VolumeActor->GetUserMatrix(), layer);
+            }
             double *range = m_poInternalImageFromInput->GetScalarRange();
             this->SetColorRange(range, 0);
             initializeTransferFunctions(0);
+        }
+        if(this->LayerInfoVec.size()>0 && this->GetImage3DDisplayForLayer(0))
+        {
+           SetRenderWindow( this->GetRenderWindow());
+
         }
 
         InternalUpdate();
@@ -1120,7 +1123,6 @@ void vtkImageView3D::RemoveLayer (int layer)
         if (this->LayerInfoVec.size() == 0)
         {
             AddLayer(0);
-
             for (auto pActor : vActorsBackup)
             {
                 this->Renderer->AddViewProp(pActor);
@@ -1128,7 +1130,6 @@ void vtkImageView3D::RemoveLayer (int layer)
                 this->Modified();
             }
         }
-
     }
 }
 
@@ -1175,7 +1176,7 @@ vtkPiecewiseFunction * vtkImageView3D::GetOpacityTransferFunction(int layer) con
 
 void vtkImageView3D::StoreColorTransferFunction(vtkColorTransferFunction *ctf, int layer)
 {
-  if(this->HasLayer(layer) &&  this-VolumeProperty->GetIndependentComponents())
+  if(this->HasLayer(layer) &&  this->VolumeProperty->GetIndependentComponents())
   {
     this->VolumeProperty->SetColor(layer,ctf);
     if (layer ==0)
@@ -1199,7 +1200,7 @@ void vtkImageView3D::StoreOpacityTransferFunction(vtkPiecewiseFunction *otf, int
 
 vtkLookupTable * vtkImageView3D::GetLookupTable(int layer) const
 {
-  vtkImage3DDisplay * imageDisplay = this->GetImage3DDisplayForLayer(layer);
+  auto * imageDisplay = this->GetImage3DDisplayForLayer(layer);
   if (!imageDisplay)
     return nullptr;
   return imageDisplay->GetLookupTable();
@@ -1207,7 +1208,7 @@ vtkLookupTable * vtkImageView3D::GetLookupTable(int layer) const
 
 bool vtkImageView3D::GetUseLookupTable(int layer) const
 {
-  vtkImage3DDisplay * imageDisplay = this->GetImage3DDisplayForLayer(layer);
+  auto * imageDisplay = this->GetImage3DDisplayForLayer(layer);
   if (!imageDisplay)
     return false;
   return imageDisplay->GetUseLookupTable();
@@ -1215,7 +1216,7 @@ bool vtkImageView3D::GetUseLookupTable(int layer) const
 
 void vtkImageView3D::SetUseLookupTable(bool use, int layer)
 {
-  vtkImage3DDisplay * imageDisplay = this->GetImage3DDisplayForLayer(layer);
+  auto * imageDisplay = this->GetImage3DDisplayForLayer(layer);
   if (!imageDisplay)
     return;
   imageDisplay->SetUseLookupTable( use );
@@ -1223,7 +1224,7 @@ void vtkImageView3D::SetUseLookupTable(bool use, int layer)
 
 double vtkImageView3D::GetColorWindow(int layer)const
 {
-  vtkImage3DDisplay * imageDisplay = this->GetImage3DDisplayForLayer(layer);
+  auto * imageDisplay = this->GetImage3DDisplayForLayer(layer);
   if (!imageDisplay)
     return 0;
   return imageDisplay->GetColorWindow();
@@ -1231,7 +1232,7 @@ double vtkImageView3D::GetColorWindow(int layer)const
 
 void vtkImageView3D::StoreColorWindow(double s, int layer)
 {
-  vtkImage3DDisplay * imageDisplay = this->GetImage3DDisplayForLayer(layer);
+  auto * imageDisplay = this->GetImage3DDisplayForLayer(layer);
   if (!imageDisplay)
     return;
   imageDisplay->SetColorWindow( s );
@@ -1239,7 +1240,7 @@ void vtkImageView3D::StoreColorWindow(double s, int layer)
 
 double vtkImageView3D::GetColorLevel(int layer)const
 {
-  vtkImage3DDisplay * imageDisplay = this->GetImage3DDisplayForLayer(layer);
+  auto * imageDisplay = this->GetImage3DDisplayForLayer(layer);
   if (!imageDisplay)
     return 0;
   return imageDisplay->GetColorLevel();
@@ -1247,7 +1248,7 @@ double vtkImageView3D::GetColorLevel(int layer)const
 
 void vtkImageView3D::StoreColorLevel(double s, int layer)
 {
-  vtkImage3DDisplay * imageDisplay = this->GetImage3DDisplayForLayer(layer);
+  auto * imageDisplay = this->GetImage3DDisplayForLayer(layer);
   if (!imageDisplay)
       return;
   imageDisplay->SetColorLevel(s);
@@ -1255,7 +1256,7 @@ void vtkImageView3D::StoreColorLevel(double s, int layer)
 
 void vtkImageView3D::StoreLookupTable(vtkLookupTable *lookuptable, int layer)
 {
-  vtkImage3DDisplay * imageDisplay = this->GetImage3DDisplayForLayer(layer);
+  auto * imageDisplay = this->GetImage3DDisplayForLayer(layer);
   if (!imageDisplay)
     return;
   return imageDisplay->SetLookupTable(lookuptable);
@@ -1263,7 +1264,7 @@ void vtkImageView3D::StoreLookupTable(vtkLookupTable *lookuptable, int layer)
 
 medVtkImageInfo* vtkImageView3D::GetMedVtkImageInfo(int layer /*= 0*/) const
 {
-    vtkImage3DDisplay * imageDisplay = this->GetImage3DDisplayForLayer(layer);
+    auto * imageDisplay = this->GetImage3DDisplayForLayer(layer);
     medVtkImageInfo *imageInfo = nullptr;
 
     if (imageDisplay)
@@ -1279,8 +1280,8 @@ void  vtkImageView3D::initializeTransferFunctions(int pi_iLayer)
 {
     this->VolumeProperty->SetShade(pi_iLayer, 1);
     this->VolumeProperty->SetComponentWeight(pi_iLayer, 1.0);
-    vtkColorTransferFunction *rgb = this->GetDefaultColorTransferFunction();
-    vtkPiecewiseFunction     *alpha = this->GetDefaultOpacityTransferFunction();
+    auto *rgb = this->GetDefaultColorTransferFunction();
+    auto     *alpha = this->GetDefaultOpacityTransferFunction();
 
     this->SetTransferFunctions(rgb, alpha, pi_iLayer);
     this->UpdateVolumeFunctions(pi_iLayer);

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
@@ -56,7 +56,7 @@ public:
     static vtkImageView3D* New();
     vtkTypeMacro(vtkImageView3D, vtkImageView);
 
-    vtkMTimeType GetMTime();
+    vtkMTimeType GetMTime() override;
 
     // Rendering Modes available.
     // PLANAR_RENDERING will render every vtkImageActor instance added with Add2DPhantom()
@@ -78,7 +78,7 @@ public:
     vtkGetObjectMacro (ActorZ, vtkImageActor);
     vtkGetObjectMacro (ExtraPlaneCollection, vtkProp3DCollection);
 
-    virtual medVtkImageInfo* GetMedVtkImageInfo(int layer = 0) const;
+    medVtkImageInfo* GetMedVtkImageInfo(int layer = 0) const override;
 
     virtual void SetVolumeMapperToRayCast();
 #ifdef MED_USE_OSPRAY_4_VR_BY_CPU
@@ -140,26 +140,26 @@ public:
     virtual void SetCroppingMode(unsigned int);
     virtual unsigned int GetCroppingMode ();
 
-    virtual void SetInput      (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = nullptr, int layer = 0);
+    void SetInput      (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = nullptr, int layer = 0) override;
     virtual bool is3D();
     static vtkActor* DataSetToActor(vtkPointSet* arg, vtkProperty* prop = nullptr);
     virtual void SetInputLayer (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = nullptr, int layer = 0);
     void SetFirstLayer(vtkAlgorithmOutput *pi_poInputAlgoImg, vtkMatrix4x4 *matrix= nullptr, int layer = 0);
 
-    virtual void SetOrientationMatrix (vtkMatrix4x4* matrix);
+    void SetOrientationMatrix (vtkMatrix4x4* matrix) override;
 
     using vtkImageView::SetColorWindow;
-    virtual void SetColorWindow(double s,int layer);
+    void SetColorWindow(double s,int layer) override;
 
     using vtkImageView::SetColorLevel;
-    virtual void SetColorLevel(double s,int layer);
+    void SetColorLevel(double s,int layer) override;
 
 
-    virtual void SetLookupTable (vtkLookupTable* lookuptable, int layer);
+    void SetLookupTable (vtkLookupTable* lookuptable, int layer) override;
 
-    virtual void SetTransferFunctions(vtkColorTransferFunction * color,
+    void SetTransferFunctions(vtkColorTransferFunction * color,
                                       vtkPiecewiseFunction * opacity,
-                                      int layer);
+                                      int layer) override;
 
     virtual void SetOpacity(double opacity, int layer);
     virtual double GetOpacity(int layer) const;
@@ -181,38 +181,38 @@ public:
     void SetOrientationMarkerViewport(double, double, double, double);
 
 
-    virtual void SetCurrentPoint (double pos[3]);
+    void SetCurrentPoint (double pos[3]) override;
 
     virtual void UpdateDisplayExtent();
 
-    virtual void InstallInteractor();
-    virtual void UnInstallInteractor();
+    void InstallInteractor() override;
+    void UnInstallInteractor() override;
 
-    virtual vtkActor* AddDataSet (vtkPointSet* arg, vtkProperty* prop = nullptr);
-    virtual void RemoveDataSet (vtkPointSet* arg);
+    vtkActor* AddDataSet (vtkPointSet* arg, vtkProperty* prop = nullptr) override;
+    void RemoveDataSet (vtkPointSet* arg) override;
 
-    virtual void AddLayer (int layer);
-    virtual int GetNumberOfLayers() const;
-    virtual void RemoveLayer (int layer);
-    virtual void RemoveAllLayers();
+    void AddLayer (int layer) override;
+    int GetNumberOfLayers() const override;
+    void RemoveLayer (int layer) override;
+    void RemoveAllLayers() override;
 
     //pure virtual methods from base class:
-    virtual vtkColorTransferFunction * GetColorTransferFunction(int layer) const;
-    virtual vtkPiecewiseFunction* GetOpacityTransferFunction (int layer) const;
-    virtual void StoreColorTransferFunction (vtkColorTransferFunction *ctf,
-                                             int layer);
-    virtual void StoreOpacityTransferFunction (vtkPiecewiseFunction *otf,
-                                               int layer);
-    virtual vtkLookupTable * GetLookupTable(int layer) const;
-    virtual bool GetUseLookupTable(int layer) const;
-    virtual void SetUseLookupTable (bool use, int layer);
+    vtkColorTransferFunction * GetColorTransferFunction(int layer) const override;
+    vtkPiecewiseFunction* GetOpacityTransferFunction (int layer) const override;
+    void StoreColorTransferFunction (vtkColorTransferFunction *ctf,
+                                             int layer) override;
+    void StoreOpacityTransferFunction (vtkPiecewiseFunction *otf,
+                                               int layer) override;
+    vtkLookupTable * GetLookupTable(int layer) const override;
+    bool GetUseLookupTable(int layer) const override;
+    void SetUseLookupTable (bool use, int layer) override;
     using vtkImageView::GetColorWindow;
-    virtual double GetColorWindow(int layer) const;
-    virtual void StoreColorWindow(double s,int layer);
+    double GetColorWindow(int layer) const override;
+    void StoreColorWindow(double s,int layer) override;
     using vtkImageView::GetColorLevel;
-    virtual double GetColorLevel(int layer) const;
-    virtual void StoreColorLevel(double s,int layer);
-    virtual void StoreLookupTable (vtkLookupTable *lookuptable, int layer);
+    double GetColorLevel(int layer) const override;
+    void StoreColorLevel(double s,int layer) override;
+    void StoreLookupTable (vtkLookupTable *lookuptable, int layer) override;
 
 protected:
 

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
@@ -594,18 +594,13 @@ void medVtkViewItkDataImageInteractor::setWindowLevel(QHash<QString, QVariant> v
     {
         d->view2d->SetColorWindow(w, imageLayer);
     }
-    if (d->view3d->GetColorWindow(imageLayer) != w)
-    {
-        d->view3d->SetColorWindow(w, imageLayer);
-    }
+
     if (d->view2d->GetColorLevel(imageLayer) != l)
     {
         d->view2d->SetColorLevel(l, imageLayer);
     }
-    if (d->view3d->GetColorLevel(imageLayer) != l)
-    {
-        d->view3d->SetColorLevel(l, imageLayer);
-    }
+
+    d->view3d->SetColorWindowLevel( w,  l,  imageLayer);
 
     //--- block
     d->minIntensityParameter->blockSignals(true);

--- a/src/plugins/legacy/itkDataImage/navigators/medVtkViewItkDataImageNavigator.cpp
+++ b/src/plugins/legacy/itkDataImage/navigators/medVtkViewItkDataImageNavigator.cpp
@@ -326,7 +326,7 @@ void medVtkViewItkDataImageNavigator::enableCropping(bool enabled)
     {
         if ( d->view3d->GetBoxWidget()->GetInteractor() )
         {
-            // d->view3D->SetCroppingModeToOff ();
+            d->view3d->SetCroppingModeToOff();
             d->view3d->SetShowBoxWidget ( 0 );
         }
     }


### PR DESCRIPTION
Major bug : missing call to internalUpdate after a new layer is added. 

Some minor changes to reduce the number of function calls, remove unecessary line, improve the lut management by the scalar range : related #326 #657 ,2 images with big diff in their scalar ranges

In order to overcome the 4 layers limit I would like to change how the layer are managed in the volume rendering. 
With less perf. constraint, it might be possible to improve the rendering of the diff layers and to make the code easier to understand. Now layer index are related index of RGBV (difficult to understand but it seems to be a nice trick) 