### PR TITLE
[LCC-LogDemons] avoid crashes (transfo, spacing, size), standardize

### DIFF
--- a/src/plugins/legacy/LCCLogDemons/LCCLogDemons.h
+++ b/src/plugins/legacy/LCCLogDemons/LCCLogDemons.h
@@ -53,7 +53,6 @@ public:
     virtual void useMask(bool flag);
     virtual void setInterpolatorType(int value);
 
-public:
     /**
      * @brief Runs the process.
      *
@@ -62,7 +61,19 @@ public:
      */
     virtual int update(ImageType);
     
-    
+    /**
+     * @brief Get parameters for tooltip in undo/redo area.
+     *
+     * @param void
+     * @return QString of the algorithm title & parameters
+    */
+    virtual QString getTitleAndParameters();
+
+    /**
+     * @brief testInputs() tests origin, dimension and spacing of the input
+     * @return medAbstractProcess::DataError according to the test result
+    */
+    medAbstractProcessLegacy::DataError testInputs();
 protected :
     /**
      * @brief
@@ -73,11 +84,9 @@ protected :
     virtual bool writeTransform(const QString& file);
     
     virtual itk::Transform<double,3,3>::Pointer getTransform();
-    virtual QString getTitleAndParameters();
 
 private:
     LCCLogDemonsPrivate *d;
-    
 };
 
 /**

--- a/src/plugins/legacy/diffeomorphicDemons/diffeomorphicDemons.cpp
+++ b/src/plugins/legacy/diffeomorphicDemons/diffeomorphicDemons.cpp
@@ -103,8 +103,8 @@ int diffeomorphicDemonsPrivate::update()
         return testResult;
     }
 
-    FixedImageType *inputFixed  = (FixedImageType*)  proc->fixedImage().GetPointer();
-    FixedImageType *inputMoving = (MovingImageType*) proc->movingImages()[0].GetPointer();
+    FixedImageType  *inputFixed  = (FixedImageType*)  proc->fixedImage().GetPointer();
+    MovingImageType *inputMoving = (MovingImageType*) proc->movingImages()[0].GetPointer();
 
     // The output volume is going to located at the origin/direction of the fixed input. Needed for rpi::DiffeomorphicDemons
     typedef itk::ChangeInformationImageFilter< FixedImageType > FilterType;
@@ -175,8 +175,8 @@ int diffeomorphicDemonsPrivate::update()
         qDebug() << "ExceptionObject caught (StartRegistration): " << err.what();
         return medAbstractProcessLegacy::FAILURE;
     }
-    time_t t2 = clock();
 
+    time_t t2 = clock();
     qDebug() << "Elasped time: " << static_cast<double>(t2-t1)/static_cast<double>(CLOCKS_PER_SEC);
 
     emit proc->progressed(80);
@@ -328,10 +328,8 @@ bool diffeomorphicDemons::writeTransform(const QString& file)
         }
         return true;
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 // /////////////////////////////////////////////////////////////////

--- a/src/plugins/legacy/diffeomorphicDemons/diffeomorphicDemonsToolBox.cpp
+++ b/src/plugins/legacy/diffeomorphicDemons/diffeomorphicDemonsToolBox.cpp
@@ -48,6 +48,7 @@ diffeomorphicDemonsToolBox::diffeomorphicDemonsToolBox(QWidget *parent)
     QLabel *explanation = new QLabel("Drop 2 datasets with same size and spacing.\n");
     explanation->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
     explanation->setWordWrap(true);
+    explanation->setStyleSheet("font: italic");
     layout->addWidget(explanation);
 
     d->iterationsBox = new QLineEdit();
@@ -126,6 +127,8 @@ diffeomorphicDemonsToolBox::diffeomorphicDemonsToolBox(QWidget *parent)
     this->addWidget(widget);
 
     connect(runButton, SIGNAL(clicked()), this, SLOT(run()));
+
+    d->process = nullptr;
 }
 
 diffeomorphicDemonsToolBox::~diffeomorphicDemonsToolBox()
@@ -151,10 +154,10 @@ dtkPlugin* diffeomorphicDemonsToolBox::plugin()
 void diffeomorphicDemonsToolBox::run()
 {
     medRegistrationSelectorToolBox *toolbox = dynamic_cast<medRegistrationSelectorToolBox*>(selectorToolBox());
-
     if(toolbox) // toolbox empty in Pipelines and not Registration workspace
     {
-        d->process = dynamic_cast<medAbstractRegistrationProcess*> (dtkAbstractProcessFactory::instance()->create("diffeomorphicDemons"));
+        d->process = dynamic_cast<medAbstractRegistrationProcess*>
+                (dtkAbstractProcessFactory::instance()->create("diffeomorphicDemons"));
         toolbox->setProcess(d->process);
 
         dtkSmartPointer<medAbstractData> fixedData(toolbox->fixedData());
@@ -195,6 +198,7 @@ void diffeomorphicDemonsToolBox::run()
             medRunnableProcess *runProcess = new medRunnableProcess;
             runProcess->setProcess (d->process);
             this->addConnectionsAndStartJob(runProcess);
+            enableOnProcessSuccessImportOutput(runProcess, false);
         }
     }
 }
@@ -211,8 +215,6 @@ medAbstractData* diffeomorphicDemonsToolBox::processOutput()
     {
         return d->process->output();
     }
-    else
-    {
-        return nullptr;
-    }
+
+    return nullptr;
 }

--- a/src/plugins/legacy/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src/plugins/legacy/manualRegistration/manualRegistrationToolBox.cpp
@@ -339,7 +339,8 @@ void manualRegistrationToolBox::computeRegistration()
 
             this->setToolBoxOnWaitStatus();
 
-            d->process = dynamic_cast<medAbstractRegistrationProcess*> (dtkAbstractProcessFactory::instance()->create("manualRegistration"));
+            d->process = dynamic_cast<medAbstractRegistrationProcess*>
+                    (dtkAbstractProcessFactory::instance()->create("manualRegistration"));
 
             medRegistrationSelectorToolBox *toolbox = dynamic_cast<medRegistrationSelectorToolBox*>(selectorToolBox());
             if(toolbox) // toolbox empty in Pipelines and not Registration workspace


### PR DESCRIPTION
Fixes https://github.com/medInria/medInria-public/issues/694

This PR:
 * LCC uses the common processbar, not its own
 * export of transformation does not crash
 * avoid crashes using data with different spacings or sizes
 * add explanation about data to use for users
 * standardize the labels with the other Registration tlbx
 * fill the getTitleAndParamaters label
 * fix double output problem with Diffeomorphic toolbox

I'm not sure the exported transformation is right however, i did not test it.

I'm going to do the same PR on master too.
:m: