### PR TITLE
[PolygonROI] solve graphical/ergonomy pb and crashes (split, clear)

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/medTableWidgetChooser.h
+++ b/src/layers/legacy/medCoreLegacy/gui/medTableWidgetChooser.h
@@ -23,7 +23,7 @@ class MEDCORELEGACY_EXPORT medTableWidgetChooser : public QTableWidget
     Q_OBJECT
 
 public:
-     medTableWidgetChooser(QWidget *parent = 0, int rowCount = 5, int colCount = 5, int sideSize = 30);
+     medTableWidgetChooser(QWidget *parent = nullptr, int rowCount = 5, int colCount = 5, int sideSize = 30);
     ~medTableWidgetChooser();
 
     QSize sizeHint() const;

--- a/src/plugins/legacy/polygonRoi/polygonEventFilter.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonEventFilter.cpp
@@ -424,7 +424,7 @@ medTagRoiManager *polygonEventFilter::getClosestManager(double *mousePos)
 
 QMenu *polygonEventFilter::changeLabelActions(medTagRoiManager* closestManager)
 {
-    QMenu *changeMenu = new QMenu("Change Label:");
+    QMenu *changeMenu = new QMenu("Change Label");
     for (medTagRoiManager *manager : managers)
     {
         if (manager!= closestManager && !manager->existingRoiInSlice())
@@ -465,8 +465,8 @@ bool polygonEventFilter::rightButtonBehaviour(medAbstractView *view, QMouseEvent
     mousePos[1] = (currentView->viewWidget()->height()-mouseEvent->y()-1)*devicePixelRatio;
     medTagRoiManager * closestManager = getClosestManager(mousePos);
 
-    QMenu *roiManagementMenu = new QMenu("Remove: ");
-    QMenu *saveMenu = new QMenu("Save as: ");
+    QMenu *roiManagementMenu = new QMenu("Remove");
+    QMenu *saveMenu = new QMenu("Save as");
     QMenu *changeMenu = nullptr;
     QWidgetAction *renameManagerAction = new QWidgetAction(&mainMenu);
     QAction *copyContourAction = new QAction("Copy", &mainMenu);

--- a/src/plugins/legacy/polygonRoi/toolboxes/contoursManagementToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/toolboxes/contoursManagementToolBox.cpp
@@ -98,8 +98,6 @@ bool contoursManagementToolBox::registered()
 
 void contoursManagementToolBox::clear()
 {
-    medToolBox::clear();
-
     currentView = nullptr;
 
     QListWidget *widget = labels.at(0);

--- a/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
@@ -445,14 +445,20 @@ void polygonRoiToolBox::updateTableWidgetView(unsigned int row, unsigned int col
 
         // Closing behavior of the non-main view
         medAbstractImageView* view = static_cast<medAbstractImageView *> (container->view());
-        connect(view, &medAbstractImageView::closed, [this, mainContainer]()
+        connect(view, &medAbstractImageView::closed, this, [this]()
         {
-            if (viewEventFilter && mainContainer)
+            if (viewEventFilter)
             {
                 viewEventFilter->clearAlternativeView();
-                mainContainer->setSelected(true);
-                // Once the alternate container is closed, the main one is allowed to be closed
-                mainContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
+                medTabbedViewContainers *tabs = this->getWorkspace()->tabbedViewContainers();
+                if (tabs)
+                {
+                    QList<medViewContainer*> containersInTab = tabs->containersInTab(tabs->currentIndex());
+
+                    containersInTab.at(0)->setSelected(true);
+                    // Once the alternate container is closed, the main one is allowed to be closed
+                    containersInTab.at(0)->setClosingMode(medViewContainer::CLOSE_VIEW);
+                }
             }
         });
 

--- a/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
@@ -137,7 +137,6 @@ polygonRoiToolBox::polygonRoiToolBox(QWidget *parent ) :
 polygonRoiToolBox::~polygonRoiToolBox()
 {
     delete viewEventFilter;
-    viewEventFilter = nullptr; // Will be tested in connect signal due to application closing
 }
 
 bool polygonRoiToolBox::registered()
@@ -154,11 +153,6 @@ dtkPlugin* polygonRoiToolBox::plugin()
 
 medAbstractData *polygonRoiToolBox::processOutput()
 {
-//    if (!m_maskData)
-//    {
-//        //generateBinaryImage();
-//    }
-//    return m_maskData; // return output data
     return nullptr;
 }
 
@@ -451,26 +445,12 @@ void polygonRoiToolBox::updateTableWidgetView(unsigned int row, unsigned int col
 
         // Closing behavior of the non-main view
         medAbstractImageView* view = static_cast<medAbstractImageView *> (container->view());
-        connect(view, &medAbstractImageView::closed, [this, mainContainer](){
-            if (viewEventFilter)
+        connect(view, &medAbstractImageView::closed, [this, mainContainer]()
+        {
+            if (viewEventFilter && mainContainer)
             {
                 viewEventFilter->clearAlternativeView();
-                medTabbedViewContainers *tabs = this->getWorkspace()->tabbedViewContainers();
-                if (tabs)
-                {
-                    QList<medViewContainer*> containersInTab = tabs->containersInTab(tabs->currentIndex());
-                    if (containersInTab.size()==1 && containersInTab.at(0)->uuid()==mainContainerUUID)
-                    {
-                        if (activateTBButton->isEnabled())
-                        {
-                            repulsorTool->setEnabled(true);
-                            tableViewChooser->setEnabled(true);
-                        }
-                    }
-                }
-
                 mainContainer->setSelected(true);
-
                 // Once the alternate container is closed, the main one is allowed to be closed
                 mainContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
             }

--- a/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
@@ -455,6 +455,21 @@ void polygonRoiToolBox::updateTableWidgetView(unsigned int row, unsigned int col
                 {
                     QList<medViewContainer*> containersInTab = tabs->containersInTab(tabs->currentIndex());
 
+                    // This code seems obsolete:
+                    // This connect is called only at the closing of the second view (split view).
+                    // When a split view is created, the main view is locked, it cannot be removed.
+                    // This code enables the repulsor and split buttons when the second view is removed.
+                    // However, without this code, the repulsor and split buttons are already well set at 
+                    //the closing of the second view.
+                    if (containersInTab.size()==1 && containersInTab.at(0)->uuid()==mainContainerUUID)
+                    {
+                        if (activateTBButton->isEnabled())
+                        {
+                            repulsorTool->setEnabled(true);
+                            tableViewChooser->setEnabled(true);
+                        }
+                    }
+
                     containersInTab.at(0)->setSelected(true);
                     // Once the alternate container is closed, the main one is allowed to be closed
                     containersInTab.at(0)->setClosingMode(medViewContainer::CLOSE_VIEW);


### PR DESCRIPTION
Fix https://github.com/medInria/medInria-public/issues/791
Fix https://github.com/medInria/medInria-public/issues/720

I wanted to solve the 2 bugs from the issue 791 in PolygonROI:
 * Open a data, split the view with the orientation buttons, close the first view -> crash
 * The orientation buttons have a glitch, they are cut (on my side at least)

But i found some other problems, which **are** solved also on this PR:
 * Open a data, activate PolygonROI, draw a ROI, change the current toolbox -> the ROI and tick are not cleared
 * Open a data, activate, split, change the current toolbox, go back to PolygonROI -> the toolbox is blocked on deactivate mode
 * Open a data, activate, split, close the application -> crash
 * Solve some typos and ergonomic position of some buttons to a better understanding of the use of this toolbox
 * PolygonROI -> Activate -> Split -> switch to an other tlbx -> go back to PolygonROI -> can't use the tlbx until the user remove the 2nd view
 * PolygonROI -> Activate -> Split -> remove the 2nd view -> remove the first one -> the remaining view is corrupted

I found also some other problems that are **not** solved by this PR:
 * Open a data, activate, split, remove the layer by the cross in the Layer toolbox -> crash
 * Open VOI Cutter firstly -> add data in the view -> switch to PolygonROI -> split -> crash
 
Hope this PR will help, do not hesitate to test or comment.

![Capture d’écran du 2020-12-08 15-50-12](https://user-images.githubusercontent.com/3910352/101499131-3480b200-396d-11eb-9457-84b6be84adfb.png)

:m:
