### PR TITLE
[FIX] - Var WorldPos has to be allocated as 4 vector

### DIFF
--- a/src/plugins/legacy/polygonRoi/data/vtkContourOverlayRepresentation.cxx
+++ b/src/plugins/legacy/polygonRoi/data/vtkContourOverlayRepresentation.cxx
@@ -223,7 +223,7 @@ int vtkContourOverlayRepresentation::AddNodeAtDisplayPosition(int X, int Y)
 
 int vtkContourOverlayRepresentation::AddNodeAtDisplayPosition(double displayPos[2])
 {
-    double worldPos[3];
+    double worldPos[4];
     double worldOrient[9] = {1.0,0.0,0.0,
                              0.0,1.0,0.0,
                              0.0,0.0,1.0};


### PR DESCRIPTION
Context:
1. build medInria-public in Debug mode on macOs
2. open polygonROI Toolbox and try to draw a contour
==> Crash

In PR #764, We developed a hack to be able to compute the correct world position.
The call to the method  vtkInteractorObserver::ComputeDisplayToWorld(this->Renderer, displayPos[0], displayPos[1], 0.0, worldPos); cause a crash in the context described above.

The description of this method is:
```
//----------------------------------------------------------------------------
// Description:
// Transform from display to world coordinates.
// WorldPt has to be allocated as 4 vector
```
But the definition of the variable WorldPos passed as an argument in method was:
double WorldPos[3]



