### PR TITLE
solve #669 in parameters retrieving 

### DIFF
--- a/src/plugins/legacy/reformat/medResliceViewer.cpp
+++ b/src/plugins/legacy/reformat/medResliceViewer.cpp
@@ -22,6 +22,7 @@
 #include <medUtilities.h>
 #include <medUtilitiesITK.h>
 #include <medVtkViewBackend.h>
+#include <medDoubleParameterL.h>
 
 #include <vtkCamera.h>
 #include <vtkCellPicker.h>
@@ -427,7 +428,9 @@ void medResliceViewer::saveImage()
 
 void medResliceViewer::thickSlabChanged(double val)
 {
-    QDoubleSpinBox *spinBoxSender = qobject_cast<QDoubleSpinBox*>(QObject::sender());
+    medDoubleParameterL * doubleParam = qobject_cast<medDoubleParameterL*>(QObject::sender());
+
+    auto spinBoxSender = doubleParam? doubleParam->getSpinBox() : nullptr;
 
     if (spinBoxSender)
     {

--- a/src/plugins/legacy/reformat/resliceToolBox.cpp
+++ b/src/plugins/legacy/reformat/resliceToolBox.cpp
@@ -196,9 +196,10 @@ void resliceToolBox::startReformat()
                 container->setDefaultWidget(d->resliceViewer->viewWidget());
                 connect(container, SIGNAL(viewRemoved()),this, SLOT(stopReformat()), Qt::UniqueConnection);
 
-                connect(d->spacingX->getSpinBox(), SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));
-                connect(d->spacingY->getSpinBox(), SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));
-                connect(d->spacingZ->getSpinBox(), SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));
+                connect(d->spacingX, SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));
+                connect(d->spacingY, SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));
+                connect(d->spacingZ, SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));
+
                 connect(d->b_saveImage, SIGNAL(clicked()), d->resliceViewer, SLOT(saveImage()));
 
                 d->reformatedImage = nullptr;


### PR DESCRIPTION
When there is no parameters changes when switching between **space** and **dimension** then the parameters are not updated : **space** parameters are used in **dimension**. 

