### PR TITLE
[Registration] undo-redo current tlbx name

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medRegistrationSelectorToolBox.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medRegistrationSelectorToolBox.cpp
@@ -126,7 +126,6 @@ void medRegistrationSelectorToolBox::changeCurrentToolBox(int index)
     connect (currentToolBox(), SIGNAL (success()),this,SLOT(enableSelectorToolBox()));
     connect (currentToolBox(), SIGNAL (failure()),this,SLOT(enableSelectorToolBox()));
 
-    unsigned int index = this->comboBox()->currentIndex();
     d->nameOfCurrentAlgorithm = this->comboBox()->itemData(index).toString();
 
     if (!d->undoRedoProcess && !d->undoRedoToolBox)


### PR DESCRIPTION
Same as https://github.com/medInria/medInria-public/pull/700 on 3.1.1

Solve the compilation error with index named twice.

:m: