### PR TITLE
[FFMPEG] switch to version n3.4.8

### DIFF
--- a/superbuild/projects_modules/VTK.cmake
+++ b/superbuild/projects_modules/VTK.cmake
@@ -91,11 +91,22 @@ if(${USE_FFmpeg})
     list(APPEND cmake_args
         # FFMPEG
         -DModule_vtkIOFFMPEG:BOOL=ON
+        -DFFMPEG_ROOT:STRING=${EP_PATH_BUILD}/ffmpeg
         -DFFMPEG_INCLUDE_DIR:STRING=${EP_PATH_BUILD}/ffmpeg/include/
-        -DFFMPEG_avcodec_LIBRARY:STRING=${EP_PATH_BUILD}/ffmpeg/lib/libavcodec.${extention}
-        -DFFMPEG_avformat_LIBRARY:STRING=${EP_PATH_BUILD}/ffmpeg/lib/libavformat.${extention}
-        -DFFMPEG_avutil_LIBRARY:STRING=${EP_PATH_BUILD}/ffmpeg/lib/libavutil.${extention}
-        -DFFMPEG_swscale_LIBRARY:STRING=${EP_PATH_BUILD}/ffmpeg/lib/libswscale.${extention}
+
+        -DFFMPEG_LIBAVCODEC_INCLUDE_DIRS:STRING=${EP_PATH_BUILD}/ffmpeg/include
+        -DFFMPEG_LIBAVDEVICE_INCLUDE_DIRS:STRING=${EP_PATH_BUILD}/ffmpeg/include
+        -DFFMPEG_LIBAVFORMAT_INCLUDE_DIRS:STRING=${EP_PATH_BUILD}/ffmpeg/include
+        -DFFMPEG_LIBAVUTIL_INCLUDE_DIRS:STRING=${EP_PATH_BUILD}/ffmpeg/include
+        -DFFMPEG_LIBSWRESAMPLE_INCLUDE_DIRS:STRING=${EP_PATH_BUILD}/ffmpeg/include
+        -DFFMPEG_LIBSWSCALE_INCLUDE_DIRS:STRING=${EP_PATH_BUILD}/ffmpeg/include
+
+        -DFFMPEG_LIBAVDEVICE_LIBRARIES:STRING=${EP_PATH_BUILD}/ffmpeg/lib/libavdevice.${extention}
+        -DFFMPEG_LIBAVCODEC_LIBRARIES:STRING=${EP_PATH_BUILD}/ffmpeg/lib/libavcodec.${extention}
+        -DFFMPEG_LIBAVFORMAT_LIBRARIES:STRING=${EP_PATH_BUILD}/ffmpeg/lib/libavformat.${extention}
+        -DFFMPEG_LIBAVUTIL_LIBRARIES:STRING=${EP_PATH_BUILD}/ffmpeg/lib/libavutil.${extention}
+        -DFFMPEG_LIBSWRESAMPLE_LIBRARIES:STRING=${EP_PATH_BUILD}/ffmpeg/lib/libswresample.${extention}
+        -DFFMPEG_LIBSWSCALE_LIBRARIES:STRING=${EP_PATH_BUILD}/ffmpeg/lib/libswscale.${extention}
     )
 endif()
 

--- a/superbuild/projects_modules/ffmpeg.cmake
+++ b/superbuild/projects_modules/ffmpeg.cmake
@@ -41,7 +41,7 @@ if (NOT USE_SYSTEM_${ep})
 
 if (NOT DEFINED ${ep}_SOURCE_DIR)
     if(UNIX) # is TRUE on all UNIX-like OS's, including Apple OS X and CygWin
-        set(tag "release/4.3") # FFMPEG
+        set(tag "n3.4.8") # FFMPEG
         set(location GIT_REPOSITORY "${GITHUB_PREFIX}FFmpeg/FFmpeg.git" GIT_TAG ${tag})
     endif()
 endif()
@@ -70,9 +70,9 @@ if (UNIX)
 
         ${location}
         CONFIGURE_COMMAND ${EP_PATH_SOURCE}/${ep}/configure
-		        --disable-yasm --disable-static 
-		        --disable-network --disable-zlib --disable-doc --disable-ffplay --disable-decoders
-		        --enable-shared --prefix=${EP_PATH_BUILD}/${ep}
+            --prefix=${EP_PATH_BUILD}/${ep}
+            --disable-static --enable-shared
+            --disable-yasm
         BUILD_COMMAND make install
         )
 


### PR DESCRIPTION
After some full continuous integration compilations, switch ffmpeg to the n3.4.8 version (which, by the way, is the one used in apt versions in Ubuntu20).

:m: