### PR TITLE
Fix a syntax error when a mask is saved on disk (windows) + some details 

### DIFF
--- a/src/plugins/legacy/polygonRoi/medTagRoiManager.cpp
+++ b/src/plugins/legacy/polygonRoi/medTagRoiManager.cpp
@@ -549,8 +549,8 @@ void medTagRoiManager::createMaskWithLabel(int label)
             }
         }
     }
-    QString name = (d->optName==QString())?QString(d->baseName):QString("%1-%2").arg(d->baseName).arg(d->optName);
-    QString desc = QString("mask: ") + name;
+    QString name = (d->optName==QString())?QString(d->baseName):QString("%1_%2").arg(d->baseName).arg(d->optName);
+    QString desc = QString("mask ") + name;
     medUtilities::setDerivedMetaData(output, inputData, desc);
     medDataManager::instance()->importData(output, false);
     return;

--- a/src/plugins/legacy/polygonRoi/polygonEventFilter.h
+++ b/src/plugins/legacy/polygonRoi/polygonEventFilter.h
@@ -135,4 +135,5 @@ private:
     medTagRoiManager *findManagerWithColor(QColor color);
     void createNewManager(medTagContours tagContours);
     medTagRoiManager *createManager();
+    void activateContour(double *mousePosition);
 };


### PR DESCRIPTION
1. Remove special characters ":" in description when a mask is saved to avoid issue on Windows
2. Add shortcut "a" to activate a contour on view
3. Remove unused lines (mousePos)
4. Remove go to slice when selected for contours named WG and TZ