### PR TITLE
[medVtkFibersData] avoid crashes opening fibers in tlbx

### DIFF
--- a/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
+++ b/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
@@ -754,6 +754,7 @@ void AlgorithmPaintToolBox::updateView()
             {
                 medAbstractData *data = v->layerData(i);
                 if(!data || data->identifier().contains("vtkDataMesh")
+                        || !data->identifier().contains("itkDataImage") //avoid medVtkFibersData also
                         || data->identifier().contains("itkDataImageVector"))
                 {
                     handleDisplayError(medAbstractProcessLegacy::DIMENSION_3D);

--- a/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonRoiToolBox.cpp
@@ -303,6 +303,7 @@ void polygonRoiToolBox::updateView()
         {
             medAbstractData *data = v->layerData(i);
             if(!data || data->identifier().contains("vtkDataMesh")
+                    || !data->identifier().contains("itkDataImage") //avoid medVtkFibersData also
                     || data->identifier().contains("itkDataImageVector"))
             {
                 handleDisplayError(medAbstractProcessLegacy::DIMENSION_3D);

--- a/src/plugins/legacy/reformat/medCropToolBox.cpp
+++ b/src/plugins/legacy/reformat/medCropToolBox.cpp
@@ -187,6 +187,7 @@ void medCropToolBox::updateView()
         {
             medAbstractData *data = view->layerData(i);
             if(!data || data->identifier().contains("vtkDataMesh")
+                    || !data->identifier().contains("itkDataImage") //avoid medVtkFibersData also
                     || data->identifier().contains("itkDataImageVector"))
             {
                 handleDisplayError(medAbstractProcessLegacy::DIMENSION_3D);

--- a/src/plugins/legacy/variationalSegmentation/varSegToolBox.cpp
+++ b/src/plugins/legacy/variationalSegmentation/varSegToolBox.cpp
@@ -286,6 +286,7 @@ void VarSegToolBox::updateView()
         {
             medAbstractData *data = d->currentView->layerData(i);
             if(!data || data->identifier().contains("vtkDataMesh")
+                    || !data->identifier().contains("itkDataImage") //avoid medVtkFibersData also
                     || data->identifier().contains("itkDataImageVector"))
             {
                 handleDisplayError(medAbstractProcessLegacy::DIMENSION_3D);

--- a/src/plugins/legacy/voiCutter/voiCutterToolBox.cpp
+++ b/src/plugins/legacy/voiCutter/voiCutterToolBox.cpp
@@ -178,6 +178,7 @@ void voiCutterToolBox::updateView()
         {
             medAbstractData *data = d->currentView->layerData(i);
             if(!data || data->identifier().contains("vtkDataMesh")
+                    || !data->identifier().contains("itkDataImage") //avoid medVtkFibersData also
                     || data->identifier().contains("itkDataImageVector"))
             {
                 handleDisplayError(medAbstractProcessLegacy::DIMENSION_3D);


### PR DESCRIPTION
Avoid crashes if you try to open medVtkFibersData in some toolboxes.

:m: