### PR TITLE
medLoggerRedirectWithBoost

### DIFF
--- a/src/app/medInria/medLogger.h
+++ b/src/app/medInria/medLogger.h
@@ -11,6 +11,13 @@ PURPOSE.
 
 =========================================================================*/
 
+#include <fstream>
+
+#ifndef Q_MOC_RUN
+#include <boost/iostreams/tee.hpp>
+#include <boost/iostreams/stream.hpp>
+#endif
+
 #include <dtkLog/dtkLog.h>
 
 #include <QtGui>
@@ -40,12 +47,19 @@ public :
 
 private slots:
     void redirectQtMessage(QtMsgType type, const QString& message);
+    void redirectMessage(const QString& message);
+    void redirectErrorMessage(const QString& message);
 
 private:
     medLoggerPrivate* const d;
 
     medLogger();
     ~medLogger();
+
+    void initializeTeeStreams();
+    void finalizeTeeStreams();
+
+    void createTeeStream(std::ostream* targetStream);
 
     /** Test the size of the log file and cut if needed
      */


### PR DESCRIPTION
This PR change the way to redirect cout and cerr.
Now don't use **dtk** to redirect log but **Boost**
It avoids some crashs or freezes when external dependencies, like RPI, did a cout or cerr.

The problem is due to incorrect re-lock mutex inside dtklogger
cd https://github.com/medInria/medInria-public/issues/695

