### PR TITLE
improve cmake file on legacy code

### DIFF
--- a/src/layers/legacy/medImageIO/CMakeLists.txt
+++ b/src/layers/legacy/medImageIO/CMakeLists.txt
@@ -12,18 +12,27 @@
 # PURPOSE.
 #
 ################################################################################
-
 set(TARGET_NAME medImageIO)
-
 
 ## #############################################################################
 ## find requireds
 ## #############################################################################
+set(ITK_IMAGES_DEPENDENCIES
+    ITKIOImageBase
+    ITKIOMeta
+    #common formats for common images
+    ITKIOBMP ITKIOJPEG ITKIOJPEG2000 ITKIOPNG ITKIOTIFF
+    #Medical images formats
+    ITKIOGIPL ITKIONRRD ITKIONIFTI ITKIOGIPL ITKIOPhilipsREC ITKIOGDCM ITKIOBioRad ITKIOBruker
+    ITKNrrdIO ITKIOMINC ITKIOHDF5 ITKIOMRC ITKIOLSM
+)
 
-find_package(ITK REQUIRED COMPONENTS ITKVtkGlue ITKIOImageBase ITKIOMeta ITKZLIB)
+find_package(ITK REQUIRED COMPONENTS ${ITK_IMAGES_DEPENDENCIES} ITKIOVTK ITKIOGIPL ITKIOGE
+    ITKIOStimulate ITKVTK ITKVtkGlue ) 
 include(${ITK_USE_FILE})
 
 #WARNING USE VTK through ITKVtkGlue and medLog
+find_package(VTK REQUIRED COMPONENTS vtkIOImage)
 
 find_package(DCMTK REQUIRED NO_MODULE)
 
@@ -70,31 +79,8 @@ target_link_libraries(${TARGET_NAME}
   dtkLog
   medCore
   medCoreLegacy
-  ITKCommon
-  ITKIOImageBase
-  ITKIOBMP
-  ITKIOBruker
-  ITKIOLSM
-  ITKIOJPEG
-  ITKIOJPEG2000
-  ITKIOPNG
-  ITKIOVTK
-  ITKIOGDCM
-  ITKNrrdIO
-  ITKIONRRD
-  ITKIOMeta
-  ITKIOMINC
-  ITKIONIFTI
-  ITKIOGIPL
-  ITKIOGE
-  ITKIOHDF5
-  ITKIOBioRad
-  ITKIOStimulate
-  ITKIOMRC
-  ITKIOTIFF
-  ITKVTK
-  vtkIOImage
-  ${ITKIOPhilipsREC_LIBRARIES}
+  ${ITK_LIBRARIES} 
+  ${VTK_LIBRARIES}  
   ${DCMTK_LIBRARIES}
   )
 

--- a/src/layers/legacy/medLog/CMakeLists.txt
+++ b/src/layers/legacy/medLog/CMakeLists.txt
@@ -21,7 +21,6 @@ set(TARGET_NAME medLog)
 
 # find dtk
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 # find itk
 find_package(ITK REQUIRED COMPONENTS ITKCommon)
@@ -72,8 +71,8 @@ target_link_libraries(${TARGET_NAME}
   Qt5::Widgets
   dtkCoreSupport
   dtkLog
-  ITKCommon
-  vtkCommonCore
+  ${ITK_LIBRARIES}
+  ${VTK_LIBRARIES}
   )
 
 ## #############################################################################

--- a/src/layers/legacy/medPacs/CMakeLists.txt
+++ b/src/layers/legacy/medPacs/CMakeLists.txt
@@ -32,8 +32,8 @@ list_header_directories_to_include(${TARGET_NAME}
 ## #############################################################################
 
 if (NOT MSVC) #TODO : what is it for ?
-  add_definitions(-Wno-write-strings)
-  add_definitions(-Wformat=0)
+  add_compile_options(-Wno-write-strings)
+  add_compile_options(-Wformat=0)
 endif()
 
 
@@ -44,7 +44,6 @@ endif()
 add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_CFILES}
   )
-
 
 ## #############################################################################
 ## Link
@@ -65,7 +64,6 @@ target_link_libraries(${TARGET_NAME}
 target_include_directories(${TARGET_NAME}
   PUBLIC ${${TARGET_NAME}_INCLUDE_DIRS}
   )
-
 
 ## #############################################################################
 ## install

--- a/src/layers/legacy/medRegistration/CMakeLists.txt
+++ b/src/layers/legacy/medRegistration/CMakeLists.txt
@@ -21,13 +21,14 @@ set(TARGET_NAME medRegistration)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
-
-find_package(ITK REQUIRED COMPONENTS ITKIOImageBase ITKTransform ITKIOTransformBase ITKIOTransformInsightLegacy ITKRegistrationCommon ITKIOMeta)#ITKCommon ITKTransformFactory
-include(${ITK_USE_FILE})
 
 find_package(RPI REQUIRED)
 include(${RPI_USE_FILE})
+include(ITKLibs) # FOR and FROM RPI
+
+find_package(ITK REQUIRED COMPONENTS ${ITKIO_LIBRARIES} ${ITK_TRANSFORM_LIBRARIES} ITKRegistrationCommon)
+include(${ITK_USE_FILE})
+
 
 
 ## #############################################################################
@@ -71,36 +72,8 @@ target_link_libraries(${TARGET_NAME}
   dtkCoreSupport
   medCoreLegacy
   dtkLog
-  ITKCommon
-  ITKIOImageBase
-  ITKIOBMP
-  ITKIOBruker
-  ITKIOLSM
-  ITKIOJPEG
-  ITKIOJPEG2000
-  ITKIOGE
-  ITKIOPNG
-  ITKIOVTK
-  ITKIOGDCM
-  ITKNrrdIO
-  ITKIONRRD
-  ITKIOMeta
-  ITKIOMINC
-  ITKIONIFTI
-  ITKIOGIPL
-  ITKIOHDF5
-  ITKIOBioRad
-  ITKIOStimulate
-  ${ITKIOPhilipsREC_LIBRARIES}
-  ITKIOTIFF
-  ITKStatistics
-  ITKIOTransformBase
-  ITKIOTransformHDF5
-  ITKIOTransformMatlab
-  ITKIOTransformInsightLegacy
-  ITKIOMRC
+  ${ITK_LIBRARIES} 
   )
-
 
 ## #############################################################################
 ## install

--- a/src/layers/legacy/medUtilities/CMakeLists.txt
+++ b/src/layers/legacy/medUtilities/CMakeLists.txt
@@ -20,17 +20,12 @@ set(TARGET_NAME medUtilities)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(VTK REQUIRED COMPONENTS vtkInteractionWidgets )
 include(${VTK_USE_FILE})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon ITKIOGDCM)
 include(${ITK_USE_FILE})
-
-if (ITK_USE_SYSTEM_GDCM)
-  add_definitions(-DITK_USE_SYSTEM_GDCM)
-endif()
 
 ## #############################################################################
 ## List sources
@@ -50,6 +45,14 @@ list_header_directories_to_include(${TARGET_NAME}
 
 add_library(${TARGET_NAME} SHARED
 ${${TARGET_NAME}_CFILES})
+
+## #############################################################################
+## Add definition
+## #############################################################################
+
+if (ITK_USE_SYSTEM_GDCM)
+  target_compile_definitions(${TARGET_NAME} PUBLIC -DITK_USE_SYSTEM_GDCM)
+endif()
 
 ## #############################################################################
 ## include directories
@@ -72,7 +75,6 @@ target_link_libraries(${TARGET_NAME}
   medVtkInria
   medVtkDataMeshBase
   )
-
 
 ## #############################################################################
 ## install

--- a/src/layers/legacy/medVtkDataMeshBase/CMakeLists.txt
+++ b/src/layers/legacy/medVtkDataMeshBase/CMakeLists.txt
@@ -20,8 +20,6 @@ set(TARGET_NAME medVtkDataMeshBase)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
-
 
 find_package(VTK REQUIRED COMPONENTS vtkCommonCore vtkCommonDataModel vtkRenderingCore vtkRenderingVolumeOpenGL2 vtkInteractionStyle vtkInteractionWidgets vtkIOParallelXML vtkIOImage vtkIOGeometry  vtkIOExport vtkRenderingContext2D vtkIOInfovis)
 include(${VTK_USE_FILE})

--- a/src/layers/legacy/medVtkInria/CMakeLists.txt
+++ b/src/layers/legacy/medVtkInria/CMakeLists.txt
@@ -24,13 +24,6 @@ include(${VTK_USE_FILE})
 
 find_package(OpenGL REQUIRED)
 
-if (USE_OSPRay)
-  add_definitions(-DMED_USE_OSPRAY_4_VR_BY_CPU)
-  set(VTK_OSPRAY_RENDERING_LIBRARY "vtkRenderingOSPRay")
-ELSE()
-  set(VTK_OSPRAY_RENDERING_LIBRARY "")
-endif()
-
 ## #############################################################################
 ## List sources
 ## #############################################################################
@@ -48,7 +41,6 @@ list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
   )
 
-
 ## #############################################################################
 ## add library
 ## #############################################################################
@@ -56,6 +48,14 @@ list_header_directories_to_include(${TARGET_NAME}
 add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_CFILES}
   )
+
+## #############################################################################
+## Add definition and options
+## #############################################################################
+
+target_compile_definitions(${TARGET_NAME} PUBLIC
+    $<$<BOOL:${USE_OSPRay}>:MED_USE_OSPRAY_4_VR_BY_CPU>
+    )
 
 ## #############################################################################
 ## include directorie.

--- a/src/plugins/legacy/LCCLogDemons/CMakeLists.txt
+++ b/src/plugins/legacy/LCCLogDemons/CMakeLists.txt
@@ -27,7 +27,6 @@ endif()
 #find_package(Qt5 COMPONENTS REQUIRED Core)
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon ITKTransform ITKRegistrationCommon ITKImageGrid ITKImageFilterBase  ITKIOImageBase ITKTransformFactory ITKIOTransformBase ITKIOMeta ITKIOTransformInsightLegacy ITKPDEDeformableRegistration ITKReview)
 include(${ITK_USE_FILE})

--- a/src/plugins/legacy/diffeomorphicDemons/CMakeLists.txt
+++ b/src/plugins/legacy/diffeomorphicDemons/CMakeLists.txt
@@ -29,12 +29,12 @@ add_definitions(-D${TARGET_NAME_UP}_VERSION="${${TARGET_NAME}_VERSION}")
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(RPI REQUIRED)
 include(${RPI_USE_FILE})
 
-find_package(ITK REQUIRED COMPONENTS ITKCommon ITKIOTransformBase ITKIOTransformInsightLegacy ITKTransform ITKTransformFactory ITKRegistrationCommon ITKIOMeta ITKIOImageBase ITKPDEDeformableRegistration ITKIOTransformBase)
+include(ITKLibs) # FOR and FROM RPI
+find_package(ITK REQUIRED COMPONENTS ${ITKIO_LIBRARIES} ${ITK_TRANSFORM_LIBRARIES} ITKRegistrationCommon ITKPDEDeformableRegistration )
 include(${ITK_USE_FILE})
 
 ## #############################################################################
@@ -51,10 +51,6 @@ list_source_files(${TARGET_NAME}
 
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
   )
 
 ## #############################################################################
@@ -76,6 +72,14 @@ endif()
 add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_PCH}
   ${${TARGET_NAME}_CFILES}
+  )
+
+## #############################################################################
+## include directories.
+## #############################################################################
+
+target_include_directories(${TARGET_NAME} 
+  PUBLIC ${${TARGET_NAME}_INCLUDE_DIRS}
   )
 
 ## #############################################################################

--- a/src/plugins/legacy/iterativeClosestPoint/CMakeLists.txt
+++ b/src/plugins/legacy/iterativeClosestPoint/CMakeLists.txt
@@ -31,7 +31,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon)
 include(${ITK_USE_FILE})
@@ -55,10 +54,6 @@ list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
   )
 
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
-  )
-
 ## #############################################################################
 ## add library
 ## #############################################################################
@@ -66,6 +61,14 @@ include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
 add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_CFILES}
   ${${TARGET_NAME}_QRC}
+  )
+
+## #############################################################################
+## include directories
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+  PUBLIC ${${TARGET_NAME}_INCLUDE_DIRS}
   )
 
 ## #############################################################################

--- a/src/plugins/legacy/itkDataDiffusionGradientList/CMakeLists.txt
+++ b/src/plugins/legacy/itkDataDiffusionGradientList/CMakeLists.txt
@@ -24,20 +24,17 @@ set(${TARGET_NAME}_VERSION ${MEDINRIA_VERSION})
 string(TOUPPER ${TARGET_NAME} TARGET_NAME_UP)
 add_definitions(-D${TARGET_NAME_UP}_VERSION="${${TARGET_NAME}_VERSION}")
 
-
 ## #############################################################################
 ## Resolve dependencies
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon)
 include(${ITK_USE_FILE})
 
 find_package(TTK REQUIRED)
 include(${TTK_USE_FILE})
-
 
 ## #############################################################################
 ## List Sources
@@ -54,10 +51,6 @@ list_source_files(${TARGET_NAME}
 
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
   )
 
 ## #############################################################################
@@ -84,6 +77,12 @@ add_library(${TARGET_NAME} SHARED
 
 
 ## #############################################################################
+## Include dir
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+    PUBLIC ${${TARGET_NAME}_INCLUDE_DIRS})
+## #############################################################################
 ## Link
 ## #############################################################################
 
@@ -95,7 +94,6 @@ target_link_libraries(${TARGET_NAME}
   medCore
   medLog
   )
-
 
 ## #############################################################################
 ## Install rules

--- a/src/plugins/legacy/itkDataImage/CMakeLists.txt
+++ b/src/plugins/legacy/itkDataImage/CMakeLists.txt
@@ -29,7 +29,6 @@ add_definitions(-D${TARGET_NAME_UP}_VERSION="${${TARGET_NAME}_VERSION}")
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 set(ITK_IMAGES_DEPENDENCIES
     ITKIOMeta
@@ -58,16 +57,7 @@ include(${ITK_USE_FILE})
 
 #WARNING USE VTK through ITKIOVTK and medLog, medVtkInria
 
-if (ITK_USE_SYSTEM_GDCM)
-  add_definitions(-DITK_USE_SYSTEM_GDCM)
-endif()
-
-if (USE_OSPRay)
-  add_definitions(-DMED_USE_OSPRAY_4_VR_BY_CPU)
-endif()
-
 find_package(DCMTK REQUIRED NO_MODULE)
-
 
 ## #############################################################################
 ## List Sources
@@ -108,17 +98,26 @@ if (MSVC)
          )
     endif()
 
-  #Prevent compiler warnings about valid std::copy.
-  if(MSVC)
-      add_definitions(-D_SCL_SECURE_NO_WARNINGS)
-  endif()
-
 endif()
 
 add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_CFILES}
   )
 
+## #############################################################################
+## definition 
+## #############################################################################
+
+target_compile_definitions(${TARGET_NAME} PUBLIC
+    $<$<BOOL:${ITK_USE_SYSTEM_GDCM}>:ITK_USE_SYSTEM_GDCM>
+    )
+target_compile_definitions(${TARGET_NAME} PUBLIC
+    $<$<BOOL:${USE_OSPRay}>:MED_USE_OSPRAY_4_VR_BY_CPU>
+    )
+
+target_compile_definitions(${TARGET_NAME} PUBLIC
+    $<$<BOOL:${MSVC}>:_SCL_SECURE_NO_WARNINGS>
+    )
 
 ## #############################################################################
 ## include directorie.
@@ -149,7 +148,6 @@ target_link_libraries(${TARGET_NAME}
 ## #############################################################################
 
 set_plugin_install_rules_legacy(${TARGET_NAME})
-
 
 ## #############################################################################
 ## Build tests

--- a/src/plugins/legacy/itkDataSHImage/CMakeLists.txt
+++ b/src/plugins/legacy/itkDataSHImage/CMakeLists.txt
@@ -24,13 +24,11 @@ set(${TARGET_NAME}_VERSION ${MEDINRIA_VERSION})
 string(TOUPPER ${TARGET_NAME} TARGET_NAME_UP)
 add_definitions(-D${TARGET_NAME_UP}_VERSION="${${TARGET_NAME}_VERSION}")
 
-
 ## #############################################################################
 ## Resolve dependencies
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKIOImageBase ITKIOMeta )
 include(${ITK_USE_FILE})
@@ -54,7 +52,6 @@ list_source_files(${TARGET_NAME}
   readers
   writers
   )
-
 
 ## #############################################################################
 ## include directorie.
@@ -87,12 +84,11 @@ endif()
 ## add library
 ## #############################################################################
 
-add_library(${TARGET_NAME} SHARED
+add_library(${TARGET_NAME} MODULE
   ${${TARGET_NAME}_PCH}
   ${${TARGET_NAME}_CFILES}
   ${${TARGET_NAME}_QRC}
   )
-
 
 ## #############################################################################
 ## Link
@@ -108,7 +104,6 @@ target_link_libraries(${TARGET_NAME}
   medVtkInria
   medImageIO
   )
-
 
 ## #############################################################################
 ## Install rules

--- a/src/plugins/legacy/itkDataTensorImage/CMakeLists.txt
+++ b/src/plugins/legacy/itkDataTensorImage/CMakeLists.txt
@@ -24,13 +24,11 @@ set(${TARGET_NAME}_VERSION ${MEDINRIA_VERSION})
 string(TOUPPER ${TARGET_NAME} TARGET_NAME_UP)
 add_definitions(-D${TARGET_NAME_UP}_VERSION="${${TARGET_NAME}_VERSION}")
 
-
 ## #############################################################################
 ## Resolve dependencies
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED  COMPONENTS ITKIOImageBase ITKIOMeta ITKIONRRD ITKIONIFTI)
 include(${ITK_USE_FILE})
@@ -40,7 +38,6 @@ include(${VTK_USE_FILE})
 
 find_package(TTK REQUIRED)
 include(${TTK_USE_FILE})
-
 
 ## #############################################################################
 ## List Sources
@@ -64,11 +61,6 @@ list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
   )
 
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
-  )
-
-
 ## #############################################################################
 ## Precompile headers
 ## #############################################################################
@@ -86,12 +78,18 @@ endif()
 ## add library
 ## #############################################################################
 
-add_library(${TARGET_NAME} SHARED
+add_library(${TARGET_NAME} MODULE
   ${${TARGET_NAME}_PCH}
   ${${TARGET_NAME}_CFILES}
   ${${TARGET_NAME}_QRC}
   )
 
+## #############################################################################
+## Include dir
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+    PUBLIC ${${TARGET_NAME}_INCLUDE_DIRS})
 
 ## #############################################################################
 ## Link
@@ -124,13 +122,11 @@ target_link_libraries(${TARGET_NAME}
   medVtkInria
   )
 
-
 ## #############################################################################
 ## Install rules
 ## #############################################################################
 
 set_plugin_install_rules_legacy(${TARGET_NAME})
-
 
 ## #############################################################################
 ## Build tests

--- a/src/plugins/legacy/itkFilters/CMakeLists.txt
+++ b/src/plugins/legacy/itkFilters/CMakeLists.txt
@@ -31,7 +31,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon ITKThresholding ITKConnectedComponents
                                      ITKSmoothing ITKBinaryMathematicalMorphology)
@@ -53,15 +52,11 @@ list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
   )
 
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
-  )
-
 ## #############################################################################
 ## add library
 ## #############################################################################
 
-add_library(${TARGET_NAME} SHARED
+add_library(${TARGET_NAME} MODULE
   ${${TARGET_NAME}_CFILES}
   ${${TARGET_NAME}_QRC}
   )

--- a/src/plugins/legacy/medAlgorithmPaint/CMakeLists.txt
+++ b/src/plugins/legacy/medAlgorithmPaint/CMakeLists.txt
@@ -31,7 +31,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon ITKRegionGrowing ITKDistanceMap ITKColormap)
 include(${ITK_USE_FILE})
@@ -50,10 +49,6 @@ list_source_files(${TARGET_NAME}
 
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
   )
 
 ## #############################################################################

--- a/src/plugins/legacy/medBinaryOperation/CMakeLists.txt
+++ b/src/plugins/legacy/medBinaryOperation/CMakeLists.txt
@@ -31,7 +31,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon ITKLabelMap)
 include(${ITK_USE_FILE})
@@ -50,10 +49,6 @@ list_source_files(${TARGET_NAME}
 
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
   )
 
 ## #############################################################################

--- a/src/plugins/legacy/medComposerArea/CMakeLists.txt
+++ b/src/plugins/legacy/medComposerArea/CMakeLists.txt
@@ -30,7 +30,6 @@ add_definitions(-D${PROJECT_NAME_UP}_VERSION="${${PROJECT_NAME}_VERSION}")
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 ## #############################################################################
 ## List Sources

--- a/src/plugins/legacy/medCreateMeshFromMask/CMakeLists.txt
+++ b/src/plugins/legacy/medCreateMeshFromMask/CMakeLists.txt
@@ -31,7 +31,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon ITKVtkGlue)
 include(${ITK_USE_FILE})
@@ -53,10 +52,6 @@ list_source_files(${TARGET_NAME}
 
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
   )
 
 ## #############################################################################

--- a/src/plugins/legacy/medExportVideo/CMakeLists.txt
+++ b/src/plugins/legacy/medExportVideo/CMakeLists.txt
@@ -36,7 +36,6 @@ if(${USE_FFmpeg})
 endif()
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon)
 include(${ITK_USE_FILE})

--- a/src/plugins/legacy/medFilteringWorkspaceL/CMakeLists.txt
+++ b/src/plugins/legacy/medFilteringWorkspaceL/CMakeLists.txt
@@ -31,7 +31,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 ## #############################################################################
 ## List Sources
@@ -47,10 +46,6 @@ list_source_files(${TARGET_NAME}
 
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
   )
 
 ## #############################################################################

--- a/src/plugins/legacy/medMaskApplication/CMakeLists.txt
+++ b/src/plugins/legacy/medMaskApplication/CMakeLists.txt
@@ -31,7 +31,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon ITKImageIntensity)
 include(${ITK_USE_FILE})
@@ -50,10 +49,6 @@ list_source_files(${TARGET_NAME}
 
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
   )
 
 ## #############################################################################

--- a/src/plugins/legacy/medMeshingWorkspace/CMakeLists.txt
+++ b/src/plugins/legacy/medMeshingWorkspace/CMakeLists.txt
@@ -31,7 +31,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 ## #############################################################################
 ## List Sources
@@ -47,10 +46,6 @@ list_source_files(${TARGET_NAME}
 
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
   )
 
 ## #############################################################################

--- a/src/plugins/legacy/medN4BiasCorrection/CMakeLists.txt
+++ b/src/plugins/legacy/medN4BiasCorrection/CMakeLists.txt
@@ -31,7 +31,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon ITKImageIntensity ITKBiasCorrection
                                      ITKImageSources ITKThresholding)
@@ -51,10 +50,6 @@ list_source_files(${TARGET_NAME}
 
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
   )
 
 ## #############################################################################

--- a/src/plugins/legacy/medRegistrationWorkspace/CMakeLists.txt
+++ b/src/plugins/legacy/medRegistrationWorkspace/CMakeLists.txt
@@ -31,7 +31,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 ## #############################################################################
 ## List Sources
@@ -47,10 +46,6 @@ list_source_files(${TARGET_NAME}
 
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
   )
 
 ## #############################################################################

--- a/src/plugins/legacy/medRemeshing/CMakeLists.txt
+++ b/src/plugins/legacy/medRemeshing/CMakeLists.txt
@@ -31,7 +31,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon)
 include(${ITK_USE_FILE})
@@ -55,10 +54,6 @@ list_source_files(${TARGET_NAME}
 
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
   )
 
 ## #############################################################################

--- a/src/plugins/legacy/medSegmentation/CMakeLists.txt
+++ b/src/plugins/legacy/medSegmentation/CMakeLists.txt
@@ -30,7 +30,6 @@ add_definitions(-D${TARGET_NAME_UP}_VERSION="${${TARGET_NAME}_VERSION}")
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon ITKLabelMap ITKVtkGlue ITKRegionGrowing)
 include(${ITK_USE_FILE})
@@ -55,11 +54,6 @@ list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
   )
 
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
-  )
-
-
 ## #############################################################################
 ## Precompile headers
 ## #############################################################################
@@ -72,11 +66,9 @@ if(MEDINRIA_USE_PRECOMPILED_HEADERS)
     )
 endif()
 
-
 ## #############################################################################
 ## add library
 ## #############################################################################
-
 
 add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_PCH}
@@ -84,6 +76,12 @@ add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_QRC}
   )
 
+## #############################################################################
+## Include dir
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+    PUBLIC ${${TARGET_NAME}_INCLUDE_DIRS})
 
 ## #############################################################################
 ## Link
@@ -98,7 +96,6 @@ target_link_libraries(${TARGET_NAME}
   medVtkInria
   medImageIO
   )
-
 
 ## #############################################################################
 ## Install rules

--- a/src/plugins/legacy/medSegmentationWorkspace/CMakeLists.txt
+++ b/src/plugins/legacy/medSegmentationWorkspace/CMakeLists.txt
@@ -31,7 +31,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 ## #############################################################################
 ## List Sources
@@ -47,10 +46,6 @@ list_source_files(${TARGET_NAME}
 
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
   )
 
 ## #############################################################################

--- a/src/plugins/legacy/medVtkFibersData/CMakeLists.txt
+++ b/src/plugins/legacy/medVtkFibersData/CMakeLists.txt
@@ -24,13 +24,11 @@ set(${TARGET_NAME}_VERSION ${MEDINRIA_VERSION})
 string(TOUPPER ${TARGET_NAME} TARGET_NAME_UP)
 add_definitions(-D${TARGET_NAME_UP}_VERSION="${${TARGET_NAME}_VERSION}")
 
-
 ## #############################################################################
 ## Resolve dependencies
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(VTK REQUIRED COMPONENTS  vtkImagingCore vtkIOLegacy vtkIOXML vtkRenderingCore vtkRenderingOpenGL2 vtkInteractionWidgets) 
 include(${VTK_USE_FILE})
@@ -57,7 +55,6 @@ list_source_files(${TARGET_NAME}
 
 set(${TARGET_NAME}_QRC medVtkFibersData.qrc)
 
-
 ## #############################################################################
 ## include directorie.
 ## #############################################################################
@@ -69,7 +66,6 @@ list_header_directories_to_include(${TARGET_NAME}
 include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
   ${MEDINRIA_INCLUDE_DIRS}
   )
-
 
 ## #############################################################################
 ## Precompile headers
@@ -88,12 +84,11 @@ endif()
 ## add library
 ## #############################################################################
 
-add_library(${TARGET_NAME} SHARED
+add_library(${TARGET_NAME} MODULE
   ${${TARGET_NAME}_PCH}
   ${${TARGET_NAME}_CFILES}
   ${${TARGET_NAME}_QRC}
   )
-
 
 ## #############################################################################
 ## Link
@@ -110,7 +105,6 @@ target_link_libraries(${TARGET_NAME}
   ITKCommon
   ITKVtkGlue
   )
-
 
 ## #############################################################################
 ## Install rules

--- a/src/plugins/legacy/medVtkView/CMakeLists.txt
+++ b/src/plugins/legacy/medVtkView/CMakeLists.txt
@@ -24,13 +24,11 @@ set(${TARGET_NAME}_VERSION ${${PROJECT_NAME}_VERSION})
 string(TOUPPER ${TARGET_NAME} TARGET_NAME_UP)
 add_definitions(-D${TARGET_NAME_UP}_VERSION="${${TARGET_NAME}_VERSION}")
 
-
 ## #############################################################################
 ## Resolve dependencies
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(VTK REQUIRED COMPONENTS vtkGUISupportQt vtkInteractionWidgets)
 include(${VTK_USE_FILE})
@@ -69,7 +67,6 @@ add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_QRC}
   )
 
-
 ## #############################################################################
 ## Link
 ## #############################################################################
@@ -88,13 +85,11 @@ target_link_libraries(${TARGET_NAME}
   medVtkDataMeshBase
   )
 
-
 ## #############################################################################
 ## Install rules
 ## #############################################################################
 
 set_plugin_install_rules_legacy(${TARGET_NAME})
-
 
 ## #############################################################################
 ## Build tests

--- a/src/plugins/legacy/meshManipulation/CMakeLists.txt
+++ b/src/plugins/legacy/meshManipulation/CMakeLists.txt
@@ -31,7 +31,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon)
 include(${ITK_USE_FILE})
@@ -54,10 +53,6 @@ list_source_files(${TARGET_NAME}
 
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
   )
 
 ## #############################################################################

--- a/src/plugins/legacy/meshMapping/CMakeLists.txt
+++ b/src/plugins/legacy/meshMapping/CMakeLists.txt
@@ -31,7 +31,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon ITKVtkGlue)
 include(${ITK_USE_FILE})
@@ -53,10 +52,6 @@ list_source_files(${TARGET_NAME}
 
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
   )
 
 ## #############################################################################

--- a/src/plugins/legacy/polygonRoi/CMakeLists.txt
+++ b/src/plugins/legacy/polygonRoi/CMakeLists.txt
@@ -34,7 +34,6 @@ find_package(dtk REQUIRED
     dtkCore
     dtkCoreSupport
     )
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon ITKImageLabel ITKVtkGlue ITKIOImageBase ITKIOMeta)
 include(${ITK_USE_FILE})
@@ -67,7 +66,6 @@ list_header_directories_to_include(${TARGET_NAME}
   )
 
 include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
   ${DATA_HEADERS}
   )
 

--- a/src/plugins/legacy/qtdcmDataSource/CMakeLists.txt
+++ b/src/plugins/legacy/qtdcmDataSource/CMakeLists.txt
@@ -24,7 +24,6 @@ set(${PROJECT_NAME}_VERSION ${MEDINRIA_VERSION})
 string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UP)
 add_definitions(-D${PROJECT_NAME_UP}_VERSION="${${PROJECT_NAME}_VERSION}")
 
-
 ## #############################################################################
 ## Resolve dependencies
 ## #############################################################################
@@ -53,11 +52,9 @@ list_header_directories_to_include(${PROJECT_NAME}
   )
 
 include_directories(${${PROJECT_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
   ${QTDCM_INCLUDE_DIRS}
   ${QTDCM_DIR}
   )
-
 
 ## #############################################################################
 ## Precompile headers
@@ -103,7 +100,6 @@ target_link_libraries(${PROJECT_NAME}
   dtkLog
   medCore
   )
-
 
 ## #############################################################################
 ## Install rules

--- a/src/plugins/legacy/reformat/CMakeLists.txt
+++ b/src/plugins/legacy/reformat/CMakeLists.txt
@@ -31,7 +31,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon ITKImageGrid ITKVtkGlue)
 include(${ITK_USE_FILE})
@@ -53,10 +52,6 @@ list_source_files(${TARGET_NAME}
 
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
   )
 
 ## #############################################################################

--- a/src/plugins/legacy/variationalSegmentation/CMakeLists.txt
+++ b/src/plugins/legacy/variationalSegmentation/CMakeLists.txt
@@ -56,10 +56,6 @@ list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
   )
 
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
-  )
-
 ## #############################################################################
 ## add library
 ## #############################################################################

--- a/src/plugins/legacy/voiCutter/CMakeLists.txt
+++ b/src/plugins/legacy/voiCutter/CMakeLists.txt
@@ -31,7 +31,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon)
 include(${ITK_USE_FILE})
@@ -54,10 +53,6 @@ list_source_files(${TARGET_NAME}
 
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
-  )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
   )
 
 ## #############################################################################

--- a/src/plugins/legacy/vtkDataMesh/CMakeLists.txt
+++ b/src/plugins/legacy/vtkDataMesh/CMakeLists.txt
@@ -29,14 +29,12 @@ add_definitions(-D${TARGET_NAME_UP}_VERSION="${${TARGET_NAME}_VERSION}")
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(VTK REQUIRED COMPONENTS vtkCommonCore vtkCommonDataModel vtkRenderingCore vtkRenderingVolumeOpenGL2 vtkInteractionStyle vtkInteractionWidgets vtkIOParallelXML vtkIOImage vtkIOGeometry  vtkIOExport vtkRenderingContext2D)
 include(${VTK_USE_FILE})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon)
 include(${ITK_USE_FILE})
-
 
 ## #############################################################################
 ## List Sources
@@ -51,7 +49,6 @@ list_source_files(${TARGET_NAME}
   writers
   )
 
-
 ## #############################################################################
 ## include directorie.
 ## #############################################################################
@@ -59,11 +56,6 @@ list_source_files(${TARGET_NAME}
 list_header_directories_to_include(${TARGET_NAME}
   ${${TARGET_NAME}_HEADERS}
   )
-
-include_directories(${${TARGET_NAME}_INCLUDE_DIRS}
-  ${MEDINRIA_INCLUDE_DIRS}
-  )
-
 
 ## #############################################################################
 ## Precompile headers
@@ -77,7 +69,6 @@ if (MEDINRIA_USE_PRECOMPILED_HEADERS)
     )
 endif()
 
-
 ## #############################################################################
 ## add library
 ## #############################################################################
@@ -87,6 +78,12 @@ add_library(${TARGET_NAME} SHARED
   ${${TARGET_NAME}_CFILES}
   )
 
+## #############################################################################
+## Include dir
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+    PUBLIC ${${TARGET_NAME}_INCLUDE_DIRS})
 
 ## #############################################################################
 ## Link
@@ -105,7 +102,6 @@ target_link_libraries(${TARGET_NAME}
   vtkIOLegacy
   medVtkDataMeshBase
   )
-
 
 ## #############################################################################
 ## Install rules

--- a/src/plugins/medImagingCompatibility/CMakeLists.txt
+++ b/src/plugins/medImagingCompatibility/CMakeLists.txt
@@ -19,7 +19,6 @@ set(TARGET_NAME medImagingCompatibilityPlugin)
 ## #############################################################################
 
 find_package(dtk REQUIRED)
-include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(dtkImaging REQUIRED)
 include_directories(${dtkImaging_INCLUDE_DIRS})


### PR DESCRIPTION
remove un necessary include directories. 
Since during a target_link on a modern cmake project (like medInria) you have automatically what you need to build. (headers, flags that have been made PUBLIC). 
I didn't build this one (I only retrieve most of the changes done on https://github.com/Inria-Asclepios/medInria-public/pull/665)

