### PR TITLE
[vtkDataMeshInteractor] Fix mesh LUT messing with image LUT

### DIFF
--- a/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
+++ b/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
@@ -560,7 +560,6 @@ void vtkDataMeshInteractor::setLut(vtkLookupTable * lut)
 
     if ( ! lut )
     {
-        std::cout<<" IN DEFAULT LUT "<<std::endl;
         lut = d->attribute->GetLookupTable();
         d->lut = LutPair(lut, "Default");
     }

--- a/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
+++ b/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
@@ -447,7 +447,6 @@ void vtkDataMeshInteractor::setAttribute(const QString & attributeName)
         int dataType = d->attribute->GetDataType();
         initWindowLevelParameters(range, dataType);
 
-        
         this->setLut(d->lut.first);
 
         mapper2d->SetScalarVisibility(1);
@@ -561,6 +560,7 @@ void vtkDataMeshInteractor::setLut(vtkLookupTable * lut)
 
     if ( ! lut )
     {
+        std::cout<<" IN DEFAULT LUT "<<std::endl;
         lut = d->attribute->GetLookupTable();
         d->lut = LutPair(lut, "Default");
     }
@@ -584,12 +584,13 @@ void vtkDataMeshInteractor::setLut(vtkLookupTable * lut)
     mapper2d->InterpolateScalarsBeforeMappingOn();
     mapper3d->InterpolateScalarsBeforeMappingOn();
 
-    d->view2d->SetLookupTable(lut);
+    int currentLayerIndex = d->view->currentLayer();
+    d->view2d->SetLookupTable(lut, currentLayerIndex);
     mapper2d->SetLookupTable(lut);
     mapper2d->UseLookupTableScalarRangeOn();
     mapper2d->InterpolateScalarsBeforeMappingOn();
 
-    d->view3d->SetLookupTable(lut,d->view->layer(this->inputData()));
+    d->view3d->SetLookupTable(lut, currentLayerIndex);
     mapper3d->SetLookupTable(lut);
     mapper3d->UseLookupTableScalarRangeOn();
     mapper3d->InterpolateScalarsBeforeMappingOn();


### PR DESCRIPTION
- Fixes a bug where, if there is a volume and a mesh in the 2D view, changing the LUT of the mesh would also change the LUT of the image.