### PR TITLE
Put back algo name in undo redo toolbox for medInria V3.1.1

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medRegistrationSelectorToolBox.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medRegistrationSelectorToolBox.cpp
@@ -126,6 +126,9 @@ void medRegistrationSelectorToolBox::changeCurrentToolBox(int index)
     connect (currentToolBox(), SIGNAL (success()),this,SLOT(enableSelectorToolBox()));
     connect (currentToolBox(), SIGNAL (failure()),this,SLOT(enableSelectorToolBox()));
 
+    unsigned int index = this->comboBox()->currentIndex();
+    d->nameOfCurrentAlgorithm = this->comboBox()->itemData(index).toString();
+
     if (!d->undoRedoProcess && !d->undoRedoToolBox)
     {
         connect(currentToolBox(), SIGNAL(success()), this, SLOT(handleOutput()));


### PR DESCRIPTION
Put back algo name in undo redo toolbox
Port of ocommowi:undo-redo-bug-corr for medInria V3.1.1
cf #693 Put back algo name in undo redo toolbox