### PR TITLE
[NiftiDataImageWriter]: impose extensions order

### DIFF
--- a/src/plugins/legacy/itkDataImage/writers/itkNiftiDataImageWriter.cpp
+++ b/src/plugins/legacy/itkDataImage/writers/itkNiftiDataImageWriter.cpp
@@ -47,8 +47,8 @@ QStringList itkNiftiDataImageWriter::handled() const {
 
 QStringList itkNiftiDataImageWriter::supportedFileExtensions() const
 {
-    return QStringList() << ".nii" << ".nii.gz" << ".nia"
-                         << ".hdr" << ".img" << ".img.gz";
+    return QStringList() << ".nii.gz" << ".nii" << ".hdr"
+                         << ".nia" << ".img" << ".img.gz";
 }
 
 bool itkNiftiDataImageWriter::registered() {

--- a/src/plugins/legacy/itkDataImage/writers/itkNiftiDataImageWriter.cpp
+++ b/src/plugins/legacy/itkDataImage/writers/itkNiftiDataImageWriter.cpp
@@ -45,6 +45,12 @@ QStringList itkNiftiDataImageWriter::handled() const {
     return s_handled();
 }
 
+QStringList itkNiftiDataImageWriter::supportedFileExtensions() const
+{
+    return QStringList() << ".nii" << ".nii.gz" << ".nia"
+                         << ".hdr" << ".img" << ".img.gz";
+}
+
 bool itkNiftiDataImageWriter::registered() {
     return medAbstractDataFactory::instance()->registerDataWriterType(s_identifier(), s_handled(), create);
 }

--- a/src/plugins/legacy/itkDataImage/writers/itkNiftiDataImageWriter.h
+++ b/src/plugins/legacy/itkDataImage/writers/itkNiftiDataImageWriter.h
@@ -24,6 +24,7 @@ public:
     virtual QString identifier()  const;
     virtual QString description() const;
     virtual QStringList handled() const;
+    virtual QStringList supportedFileExtensions() const;
 
     static bool registered();
 

--- a/src/plugins/legacy/itkDataImage/writers/itkNiftiDataImageWriter.h
+++ b/src/plugins/legacy/itkDataImage/writers/itkNiftiDataImageWriter.h
@@ -21,10 +21,10 @@ public:
     itkNiftiDataImageWriter();
     virtual ~itkNiftiDataImageWriter();
 
-    virtual QString identifier()  const;
-    virtual QString description() const;
-    virtual QStringList handled() const;
-    virtual QStringList supportedFileExtensions() const;
+    QString identifier()  const override;
+    QString description() const override;
+    QStringList handled() const override;
+    QStringList supportedFileExtensions() const override;
 
     static bool registered();
 


### PR DESCRIPTION
-impose extension .nii before .nia because medinria can not read .nia