### PR TITLE
[Help Buttons] buttons on Optimus & LCC tlbx were not working

### DIFF
--- a/src/plugins/legacy/LCCLogDemons/LCCLogDemonsPlugin.cpp
+++ b/src/plugins/legacy/LCCLogDemons/LCCLogDemonsPlugin.cpp
@@ -43,7 +43,7 @@ LCCLogDemonsPlugin::~LCCLogDemonsPlugin()
 {
     delete d;
     
-    d = NULL;
+    d = nullptr;
 }
 
 bool LCCLogDemonsPlugin::initialize()

--- a/src/plugins/legacy/LCCLogDemons/LCCLogDemonsPlugin.h
+++ b/src/plugins/legacy/LCCLogDemons/LCCLogDemonsPlugin.h
@@ -26,7 +26,7 @@ class LCCLogDemonsPLUGIN_EXPORT LCCLogDemonsPlugin : public dtkPlugin
     Q_INTERFACES(dtkPlugin)
     
 public:
-    LCCLogDemonsPlugin(QObject *parent = 0);
+    LCCLogDemonsPlugin(QObject *parent = nullptr);
     ~LCCLogDemonsPlugin();
     
     virtual bool initialize();

--- a/src/plugins/legacy/LCCLogDemons/LCCLogDemonsToolBox.cpp
+++ b/src/plugins/legacy/LCCLogDemons/LCCLogDemonsToolBox.cpp
@@ -213,7 +213,7 @@ LCCLogDemonsToolBox::~LCCLogDemonsToolBox()
 dtkPlugin * LCCLogDemonsToolBox::plugin()
 {
 	medPluginManager* pm = medPluginManager::instance();
-	dtkPlugin* plugin = pm->plugin("LCC Log Demons");
+	dtkPlugin* plugin = pm->plugin("LCCLogDemonsPlugin");
 	return plugin;
 }
 

--- a/src/plugins/legacy/LCCLogDemons/LCCLogDemonsToolBox.h
+++ b/src/plugins/legacy/LCCLogDemons/LCCLogDemonsToolBox.h
@@ -26,7 +26,7 @@ class LCCLogDemonsPLUGIN_EXPORT LCCLogDemonsToolBox : public medAbstractSelectab
                           << "Registration")
     
 public:
-    LCCLogDemonsToolBox(QWidget *parent = 0);
+    LCCLogDemonsToolBox(QWidget *parent = nullptr);
     ~LCCLogDemonsToolBox();
 
 	dtkPlugin * plugin() override;

--- a/src/plugins/legacy/itkProcessRegistrationOptimus/itkProcessRegistrationOptimusPlugin.h
+++ b/src/plugins/legacy/itkProcessRegistrationOptimus/itkProcessRegistrationOptimusPlugin.h
@@ -22,7 +22,7 @@ class ITKPROCESSREGISTRATIONOPTIMUSPLUGIN_EXPORT itkProcessRegistrationOptimusPl
     Q_INTERFACES(dtkPlugin)
 
 public:
-     itkProcessRegistrationOptimusPlugin(QObject *parent = 0);
+     itkProcessRegistrationOptimusPlugin(QObject *parent = nullptr);
     ~itkProcessRegistrationOptimusPlugin(void);
 
      virtual bool initialize(void);

--- a/src/plugins/legacy/itkProcessRegistrationOptimus/itkProcessRegistrationOptimusToolBox.cpp
+++ b/src/plugins/legacy/itkProcessRegistrationOptimus/itkProcessRegistrationOptimusToolBox.cpp
@@ -143,13 +143,13 @@ itkProcessRegistrationOptimusToolBox::~itkProcessRegistrationOptimusToolBox(void
 {
     delete d;
 
-    d = NULL;
+    d = nullptr;
 }
 
 dtkPlugin * itkProcessRegistrationOptimusToolBox::plugin()
 {
     medPluginManager* pm = medPluginManager::instance();
-    dtkPlugin* plugin = pm->plugin("Optimus");
+    dtkPlugin* plugin = pm->plugin("itkProcessRegistrationOptimusPlugin");
     return plugin;
 }
 

--- a/src/plugins/legacy/itkProcessRegistrationOptimus/itkProcessRegistrationOptimusToolBox.h
+++ b/src/plugins/legacy/itkProcessRegistrationOptimus/itkProcessRegistrationOptimusToolBox.h
@@ -22,7 +22,7 @@ class itkProcessRegistrationOptimusToolBox : public medAbstractSelectableToolBox
     MED_TOOLBOX_INTERFACE("Optimus", "interface to the optimus algorithm", <<"Registration")
 
 public:
-     itkProcessRegistrationOptimusToolBox(QWidget *parentToolBox = 0);
+     itkProcessRegistrationOptimusToolBox(QWidget *parentToolBox = nullptr);
     ~itkProcessRegistrationOptimusToolBox(void);
 
     dtkPlugin * plugin() override;


### PR DESCRIPTION
The Help buttons in the Optimus and LCC Log Demons toolboxes were not working. The plugin name called in the toolbox needs to be the same as the plugin name declared in the plugin files.

:m: