### PR TITLE
[Database importer] Fix creation of multiple clones of the same study when importing.

### DIFF
--- a/src/layers/legacy/medCoreLegacy/data/medMetaDataKeys.h
+++ b/src/layers/legacy/medCoreLegacy/data/medMetaDataKeys.h
@@ -48,7 +48,7 @@ namespace medMetaDataKeys
 
         const QStringList getValues(const medAbstractData *data) const { return data->metaDataValues(KEY); }
 
-        const QString getFirstValue(const medAbstractData *data, const QString defaultValue=QString()) const
+        const QString getFirstValue(const medAbstractData *data, const QString defaultValue=QString("")) const
         {
             return  data->hasMetaData(KEY) ? data->metaDataValues(KEY)[0] : defaultValue;
         }


### PR DESCRIPTION
- Fixes #757 , so it seems

Instanciating a QString with no parameters and "" (empty string) is not the same thing. This seems important when querying the database for existing studies, patients, etc.

Does this change impacts other areas of the code ?