### PR TITLE
[DICOM import] Quick fix for creation of multi series from unique series

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
@@ -251,6 +251,7 @@ void medAbstractDatabaseImporter::importFile ( void )
             if ( !volumeUniqueIdToVolumeNumber.contains ( volumeId ) )
             {
                 volumeUniqueIdToVolumeNumber[volumeId] = volumeNumber;
+                std::cout<<" -------- adding "<<volumeId.toStdString()<<" with "<<volumeNumber<<std::endl;
                 volumeNumber++;
             }
 
@@ -996,13 +997,13 @@ QString medAbstractDatabaseImporter::generateUniqueVolumeId ( const medAbstractD
 
     orientation = "";
 
-    // truncate orientation to 5 digits for a more robust import since
-    // sometimes orientation only differs with the last 2 digits, creating
+    // truncate orientation to 4 digits for a more robust import since
+    // sometimes orientation only differs with the last digits, creating
     // multiple series
     for( QString orient : orientations )
     {
         double d_orient = orient.toDouble();
-        orientation += QString::number ( d_orient, 'g', 5 );
+        orientation += QString::number ( d_orient, 'g', 4 );
     }
 
     // define a unique key string to identify which volume an image belongs to.

--- a/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
@@ -251,7 +251,6 @@ void medAbstractDatabaseImporter::importFile ( void )
             if ( !volumeUniqueIdToVolumeNumber.contains ( volumeId ) )
             {
                 volumeUniqueIdToVolumeNumber[volumeId] = volumeNumber;
-                std::cout<<" -------- adding "<<volumeId.toStdString()<<" with "<<volumeNumber<<std::endl;
                 volumeNumber++;
             }
 


### PR DESCRIPTION
- Fixes #806

**This is a quick fix that does not adress the underlying problem.**

Simplified description of the issue:
When looking for files to import, medInria creates a temporary 'unique' identifier for each image series: if `n` files have the same identifier then they are part of the same series.
This identifier is a concatenation of multiple values of metadata, like patient name, series description, slice thickness, rows, columns... and orientation
The problem is that floating point values (like orientation) can have small variations in each DICOM files: this creates different identifiers for the same image series.
The issue was thought 'solved' previously, as evidenced by the comments in the code. 

I personally believe that we should be creating an identifier using other metadata, e.g. the [Series Instance UID](https://dicom.innolitics.com/ciods/ct-image/general-series/0020000e) tag and others, and remove the decimal tags.
