### PR TITLE
mem leak on  vtkInriaInteractorStylePolygonRepulsor (polygonRoi)

### DIFF
--- a/src/plugins/legacy/polygonRoi/repulsor/vtkInriaInteractorStylePolygonRepulsor.cxx
+++ b/src/plugins/legacy/polygonRoi/repulsor/vtkInriaInteractorStylePolygonRepulsor.cxx
@@ -211,8 +211,10 @@ void vtkInriaInteractorStylePolygonRepulsor::RedefinePolygons()
                     ptWorld1[0] = ptWorldtmp[0];
                     ptWorld1[1] = ptWorldtmp[1];
                     ptWorld1[2] = ptWorldtmp[2];
+                    double * pt_k = listPoints[k];
                     listPoints.replace(k,ptWorld1);
-                    contourChanged= true;
+                    delete [] pt_k;
+                    contourChanged = true;
 
                     for( int delta = -1; delta <= 1; delta++ )
                     {
@@ -278,8 +280,10 @@ void vtkInriaInteractorStylePolygonRepulsor::RedefinePolygons()
                     this->ListPolygonsToSave.append(roi);
                 }
             }
+            qDeleteAll(listPoints);
+            listPoints.clear();
+            polyData->Delete();
         }
-
     }
 }
 

--- a/src/plugins/legacy/polygonRoi/repulsor/vtkInriaInteractorStylePolygonRepulsor.h
+++ b/src/plugins/legacy/polygonRoi/repulsor/vtkInriaInteractorStylePolygonRepulsor.h
@@ -34,9 +34,9 @@ public:
     vtkTypeMacro(vtkInriaInteractorStylePolygonRepulsor, vtkInteractorStyleImageView2D)
     void PrintSelf(ostream& os, vtkIndent indent);
 
-    virtual void OnMouseMove();
-    virtual void OnLeftButtonDown();
-    virtual void OnLeftButtonUp();
+    void OnMouseMove() override;
+    void OnLeftButtonDown() override;
+    void OnLeftButtonUp() override;
     void SetCurrentView(medAbstractView *view);
     void SetManager(medTagRoiManager *closestManagerInSlice);
     medTagRoiManager *GetManager(){ return manager;}
@@ -47,10 +47,12 @@ public:
 protected:
     vtkInriaInteractorStylePolygonRepulsor();
     ~vtkInriaInteractorStylePolygonRepulsor();
+    vtkInriaInteractorStylePolygonRepulsor(const vtkInriaInteractorStylePolygonRepulsor&) = delete;
+    void operator=(const vtkInriaInteractorStylePolygonRepulsor&) = delete;
 
     virtual void RedefinePolygons();
     void ReallyDeletePoint(vtkSmartPointer<vtkPoints> points, vtkIdList *idList);
-    void  DisplayPointFromPolygon(double *displayPoint, QList<double*> list, int ind);
+    void DisplayPointFromPolygon(double *displayPoint, QList<double*> list, int ind);
 
     int Position[2];
     int On;
@@ -61,7 +63,4 @@ protected:
     QList<polygonRoi*> ListPolygonsToSave;
     medTagRoiManager* manager;
 
-private:
-    vtkInriaInteractorStylePolygonRepulsor(const vtkInriaInteractorStylePolygonRepulsor&);  // Not implemented
-    void operator=(const vtkInriaInteractorStylePolygonRepulsor&);  // Not implemented
 };


### PR DESCRIPTION
minor mem leak on  vtkInriaInteractorStylePolygonRepulsor

modernize with override and delete. 

