### PR TITLE
[ComponentSizeThresholdFilter]: add option to binarize the ouput or not

### DIFF
--- a/src/plugins/legacy/itkFilters/itkFiltersComponentSizeThresholdProcess.cpp
+++ b/src/plugins/legacy/itkFilters/itkFiltersComponentSizeThresholdProcess.cpp
@@ -147,7 +147,6 @@ int itkFiltersComponentSizeThresholdProcess::updateProcess(medAbstractData *inpu
 
     setOutputData(medAbstractDataFactory::instance()->createSmartPointer(medUtilitiesITK::itkDataImageId<OutputImageType>()));
 
-    std::cout << "d->binarize = " << d->binarize << std::endl;
     if (d->binarize == true)
     {
 

--- a/src/plugins/legacy/itkFilters/itkFiltersComponentSizeThresholdProcess.cpp
+++ b/src/plugins/legacy/itkFilters/itkFiltersComponentSizeThresholdProcess.cpp
@@ -28,9 +28,11 @@ class itkFiltersComponentSizeThresholdProcessPrivate
 {
 public:
     double minimumSize;
+    bool binarize;
 };
 
-const double itkFiltersComponentSizeThresholdProcess::defaultMinimumSize = 50.0;
+const int itkFiltersComponentSizeThresholdProcess::defaultMinimumSize = 50;
+const bool itkFiltersComponentSizeThresholdProcess::defaultBinarize = true;
 
 //-------------------------------------------------------------------------------------------
 
@@ -38,6 +40,7 @@ itkFiltersComponentSizeThresholdProcess::itkFiltersComponentSizeThresholdProcess
     : itkFiltersProcessBase(parent), d(new itkFiltersComponentSizeThresholdProcessPrivate)
 {  
     d->minimumSize = defaultMinimumSize;
+    d->binarize = defaultBinarize;
 }
 
 itkFiltersComponentSizeThresholdProcess::itkFiltersComponentSizeThresholdProcess(const itkFiltersComponentSizeThresholdProcess& other)
@@ -66,9 +69,20 @@ QString itkFiltersComponentSizeThresholdProcess::description() const
 
 //-------------------------------------------------------------------------------------------
 
-void itkFiltersComponentSizeThresholdProcess::setParameter(int data)
+void itkFiltersComponentSizeThresholdProcess::setParameter(int data, int channel)
 {
-    d->minimumSize = data;
+    switch(channel)
+    {
+    case 1:
+        d->minimumSize = data;
+        break;
+    case 2:
+        d->binarize = static_cast<bool>(data);
+        break;
+    default:
+        qDebug()<< metaObject()->className()
+                << "::set parameter - unknown channel.";
+    }
 }
 
 //-------------------------------------------------------------------------------------------
@@ -126,24 +140,33 @@ int itkFiltersComponentSizeThresholdProcess::updateProcess(medAbstractData *inpu
     relabelFilter->SetMinimumObjectSize(d->minimumSize);
     relabelFilter->Update();
 
-    // BINARY FILTER
-    typedef itk::BinaryThresholdImageFilter <OutputImageType, OutputImageType> BinaryThresholdImageFilterType;
-    typename BinaryThresholdImageFilterType::Pointer thresholdFilter
-            = BinaryThresholdImageFilterType::New();
-    thresholdFilter->SetInput(relabelFilter->GetOutput());
-    thresholdFilter->SetUpperThreshold(0);
-    thresholdFilter->SetInsideValue(0);
-    thresholdFilter->SetOutsideValue(1);
-
-    thresholdFilter->Update();
-
     itk::CStyleCommand::Pointer callback = itk::CStyleCommand::New();
-    callback->SetClientData(( void * ) this);
-    callback->SetCallback(itkFiltersProcessBase::eventCallback);
-    connectedComponentFilter->AddObserver(itk::ProgressEvent(), callback);
+    callback->SetClientData ( ( void * ) this );
+    callback->SetCallback ( itkFiltersProcessBase::eventCallback );
+    connectedComponentFilter->AddObserver ( itk::ProgressEvent(), callback );
 
     setOutputData(medAbstractDataFactory::instance()->createSmartPointer(medUtilitiesITK::itkDataImageId<OutputImageType>()));
-    getOutputData()->setData(thresholdFilter->GetOutput());
+
+    std::cout << "d->binarize = " << d->binarize << std::endl;
+    if (d->binarize == true)
+    {
+
+        // BINARY FILTER
+        typedef itk::BinaryThresholdImageFilter <OutputImageType, OutputImageType> BinaryThresholdImageFilterType;
+        typename BinaryThresholdImageFilterType::Pointer thresholdFilter
+                = BinaryThresholdImageFilterType::New();
+        thresholdFilter->SetInput(relabelFilter->GetOutput());
+        thresholdFilter->SetUpperThreshold(0);
+        thresholdFilter->SetInsideValue(0);
+        thresholdFilter->SetOutsideValue(1);
+
+        thresholdFilter->Update();
+        getOutputData()->setData(thresholdFilter->GetOutput());
+    }
+    else
+    {
+        getOutputData()->setData( relabelFilter->GetOutput());
+    }
 
     QString newSeriesDescription = "connectedComponent " + QString::number(d->minimumSize);
     medUtilities::setDerivedMetaData(getOutputData(), inputData, newSeriesDescription);

--- a/src/plugins/legacy/itkFilters/itkFiltersComponentSizeThresholdProcess.h
+++ b/src/plugins/legacy/itkFilters/itkFiltersComponentSizeThresholdProcess.h
@@ -28,7 +28,8 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersComponentSizeThresholdProcess : public i
 public:
     typedef itk::Image<unsigned short, 3> OutputImageType;
 
-    static const double defaultMinimumSize;
+    static const int defaultMinimumSize;
+    static const bool defaultBinarize;
 
     itkFiltersComponentSizeThresholdProcess(itkFiltersComponentSizeThresholdProcess *parent = nullptr);
     itkFiltersComponentSizeThresholdProcess(const itkFiltersComponentSizeThresholdProcess& other);
@@ -37,7 +38,7 @@ public:
     virtual QString description() const;
     
 public slots:
-    void setParameter(int data);
+    void setParameter(int data, int channel);
     int tryUpdate();
 
 protected:

--- a/src/plugins/legacy/itkFilters/itkFiltersToolBox.cpp
+++ b/src/plugins/legacy/itkFilters/itkFiltersToolBox.cpp
@@ -84,6 +84,7 @@ public:
     QSpinBox *shrink1Value;
     QSpinBox *shrink2Value;
     medIntParameterL *componentSizeThresholdFilterValue;
+    QCheckBox *binaryComponentThreshold;
 
     QDoubleSpinBox *intensityMinimumValue;
     QDoubleSpinBox *intensityMaximumValue;
@@ -405,9 +406,18 @@ itkFiltersToolBox::itkFiltersToolBox(QWidget *parent)
     d->componentSizeThresholdFilterValue->setRange ( 0, 100000 );
     d->componentSizeThresholdFilterValue->setValue ( itkFiltersComponentSizeThresholdProcess::defaultMinimumSize );
     d->componentSizeThresholdFilterValue->setObjectName("componentSizeThresholdFilterValue");
-    QHBoxLayout *componentSizeThresholdFilterLayout = new QHBoxLayout;
-    componentSizeThresholdFilterLayout->addWidget(d->componentSizeThresholdFilterValue->getLabel());
-    componentSizeThresholdFilterLayout->addWidget(d->componentSizeThresholdFilterValue->getSpinBox());
+
+    d->binaryComponentThreshold = new QCheckBox(tr("Binarize"));
+    d->binaryComponentThreshold->setChecked(itkFiltersComponentSizeThresholdProcess::defaultBinarize);
+    d->binaryComponentThreshold->setObjectName("componentSizeThresholdCheckBox");
+
+    QHBoxLayout *componentSizeThresholdValueLayout = new QHBoxLayout;
+    componentSizeThresholdValueLayout->addWidget(d->componentSizeThresholdFilterValue->getLabel());
+    componentSizeThresholdValueLayout->addWidget(d->componentSizeThresholdFilterValue->getSpinBox());
+
+    QVBoxLayout *componentSizeThresholdFilterLayout = new QVBoxLayout;
+    componentSizeThresholdFilterLayout->addWidget(d->binaryComponentThreshold);
+    componentSizeThresholdFilterLayout->addLayout (componentSizeThresholdValueLayout);
     d->componentSizeThresholdFilterWidget->setLayout(componentSizeThresholdFilterLayout);
 
     // Run button:
@@ -703,7 +713,8 @@ void itkFiltersToolBox::setupItkComponentSizeThresholdProcess()
     d->process = dtkAbstractProcessFactory::instance()->createSmartPointer("itkComponentSizeThresholdProcess");
 
     d->process->setInput(this->selectorToolBox()->data());
-    d->process->setParameter(d->componentSizeThresholdFilterValue->value());
+    d->process->setParameter(d->componentSizeThresholdFilterValue->value(), 1);
+    d->process->setParameter(static_cast<int>(d->binaryComponentThreshold->isChecked()), 2);
 }
 
 void itkFiltersToolBox::run()


### PR DESCRIPTION
add option to binarize or not the filter output. Can be useful to keep an image labeled by components size.