### PR TITLE
[Various] typos and tooltips found

### DIFF
--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
@@ -345,7 +345,7 @@ void vtkImageView2D::SetSlice(int slice)
   double pos[3];
   pointTransform->TransformPoint ( this->CurrentPoint , pos );
   // NB: Modified() and InvokeEvent( vtkImageView::CurrentPointChangedEvent ) are
-  // callled in SetCurrentPoint()
+  // called in SetCurrentPoint()
 
   // Shift the camera with the slice, so that the slice does not go behind the camera.
   vtkCamera *camera = this->GetRenderer()->GetActiveCamera();

--- a/src/plugins/legacy/diffeomorphicDemons/diffeomorphicDemons.cpp
+++ b/src/plugins/legacy/diffeomorphicDemons/diffeomorphicDemons.cpp
@@ -244,7 +244,7 @@ itk::Transform<double,3,3>::Pointer diffeomorphicDemons::getTransform()
     typedef float PixelType;
     typedef double TransformScalarType;
     typedef itk::Image< PixelType, 3 > RegImageType;
-    //normaly should use long switch cases, but here we know we work with float3 data.
+    // Normally should use long switch cases, but here we know we work with float3 data.
     if (rpi::DiffeomorphicDemons<RegImageType,RegImageType,TransformScalarType> * registration =
             static_cast<rpi::DiffeomorphicDemons<RegImageType,RegImageType,TransformScalarType> *>(d->registrationMethod))
     {
@@ -259,50 +259,50 @@ QString diffeomorphicDemons::getTitleAndParameters()
     typedef float PixelType;
     typedef double TransformScalarType;
     typedef itk::Image< PixelType, 3 > RegImageType;
-    //normaly should use long switch cases, but here we know we work with float3 data.
+    // Normally should use long switch cases, but here we know we work with float3 data.
     typedef rpi::DiffeomorphicDemons<RegImageType,RegImageType,TransformScalarType> RegistrationType;
     RegistrationType *registration = static_cast<RegistrationType *>(d->registrationMethod);
 
     QString titleAndParameters;
     titleAndParameters += "DiffeomorphicDemons\n";
-    titleAndParameters += "  Max number of iterations   : " + QString::fromStdString(rpi::VectorToString(registration->GetNumberOfIterations())) + "\n";
+    titleAndParameters += "  Max number of iterations: " + QString::fromStdString(rpi::VectorToString(registration->GetNumberOfIterations())) + "\n";
     switch (registration->GetUpdateRule())
     {
     case 0:
-        titleAndParameters += "  Update rule   : DIFFEOMORPHIC\n";
+        titleAndParameters += "  Update rule: DIFFEOMORPHIC\n";
         break;
     case 1:
-        titleAndParameters += "  Update rule   : ADDITIVE\n";
+        titleAndParameters += "  Update rule: ADDITIVE\n";
         break;
     case 2:
-        titleAndParameters += "  Update rule   : COMPOSITIVE\n";
+        titleAndParameters += "  Update rule: COMPOSITIVE\n";
         break;
     default:
-        titleAndParameters += "  Update rule   : Unknown\n";
+        titleAndParameters += "  Update rule: Unknown\n";
     }
 
     switch( registration->GetGradientType() )
     {
     case 0:
-        titleAndParameters += "  Gradient type   : SYMMETRIZED\n";
+        titleAndParameters += "  Gradient type: SYMMETRIZED\n";
         break;
     case 1:
-        titleAndParameters += "  Gradient type   : FIXED_IMAGE\n";
+        titleAndParameters += "  Gradient type: FIXED_IMAGE\n";
         break;
     case 2:
-        titleAndParameters += "  Gradient type   : WARPED_MOVING_IMAGE\n";
+        titleAndParameters += "  Gradient type: WARPED_MOVING_IMAGE\n";
         break;
     case 3:
-        titleAndParameters += "  Gradient type   : MAPPED_MOVING_IMAGE\n";
+        titleAndParameters += "  Gradient type: MAPPED_MOVING_IMAGE\n";
         break;
     default:
-        titleAndParameters += "  Gradient type   : Unknown\n";
+        titleAndParameters += "  Gradient type: Unknown\n";
     }
 
-    titleAndParameters += "  Maximum step length   : " + QString::number(registration->GetMaximumUpdateStepLength()) + " (voxel unit)\n";
-    titleAndParameters += "  Update field standard deviation   : " + QString::number(registration->GetUpdateFieldStandardDeviation()) + " (voxel unit)\n";
-    titleAndParameters += "  Displacement field standard deviation   : " + QString::number(registration->GetDisplacementFieldStandardDeviation()) + " (voxel unit)\n";
-    titleAndParameters += "  Use histogram matching   : " + QString::fromStdString(rpi::BooleanToString(registration->GetUseHistogramMatching())) + "\n";
+    titleAndParameters += "  Maximum step length: " + QString::number(registration->GetMaximumUpdateStepLength()) + " (voxel unit)\n";
+    titleAndParameters += "  Update field standard deviation: " + QString::number(registration->GetUpdateFieldStandardDeviation()) + " (voxel unit)\n";
+    titleAndParameters += "  Displacement field standard deviation: " + QString::number(registration->GetDisplacementFieldStandardDeviation()) + " (voxel unit)\n";
+    titleAndParameters += "  Use histogram matching: " + QString::fromStdString(rpi::BooleanToString(registration->GetUseHistogramMatching())) + "\n";
 
     return titleAndParameters;
 }
@@ -312,7 +312,7 @@ bool diffeomorphicDemons::writeTransform(const QString& file)
     typedef float PixelType;
     typedef double TransformScalarType;
     typedef itk::Image< PixelType, 3 > RegImageType;
-    //normaly should use long switch cases, but here we know we work with float3 data.
+    // Normally should use long switch cases, but here we know we work with float3 data.
     if (rpi::DiffeomorphicDemons<RegImageType,RegImageType,TransformScalarType> * registration =
             static_cast<rpi::DiffeomorphicDemons<RegImageType,RegImageType,TransformScalarType> *>(d->registrationMethod))
     {

--- a/src/plugins/legacy/medVtkView/medVtkViewNavigator.cpp
+++ b/src/plugins/legacy/medVtkView/medVtkViewNavigator.cpp
@@ -113,6 +113,7 @@ medVtkViewNavigator::medVtkViewNavigator(medAbstractView *parent) :
     d->oAxialParameter = new medBoolParameterL("axial", this);
     d->oAxialParameter->setIcon(QIcon(":/icons/AxialIcon.png"));
     d->oAxialParameter->setIconSize(QSize(40,40));
+    d->oAxialParameter->setToolTip("Axial");
     d->oAxialParameter->getPushButton()->setMinimumSize(64,64);
     connect(d->oAxialParameter, SIGNAL(valueChanged(bool)),
             this, SLOT(setAxial(bool)));
@@ -120,6 +121,7 @@ medVtkViewNavigator::medVtkViewNavigator(medAbstractView *parent) :
     d->oCoronalParameter = new medBoolParameterL("coronal", this);
     d->oCoronalParameter->setIcon(QIcon(":/icons/CoronalIcon.png"));
     d->oCoronalParameter->setIconSize(QSize(40,40));
+    d->oCoronalParameter->setToolTip("Coronal");
     d->oCoronalParameter->getPushButton()->setMinimumSize(64,64);
     connect(d->oCoronalParameter, SIGNAL(valueChanged(bool)),
             this, SLOT(setCoronal(bool)));
@@ -127,6 +129,7 @@ medVtkViewNavigator::medVtkViewNavigator(medAbstractView *parent) :
     d->oSagittalParameter = new medBoolParameterL("sagittal", this);
     d->oSagittalParameter->setIcon(QIcon(":/icons/SagittalIcon.png"));
     d->oSagittalParameter->setIconSize(QSize(40,40));
+    d->oSagittalParameter->setToolTip("Sagittal");
     d->oSagittalParameter->getPushButton()->setMinimumSize(64,64);
     connect(d->oSagittalParameter, SIGNAL(valueChanged(bool)),
             this, SLOT(setSagittal(bool)));
@@ -134,6 +137,7 @@ medVtkViewNavigator::medVtkViewNavigator(medAbstractView *parent) :
     d->o3dParameter = new medBoolParameterL("3d", this);
     d->o3dParameter->setIcon(QIcon(":/icons/3DIcon.png"));
     d->o3dParameter->setIconSize(QSize(40,40));
+    d->o3dParameter->setToolTip("3D");
     d->o3dParameter->getPushButton()->setMinimumSize(64,64);
     connect(d->o3dParameter, SIGNAL(valueChanged(bool)),
             this, SLOT(set3d(bool)));


### PR DESCRIPTION
At the end of the 3.1.1 release i found some things to enhanced for 4.0. They were not an emergency for 3.1.1.

 * some typos are removed in comments
 * remove spaces in text in diffeomorphicDemons where it's not needed (as in LCCLogDemmons)
 * added tooltips to the orientation buttons

:m: