### PR TITLE
Handle workspace construction failure

### DIFF
--- a/src/app/medInria/areas/workspaces/medWorkspaceArea.cpp
+++ b/src/app/medInria/areas/workspaces/medWorkspaceArea.cpp
@@ -341,13 +341,18 @@ void medWorkspaceArea::removeToolBox(medToolBox *toolbox)
     d->toolBoxContainer->removeToolBox(toolbox);
 }
 
-void medWorkspaceArea::setCurrentWorkspace(medAbstractWorkspaceLegacy *workspace)
+bool medWorkspaceArea::setCurrentWorkspace(medAbstractWorkspaceLegacy *workspace)
 {
     if (d->currentWorkspace == workspace)
-        return;
+        return true;
 
     if (!d->workspaces.contains(workspace->identifier()))
-        this->setupWorkspace(workspace->identifier());
+    {
+        if (!this->setupWorkspace(workspace->identifier()))
+        {
+            return false;
+        }
+    }
 
     this->disconnect(this, SIGNAL(open(medDataIndex)), d->currentWorkspace, 0);
 
@@ -375,14 +380,20 @@ void medWorkspaceArea::setCurrentWorkspace(medAbstractWorkspaceLegacy *workspace
 
     medParameterGroupManagerL::instance()->setCurrentWorkspace(workspace->identifier());
 
+    return true;
 }
 
-void medWorkspaceArea::setCurrentWorkspace(const QString &id)
+bool medWorkspaceArea::setCurrentWorkspace(const QString &id)
 {
     if (!d->workspaces.contains(id))
-        this->setupWorkspace(id);
+    {
+        if (!this->setupWorkspace(id))
+        {
+            return false;
+        }
+    }
 
-    this->setCurrentWorkspace(d->workspaces.value(id));
+    return this->setCurrentWorkspace(d->workspaces.value(id));
 }
 
 medAbstractWorkspaceLegacy* medWorkspaceArea::currentWorkspace()
@@ -390,10 +401,10 @@ medAbstractWorkspaceLegacy* medWorkspaceArea::currentWorkspace()
     return d->currentWorkspace;
 }
 
-void medWorkspaceArea::setupWorkspace(const QString &id)
+bool medWorkspaceArea::setupWorkspace(const QString &id)
 {
     if (d->workspaces.contains(id))
-        return;
+        return true;
 
     medAbstractWorkspaceLegacy *workspace = nullptr;
 
@@ -405,10 +416,12 @@ void medWorkspaceArea::setupWorkspace(const QString &id)
     else
     {
         qWarning()<< "Workspace " << id << " couldn't be created";
-        return;
+        return false;
     }
     workspace->setupTabbedViewContainer();
     workspace->setInitialGroups();
+
+    return true;
 }
 
 void medWorkspaceArea::addDatabaseView(medDatabaseDataSource* dataSource)

--- a/src/app/medInria/areas/workspaces/medWorkspaceArea.h
+++ b/src/app/medInria/areas/workspaces/medWorkspaceArea.h
@@ -56,14 +56,14 @@ public:
     QPixmap grabScreenshot();
     void grabVideo();
 
-    void setupWorkspace(const QString& id);
+    bool setupWorkspace(const QString& id);
 
     void addToolBox(medToolBox *toolbox);
     void insertToolBox(int index, medToolBox *toolbox);
     void removeToolBox(medToolBox *toolbox);
 
-    void setCurrentWorkspace(medAbstractWorkspaceLegacy* workspace);
-    void setCurrentWorkspace(const QString& id);
+    bool setCurrentWorkspace(medAbstractWorkspaceLegacy* workspace);
+    bool setCurrentWorkspace(const QString& id);
 
     medAbstractWorkspaceLegacy* currentWorkspace();
 

--- a/src/app/medInria/medMainWindow.cpp
+++ b/src/app/medInria/medMainWindow.cpp
@@ -675,7 +675,13 @@ void medMainWindow::showWorkspace(QString workspace)
     d->quickAccessButton->setText(tr("Workspace: ") + details->name);
     d->shortcutAccessWidget->updateSelected(workspace);
     d->quickAccessWidget->updateSelected(workspace);
-    d->workspaceArea->setCurrentWorkspace(workspace);
+
+    if (!d->workspaceArea->setCurrentWorkspace(workspace))
+    {
+        QString message = QString("Cannot open workspace ") + details->name;
+        medMessageController::instance()->showError(message, 3000);
+        switchToHomepageArea();
+    }
 
     this->hideQuickAccess();
     this->hideShortcutAccess();

--- a/src/layers/legacy/medCoreLegacy/gui/factories/medWorkspaceFactory.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/factories/medWorkspaceFactory.cpp
@@ -63,9 +63,24 @@ medAbstractWorkspaceLegacy *medWorkspaceFactory::createWorkspace(QString type,QW
     {
         return nullptr;
     }
-    medAbstractWorkspaceLegacy * workspace = d->creators[type]->creator(parent);
 
-    return workspace;
+    // create a deletable parent to clean up in case of constructor failure.
+    parent = new QWidget(parent);
+
+    try
+    {
+        return d->creators[type]->creator(parent);
+    }
+    catch (const std::exception& e)
+    {
+        qWarning() << e.what();
+    }
+    catch (...)
+    {
+    }
+
+    parent->deleteLater();
+    return nullptr;
 }
 
 /**

--- a/src/layers/legacy/medCoreLegacy/gui/medAbstractWorkspaceLegacy.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/medAbstractWorkspaceLegacy.cpp
@@ -73,7 +73,7 @@ medAbstractWorkspaceLegacy::medAbstractWorkspaceLegacy(QWidget *parent)
 {
     d->parent = parent;
 
-    d->selectionToolBox = new medToolBox;
+    d->selectionToolBox = new medToolBox(parent);
     d->selectionToolBox->setTitle("Selection");
     d->selectionToolBox->header()->hide();
     d->selectionToolBox->hide();


### PR DESCRIPTION
This PR adds the possibility to handle workspace construction failure.

If an (unrecoverable) error is encountered in the constructor, it should throw an exception. This will be caught and handled by the workspace factory. The switch to the workspace will be cancelled and medInria will switch to the home area instead. To make sure resources are properly freed, a dedicated "parent" widget is given to the workspace so that all qwidgets it has created can be destroyed easily.