### PR TITLE
Fix #581 once min/max intensities in 3D V4.0

### DIFF
--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
@@ -559,6 +559,7 @@ void medVtkViewItkDataImageInteractor::setWindowLevelFromMinMax()
 
         // Call function from vtkImageView shared by view2d and view3d
         d->view2d->SetColorWindowLevel(window, level, imageLayer);
+        d->view3d->SetColorWindowLevel(window, level, imageLayer);
 
         this->windowLevelParameter()->blockSignals(false);
         //--- unblock


### PR DESCRIPTION
Fix #581 [Tests] 3.1.1 and master -> once min/max intensities in 3D, it's kept
For 4.0