### PR TITLE
[CMake] avoid complete recompilation and patchs problems (on mac for instance)

### DIFF
--- a/superbuild/external_projects_tools/EP_GeneratePatchCommand.cmake
+++ b/superbuild/external_projects_tools/EP_GeneratePatchCommand.cmake
@@ -15,7 +15,7 @@ function(ep_GeneratePatchCommand ep OutVar)
         endif()
     endforeach()
 
-    set(PATCH_COMMAND)
+    set(PATCH_COMMAND "")
     if (NOT "${PATCHES_TO_APPLY}" STREQUAL "")
         set(PATCH_COMMAND ${GIT_BIN} apply --ignore-whitespace ${PATCHES_TO_APPLY})
     endif()

--- a/superbuild/projects_modules/DCMTK.cmake
+++ b/superbuild/projects_modules/DCMTK.cmake
@@ -36,12 +36,12 @@ EP_Initialisation(${ep}
 if (NOT USE_SYSTEM_${ep})
 
 ## #############################################################################
-## Set up versioning control.
+## Set up versioning control
 ## #############################################################################
 
-set(tag "DCMTK-3.6.2")
 if (NOT DEFINED ${ep}_SOURCE_DIR)
-  set(location GIT_REPOSITORY "git://git.dcmtk.org/dcmtk.git" GIT_TAG ${tag})
+    set(git_url git://git.dcmtk.org/dcmtk.git)
+    set(git_tag DCMTK-3.6.2)
 endif()
 
 ## #############################################################################
@@ -106,11 +106,15 @@ ExternalProject_Add(${ep}
   BINARY_DIR ${build_path}
   TMP_DIR ${tmp_path}
   STAMP_DIR ${stamp_path}
-  ${location}
+
+  GIT_REPOSITORY ${git_url}
+  GIT_TAG ${git_tag}
   PATCH_COMMAND ${${ep}_PATCH_COMMAND}
   CMAKE_GENERATOR ${gen}
   CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
   CMAKE_ARGS ${cmake_args}
+  DEPENDS ${${ep}_dependencies}
+  INSTALL_COMMAND ""
   BUILD_ALWAYS 0
   )
 

--- a/superbuild/projects_modules/DCMTK.cmake
+++ b/superbuild/projects_modules/DCMTK.cmake
@@ -39,8 +39,10 @@ if (NOT USE_SYSTEM_${ep})
 ## Set up versioning control.
 ## #############################################################################
 
-set(git_url git://git.dcmtk.org/dcmtk.git)
-set(git_tag DCMTK-3.6.2)
+set(tag "DCMTK-3.6.2")
+if (NOT DEFINED ${ep}_SOURCE_DIR)
+  set(location GIT_REPOSITORY "git://git.dcmtk.org/dcmtk.git" GIT_TAG ${tag})
+endif()
 
 ## #############################################################################
 ## Check if patch has to be applied
@@ -104,16 +106,14 @@ ExternalProject_Add(${ep}
   BINARY_DIR ${build_path}
   TMP_DIR ${tmp_path}
   STAMP_DIR ${stamp_path}
-  
-  GIT_REPOSITORY ${git_url}
-  GIT_TAG ${git_tag}
+  ${location}
   PATCH_COMMAND ${${ep}_PATCH_COMMAND}
   CMAKE_GENERATOR ${gen}
   CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
   CMAKE_ARGS ${cmake_args}
-  DEPENDS ${${ep}_dependencies}
-  INSTALL_COMMAND ""
-  BUILD_ALWAYS 0
+  #DEPENDS ${${ep}_dependencies}
+  #INSTALL_COMMAND ""
+  #BUILD_ALWAYS 0
   )
 
 ## #############################################################################

--- a/superbuild/projects_modules/DCMTK.cmake
+++ b/superbuild/projects_modules/DCMTK.cmake
@@ -113,7 +113,7 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 1
+  BUILD_ALWAYS 0
   )
 
 ## #############################################################################

--- a/superbuild/projects_modules/DCMTK.cmake
+++ b/superbuild/projects_modules/DCMTK.cmake
@@ -111,9 +111,7 @@ ExternalProject_Add(${ep}
   CMAKE_GENERATOR ${gen}
   CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
   CMAKE_ARGS ${cmake_args}
-  #DEPENDS ${${ep}_dependencies}
-  #INSTALL_COMMAND ""
-  #BUILD_ALWAYS 0
+  BUILD_ALWAYS 0
   )
 
 ## #############################################################################
@@ -122,7 +120,6 @@ ExternalProject_Add(${ep}
 
 ExternalProject_Get_Property(${ep} binary_dir)
 set(${ep}_DIR ${binary_dir} PARENT_SCOPE)
-
 
 endif() #NOT USE_SYSTEM_ep
 

--- a/superbuild/projects_modules/DCMTK.cmake
+++ b/superbuild/projects_modules/DCMTK.cmake
@@ -115,7 +115,7 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 0
+  BUILD_ALWAYS 1
   )
 
 ## #############################################################################

--- a/superbuild/projects_modules/ITK.cmake
+++ b/superbuild/projects_modules/ITK.cmake
@@ -35,11 +35,13 @@ EP_Initialisation(${ep}
 if (NOT USE_SYSTEM_${ep})
 
 ## #############################################################################
-## Set up versioning control.
+## Set up versioning control
 ## #############################################################################
 
-set(git_url ${GITHUB_PREFIX}InsightSoftwareConsortium/ITK.git)
-set(git_tag v5.0.0)
+if (NOT DEFINED ${ep}_SOURCE_DIR)
+    set(git_url ${GITHUB_PREFIX}InsightSoftwareConsortium/ITK.git)
+    set(git_tag v5.0.0)
+endif()
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project
@@ -99,15 +101,12 @@ ExternalProject_Add(${ep}
   BUILD_ALWAYS 0
   )
 
-
 ## #############################################################################
 ## Set variable to provide infos about the project
 ## #############################################################################
 
 ExternalProject_Get_Property(ITK binary_dir)
 set(${ep}_DIR ${binary_dir} PARENT_SCOPE)
-
-
 
 endif() #NOT USE_SYSTEM_ep
 

--- a/superbuild/projects_modules/ITK.cmake
+++ b/superbuild/projects_modules/ITK.cmake
@@ -96,7 +96,7 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 1
+  BUILD_ALWAYS 0
   )
 
 

--- a/superbuild/projects_modules/ITK.cmake
+++ b/superbuild/projects_modules/ITK.cmake
@@ -98,7 +98,7 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 0
+  BUILD_ALWAYS 1
   )
 
 ## #############################################################################

--- a/superbuild/projects_modules/LogDemons.cmake
+++ b/superbuild/projects_modules/LogDemons.cmake
@@ -92,9 +92,8 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 1   
+  BUILD_ALWAYS 0
   )
-  
   
 ## #############################################################################
 ## Set variable to provide infos about the project

--- a/superbuild/projects_modules/LogDemons.cmake
+++ b/superbuild/projects_modules/LogDemons.cmake
@@ -36,12 +36,13 @@ EP_Initialisation(${ep}
 
 if (NOT USE_SYSTEM_${ep})
 ## #############################################################################
-## Set up versioning control.
+## Set up versioning control
 ## #############################################################################
 
-set(git_url ${GITHUB_PREFIX}Inria-Asclepios/LCC-LogDemons.git)
-set(git_tag master)
-
+if (NOT DEFINED ${ep}_SOURCE_DIR)
+    set(git_url ${GITHUB_PREFIX}Inria-Asclepios/LCC-LogDemons.git)
+    set(git_tag master)
+endif()
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project

--- a/superbuild/projects_modules/LogDemons.cmake
+++ b/superbuild/projects_modules/LogDemons.cmake
@@ -39,10 +39,8 @@ if (NOT USE_SYSTEM_${ep})
 ## Set up versioning control
 ## #############################################################################
 
-if (NOT DEFINED ${ep}_SOURCE_DIR)
-    set(git_url ${GITHUB_PREFIX}Inria-Asclepios/LCC-LogDemons.git)
-    set(git_tag master)
-endif()
+  set(git_url ${GITHUB_PREFIX}Inria-Asclepios/LCC-LogDemons.git)
+  set(git_tag master)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project
@@ -93,7 +91,7 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 0
+  BUILD_ALWAYS 1
   )
   
 ## #############################################################################

--- a/superbuild/projects_modules/QtDCM.cmake
+++ b/superbuild/projects_modules/QtDCM.cmake
@@ -37,11 +37,13 @@ EP_Initialisation(${ep}
 if (NOT USE_SYSTEM_${ep})
 
 ## #############################################################################
-## Set up versioning control.
+## Set up versioning control
 ## #############################################################################
 
-set(git_url ${GITHUB_PREFIX}medInria/qtdcm.git)
-set(git_tag APHP) 
+if (NOT DEFINED ${ep}_SOURCE_DIR)
+    set(git_url ${GITHUB_PREFIX}medInria/qtdcm.git)
+    set(git_tag APHP)
+endif()
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project

--- a/superbuild/projects_modules/QtDCM.cmake
+++ b/superbuild/projects_modules/QtDCM.cmake
@@ -40,10 +40,8 @@ if (NOT USE_SYSTEM_${ep})
 ## Set up versioning control
 ## #############################################################################
 
-if (NOT DEFINED ${ep}_SOURCE_DIR)
-    set(git_url ${GITHUB_PREFIX}medInria/qtdcm.git)
-    set(git_tag APHP)
-endif()
+set(git_url ${GITHUB_PREFIX}medInria/qtdcm.git)
+set(git_tag APHP)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project
@@ -101,7 +99,7 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 0
+  BUILD_ALWAYS 1
   )  
 
 ## #############################################################################

--- a/superbuild/projects_modules/QtDCM.cmake
+++ b/superbuild/projects_modules/QtDCM.cmake
@@ -99,7 +99,7 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 1
+  BUILD_ALWAYS 0
   )  
 
 ## #############################################################################

--- a/superbuild/projects_modules/RPI.cmake
+++ b/superbuild/projects_modules/RPI.cmake
@@ -92,7 +92,7 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 0
+  BUILD_ALWAYS 1
   )  
   
 ## #############################################################################

--- a/superbuild/projects_modules/RPI.cmake
+++ b/superbuild/projects_modules/RPI.cmake
@@ -37,11 +37,13 @@ EP_Initialisation(${ep}
 if (NOT USE_SYSTEM_${ep})
 
 ## #############################################################################
-## Set up versioning control.
+## Set up versioning control
 ## #############################################################################
 
-set(git_url ${GITHUB_PREFIX}Inria-Asclepios/RPI.git)
-set(git_tag ITK5.0)
+if (NOT DEFINED ${ep}_SOURCE_DIR)
+    set(git_url ${GITHUB_PREFIX}Inria-Asclepios/RPI.git)
+    set(git_tag ITK5.0)
+endif()
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project

--- a/superbuild/projects_modules/RPI.cmake
+++ b/superbuild/projects_modules/RPI.cmake
@@ -90,9 +90,8 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 1
-  ) 
-  
+  BUILD_ALWAYS 0
+  )  
   
 ## #############################################################################
 ## Set variable to provide infos about the project

--- a/superbuild/projects_modules/TTK.cmake
+++ b/superbuild/projects_modules/TTK.cmake
@@ -91,9 +91,8 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 1   
-  )
-  
+  BUILD_ALWAYS 0
+  )  
   
 ## #############################################################################
 ## Set variable to provide infos about the project
@@ -101,7 +100,6 @@ ExternalProject_Add(${ep}
 
 ExternalProject_Get_Property(${ep} binary_dir)
 set(${ep}_DIR ${binary_dir} PARENT_SCOPE)
-
   
 endif() #NOT USE_SYSTEM_ep
 

--- a/superbuild/projects_modules/TTK.cmake
+++ b/superbuild/projects_modules/TTK.cmake
@@ -35,13 +35,15 @@ EP_Initialisation(${ep}
   )
 
 if (NOT USE_SYSTEM_${ep})
+
 ## #############################################################################
-## Set up versioning control.
+## Set up versioning control
 ## #############################################################################
 
-set(git_url ${GITHUB_PREFIX}Inria-Asclepios/TTK-Public.git)
-set(git_tag master)
-
+if (NOT DEFINED ${ep}_SOURCE_DIR)
+    set(git_url ${GITHUB_PREFIX}Inria-Asclepios/TTK-Public.git)
+    set(git_tag master)
+endif()
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project

--- a/superbuild/projects_modules/TTK.cmake
+++ b/superbuild/projects_modules/TTK.cmake
@@ -40,10 +40,8 @@ if (NOT USE_SYSTEM_${ep})
 ## Set up versioning control
 ## #############################################################################
 
-if (NOT DEFINED ${ep}_SOURCE_DIR)
-    set(git_url ${GITHUB_PREFIX}Inria-Asclepios/TTK-Public.git)
-    set(git_tag master)
-endif()
+set(git_url ${GITHUB_PREFIX}Inria-Asclepios/TTK-Public.git)
+set(git_tag master)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project
@@ -93,7 +91,7 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 0
+  BUILD_ALWAYS 1
   )  
   
 ## #############################################################################

--- a/superbuild/projects_modules/VTK.cmake
+++ b/superbuild/projects_modules/VTK.cmake
@@ -35,11 +35,13 @@ EP_Initialisation(${ep}
 if (NOT USE_SYSTEM_${ep})
 
 ## #############################################################################
-## Set up versioning control.
+## Set up versioning control
 ## #############################################################################
 
-set(git_url ${GITHUB_PREFIX}Kitware/VTK.git)
-set(git_tag v8.1.2)
+if (NOT DEFINED ${ep}_SOURCE_DIR)
+    set(git_url ${GITHUB_PREFIX}Kitware/VTK.git)
+    set(git_tag v8.1.2)
+endif()
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project

--- a/superbuild/projects_modules/VTK.cmake
+++ b/superbuild/projects_modules/VTK.cmake
@@ -139,7 +139,7 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 0
+  BUILD_ALWAYS 1
   )
   
 ## #############################################################################

--- a/superbuild/projects_modules/VTK.cmake
+++ b/superbuild/projects_modules/VTK.cmake
@@ -137,7 +137,7 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 1
+  BUILD_ALWAYS 0
   )
   
 ## #############################################################################

--- a/superbuild/projects_modules/dtk.cmake
+++ b/superbuild/projects_modules/dtk.cmake
@@ -102,7 +102,7 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 0
+  BUILD_ALWAYS 1
   )
 
 ## #############################################################################

--- a/superbuild/projects_modules/dtk.cmake
+++ b/superbuild/projects_modules/dtk.cmake
@@ -102,7 +102,7 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 1
+  BUILD_ALWAYS 0
   )
 
 

--- a/superbuild/projects_modules/dtk.cmake
+++ b/superbuild/projects_modules/dtk.cmake
@@ -37,12 +37,13 @@ EP_Initialisation(${ep}
 if (NOT USE_SYSTEM_${ep})
 
 ## #############################################################################
-## Set up versioning control.
+## Set up versioning control
 ## #############################################################################
 
-set(git_url ${GITLAB_INRIA_PREFIX}dtk/dtk.git)
-set(git_tag 1.7.1)
-
+if (NOT DEFINED ${ep}_SOURCE_DIR)
+    set(git_url ${GITLAB_INRIA_PREFIX}dtk/dtk.git)
+    set(git_tag 1.7.1)
+endif()
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project
@@ -81,7 +82,6 @@ set(cmake_args
   -DQt5_DIR=${Qt5_DIR}
   )
 
-
 ## #############################################################################
 ## Add external-project
 ## #############################################################################
@@ -104,7 +104,6 @@ ExternalProject_Add(${ep}
   INSTALL_COMMAND ""
   BUILD_ALWAYS 0
   )
-
 
 ## #############################################################################
 ## Set variable to provide infos about the project

--- a/superbuild/projects_modules/dtkImaging.cmake
+++ b/superbuild/projects_modules/dtkImaging.cmake
@@ -37,12 +37,13 @@ EP_Initialisation(${ep}
 if (NOT USE_SYSTEM_${ep})
 
 ## #############################################################################
-## Set up versioning control.
+## Set up versioning control
 ## #############################################################################
 
-set(git_url ${GITLAB_INRIA_PREFIX}dtk/dtk-imaging.git)
-set(git_tag master)
-
+if (NOT DEFINED ${ep}_SOURCE_DIR)
+    set(git_url ${GITLAB_INRIA_PREFIX}dtk/dtk-imaging.git)
+    set(git_tag master)
+endif()
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project
@@ -93,7 +94,6 @@ ExternalProject_Add(${ep}
   INSTALL_COMMAND ""
   BUILD_ALWAYS 0
   )
-
 
 ## #############################################################################
 ## Set variable to provide infos about the project

--- a/superbuild/projects_modules/dtkImaging.cmake
+++ b/superbuild/projects_modules/dtkImaging.cmake
@@ -91,7 +91,7 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 1
+  BUILD_ALWAYS 0
   )
 
 

--- a/superbuild/projects_modules/dtkImaging.cmake
+++ b/superbuild/projects_modules/dtkImaging.cmake
@@ -40,10 +40,8 @@ if (NOT USE_SYSTEM_${ep})
 ## Set up versioning control
 ## #############################################################################
 
-if (NOT DEFINED ${ep}_SOURCE_DIR)
-    set(git_url ${GITLAB_INRIA_PREFIX}dtk/dtk-imaging.git)
-    set(git_tag master)
-endif()
+set(git_url ${GITLAB_INRIA_PREFIX}dtk/dtk-imaging.git)
+set(git_tag master)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project
@@ -92,7 +90,7 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 0
+  BUILD_ALWAYS 1
   )
 
 ## #############################################################################

--- a/superbuild/projects_modules/ffmpeg.cmake
+++ b/superbuild/projects_modules/ffmpeg.cmake
@@ -36,7 +36,7 @@ EP_Initialisation(${ep}
 if (NOT USE_SYSTEM_${ep})
 
 ## #############################################################################
-## Define repository where get the sources
+## Set up versioning control
 ## #############################################################################
 
 if (NOT DEFINED ${ep}_SOURCE_DIR)


### PR DESCRIPTION
The ALWAYS_BUILD cmake parameter is set to 0 on projects modules, except medInria. It avoids a complete recompilation each time you compile.

The patch_command and "if (NOT DEFINED ${ep}_SOURCE_DIR)" avoids some patch problems seen on some computers.

:m: