### PR TITLE
[FIX] - Label name were lost at import in specific cases

### DIFF
--- a/src/plugins/legacy/polygonRoi/data/medContourSharedInfo.cpp
+++ b/src/plugins/legacy/polygonRoi/data/medContourSharedInfo.cpp
@@ -9,6 +9,9 @@ medContourSharedInfo::medContourSharedInfo(QString name, QColor color, bool sele
     secondName = QString();
     secondColor = QColor::Invalid;
     changeName = false;
+    updateColor = false;
+    checked = false;
+    updateDesc = false;
 }
 
 void medContourSharedInfo::setAdditionalNameAndColor(QString name, QColor color)

--- a/src/plugins/legacy/polygonRoi/polygonEventFilter.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonEventFilter.cpp
@@ -822,12 +822,16 @@ void polygonEventFilter::receiveDatasFromToolbox(QList<medContourSharedInfo> inf
 
 void polygonEventFilter::receiveActivationState(medContourSharedInfo info)
 {
+    activeManager = nullptr;
     medTagRoiManager *manager = findManagerWithColor(info.getColor());
     if (manager)
     {
         activeManager = manager;
-        enableActiveManagerIfExists();
     }
+    activeColor = info.getColor();
+    activeName = info.getName();
+    scoreState = info.hasScore();
+    enableActiveManagerIfExists();
 }
 
 void polygonEventFilter::receiveContourState(medContourSharedInfo info)
@@ -1019,7 +1023,6 @@ void polygonEventFilter::loadContours(medTagContours tagContours, QColor color)
 
     activeName = tagContours.getLabelName();
     activeColor = color;
-    qDebug()<<"create manager with name "<<activeName<<" and color "<<activeColor.toRgb();
     if (findManagerWithColor(color) != nullptr)
     {
         emit sendErrorMessage(QString("loadContours - contour with color %1 already exists").arg(color.toRgb().name()));

--- a/src/plugins/legacy/polygonRoi/toolboxes/contoursManagementToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/toolboxes/contoursManagementToolBox.cpp
@@ -240,7 +240,7 @@ bool contoursManagementToolBox::loadUrologyContours(QListWidget *widget, QVector
             {
                 itemFound = true;
                 color = item->icon().pixmap(QSize(20,20)).toImage().pixelColor(0,0);
-                if (tagContours.isTarget())
+                if (tagContours.isTarget() && tagContours.getScore()!=QString())
                 {
                     QString name = QString("%1 - %2").arg(tagContours.getLabelName()).arg(tagContours.getScore());
                     item->setText(name);
@@ -726,14 +726,22 @@ void contoursManagementToolBox::removeLabelNameInList()
     for (int row = 0; row<widget->count(); row++)
     {
         QListWidgetItem *item = widget->item(row);
-        if (item->isSelected() && row > minRowNumber)
+        if (item->isSelected())
         {
             QString name = item->text();
             name = name.remove(QRegExp(" - PIRADS[0-9]"));
             QColor col = item->icon().pixmap(QSize(20,20)).toImage().pixelColor(0,0);
             medContourSharedInfo info = medContourSharedInfo(name, col);
             emit labelToDelete(info);
-            widget->takeItem(row);
+            if (row > minRowNumber)
+            {
+                widget->takeItem(row);
+            }
+            else
+            {
+                info.setScoreInfo(item->flags().testFlag(Qt::ItemIsUserCheckable));
+                emit sendActivationState(info);
+            }
         }
     }
     widget->setMaximumHeight((20*widget->count())+5);
@@ -756,7 +764,7 @@ void contoursManagementToolBox::switchTargetState(bool state)
             if (item->isSelected() && row > 3)
             {
                 bool itemCheckable = item->flags().testFlag(Qt::ItemIsUserCheckable);
-                QString name;
+                QString name = "unamed";
                 QColor color;
                 if (itemCheckable && !state)
                 {
@@ -878,6 +886,7 @@ void contoursManagementToolBox::receiveContoursDatasFromView(medContourSharedInf
                 item->setCheckState(Qt::Unchecked);
             }
             medContourSharedInfo activationInfo = medContourSharedInfo(itemName, itemColor);
+            activationInfo.setScoreInfo(item->flags().testFlag(Qt::ItemIsUserCheckable));
             emit sendActivationState(activationInfo);
         }
 


### PR DESCRIPTION
Fix bugs just before delivering binary to APHP
A ) Scenario:
1. Add a score to a pre-defined target in widget list  (target 1 or target 2 for instance)
2. delete it and re-create it without score.
3. Save contours
4. Load the saved contours 
  ==> The target was displayed with name `Target 1 - `
B ) Delete a predefined label with button minus (-)
The selected contour is delete in view but the name is in the widget list yet.
 ==> Clic on view ==> no color is selected and we were unable to create a new contour