### PR TITLE
Fix #581 once min/max intensities in 3D V3.1.1

### DIFF
--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
@@ -560,6 +560,7 @@ void medVtkViewItkDataImageInteractor::setWindowLevelFromMinMax()
 
         // Call function from vtkImageView shared by view2d and view3d
         d->view2d->SetColorWindowLevel(window, level, imageLayer);
+        d->view3d->SetColorWindowLevel(window, level, imageLayer);
 
         this->windowLevelParameter()->blockSignals(false);
         //--- unblock


### PR DESCRIPTION
Fix #581 [Tests] 3.1.1 and master -> once min/max intensities in 3D, it's kept 
For 3.1.x