### PR TITLE
itkDataTensorImageVtkViewInteractor & itkDataSHImageVtkViewInteractor minor mem leak and override

### DIFF
--- a/src/plugins/legacy/itkDataSHImage/interactors/itkDataSHImageVtkViewInteractor.cpp
+++ b/src/plugins/legacy/itkDataSHImage/interactors/itkDataSHImageVtkViewInteractor.cpp
@@ -170,6 +170,8 @@ itkDataSHImageVtkViewInteractor::itkDataSHImageVtkViewInteractor(medAbstractView
 
 itkDataSHImageVtkViewInteractor::~itkDataSHImageVtkViewInteractor()
 {
+    d->manager->Delete();
+    d->orientationMatrix->Delete();
     delete d;
     d = nullptr;
 }

--- a/src/plugins/legacy/itkDataSHImage/interactors/itkDataSHImageVtkViewInteractor.h
+++ b/src/plugins/legacy/itkDataSHImage/interactors/itkDataSHImageVtkViewInteractor.h
@@ -56,19 +56,19 @@ public:
         SHMatrixRshBasis
     };
 
-    virtual QString description() const;
-    virtual QString identifier() const;
-    virtual QStringList handled() const;
+    QString description() const override;
+    QString identifier() const override;
+    QStringList handled() const override;
 
     static bool registered();
 
-    virtual void setInputData(medAbstractData * data);
+    void setInputData(medAbstractData * data) override;
 
-    virtual QWidget* buildLayerWidget();
-    virtual QWidget* buildToolBoxWidget();
-    virtual QWidget* buildToolBarWidget();
-    virtual QList<medAbstractParameterL*> linkableParameters();
-    virtual QList<medBoolParameterL*> mouseInteractionParameters();
+    QWidget* buildLayerWidget() override;
+    QWidget* buildToolBoxWidget() override;
+    QWidget* buildToolBarWidget() override;
+    QList<medAbstractParameterL*> linkableParameters() override;
+    QList<medBoolParameterL*> mouseInteractionParameters() override;
 
     void removeData();
 
@@ -136,9 +136,9 @@ public slots:
     void setVisibility(bool visibility);
     void setWindowLevel(QHash<QString, QVariant>);
 
-    virtual void setUpViewForThumbnail();
+    void setUpViewForThumbnail() override;
 
-    virtual void updateWidgets();
+    void updateWidgets() override;
 
     virtual void moveToSlice  (int slice);
 

--- a/src/plugins/legacy/itkDataTensorImage/interactors/itkDataTensorImageVtkViewInteractor.cpp
+++ b/src/plugins/legacy/itkDataTensorImage/interactors/itkDataTensorImageVtkViewInteractor.cpp
@@ -181,6 +181,8 @@ itkDataTensorImageVtkViewInteractor::itkDataTensorImageVtkViewInteractor(medAbst
 
 itkDataTensorImageVtkViewInteractor::~itkDataTensorImageVtkViewInteractor()
 {
+    d->manager->Delete();
+    d->orientationMatrix->Delete();
     delete d;
     d = nullptr;
 }

--- a/src/plugins/legacy/itkDataTensorImage/interactors/itkDataTensorImageVtkViewInteractor.h
+++ b/src/plugins/legacy/itkDataTensorImage/interactors/itkDataTensorImageVtkViewInteractor.h
@@ -52,23 +52,23 @@ public:
 
 public slots:
 
-    virtual QString description() const;
-    virtual QString identifier() const;
-    virtual QStringList handled() const;
+    QString description() const override;
+    QString identifier() const override;
+    QStringList handled() const override;
 
     static bool registered();
 
-    virtual void setInputData(medAbstractData * data);
+    void setInputData(medAbstractData * data) override;
 
-    virtual QWidget* buildLayerWidget();
-    virtual QWidget* buildToolBoxWidget();
-    virtual QWidget* buildToolBarWidget();
-    virtual QList<medAbstractParameterL*> linkableParameters();
-    virtual QList<medBoolParameterL*> mouseInteractionParameters();
+    QWidget* buildLayerWidget() override;
+    QWidget* buildToolBoxWidget() override;
+    QWidget* buildToolBarWidget() override;
+    QList<medAbstractParameterL*> linkableParameters() override;
+    QList<medBoolParameterL*> mouseInteractionParameters() override;
 
     void removeData();
 
-    virtual void updateWidgets();
+    void updateWidgets() override;
 
 public slots:
     void setOpacity(double opacity);
@@ -121,7 +121,7 @@ public slots:
 
     void setScale(int minorScale, int majorScaleExponent);
 
-    virtual void setUpViewForThumbnail();
+    void setUpViewForThumbnail() override;
 
     void moveToSlice(int slice);
 


### PR DESCRIPTION
minor mem leak and override (that is more secure than virtual : your add one more constraint, the function has to be declared in the base class and to be virtual, if a change occured in the base class API than it will be reported as an error during compilation) 