### PR TITLE
[MetaDataSetSequence]: fix wrong sequence duration and number of timeStep

### DIFF
--- a/src/layers/legacy/medCoreLegacy/views/navigators/medAbstractImageViewNavigator.cpp
+++ b/src/layers/legacy/medCoreLegacy/views/navigators/medAbstractImageViewNavigator.cpp
@@ -121,7 +121,7 @@ void medAbstractImageViewNavigator::updateTimeLineParameter()
     }
     if(viewHasTemporalData)
     {
-        unsigned int numFrames = (unsigned int)round(sequenceDuration * sequenceFrameRate + 1.0);
+        unsigned int numFrames = (unsigned int)round(sequenceDuration * sequenceFrameRate);
         d->timeLineParameter->setNumberOfFrame(numFrames);
         d->timeLineParameter->setDuration(sequenceDuration);
         d->timeLineParameter->show();

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSetSequence.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSetSequence.cxx
@@ -354,9 +354,7 @@ void vtkMetaDataSetSequence::ComputeSequenceDuration()
         return;
     }
 
-    double step = (this->GetMaxTime() - this->GetMinTime())/(double)(this->GetNumberOfMetaDataSets()-1);
-
-    this->SequenceDuration = this->GetMaxTime() - this->GetMinTime() + step;
+    this->SequenceDuration = this->GetMaxTime() - this->GetMinTime();
 }
 
 //----------------------------------------------------------------------------
@@ -704,9 +702,12 @@ void vtkMetaDataSetSequence::CopyInformation (vtkMetaDataSet *metadataset)
 //----------------------------------------------------------------------------
 void vtkMetaDataSetSequence::ComputeTimesFromDuration()
 {
-    for (int i=0; i<this->GetNumberOfMetaDataSets(); i++)
+    int nbDataSets = this->GetNumberOfMetaDataSets();
+    // compute the time step between each data set
+    double dt = this->GetSequenceDuration() / (nbDataSets - 1);
+    for (int i = 0; i < nbDataSets; i++)
     {
-        this->GetMetaDataSet(i)->SetTime((double) ( i )/ (double)(this->GetNumberOfMetaDataSets() ) );
+        this->GetMetaDataSet(i)->SetTime(dt * i);
     }
 }
 


### PR DESCRIPTION
-The number of frame rate was not compute as it should. Creating a shift of 1 frame on the time interactor
-Fix frong computation of time for each metadataset
