### PR TITLE
Put back algo name in undo redo toolbox

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medRegistrationSelectorToolBox.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medRegistrationSelectorToolBox.cpp
@@ -126,6 +126,9 @@ void medRegistrationSelectorToolBox::changeCurrentToolBox(int index)
     connect (currentToolBox(), SIGNAL (success()),this,SLOT(enableSelectorToolBox()));
     connect (currentToolBox(), SIGNAL (failure()),this,SLOT(enableSelectorToolBox()));
 
+    unsigned int index = this->comboBox()->currentIndex();
+    d->nameOfCurrentAlgorithm = this->comboBox()->itemData(index).toString();
+
     if (!d->undoRedoProcess && !d->undoRedoToolBox)
     {
         connect(currentToolBox(), SIGNAL(success()), this, SLOT(handleOutput()));


### PR DESCRIPTION
Names of the algos run were not shown anymore in the undo redo toolbox after running a registration algorithm. This corrects it. To be pushed on 3.1.x as well