### PR TITLE
[Package] Mac: do not keep useless Qt plugins

### DIFF
--- a/packaging/apple/mac_packager.sh.in
+++ b/packaging/apple/mac_packager.sh.in
@@ -33,6 +33,9 @@ done
 
 @dtk_DIR@/bin/dtkDeploy medInria.app $injectDirs &>/dev/null
 
+# Remove useless plugins
+\rm -fr PlugIns/{bearer, iconengines, imageformats, platforminputcontexts, platforms, printsupport, sqldrivers, styles, virtualkeyboard}
+
 #Run fancy packaging apple script
 
 \cp -f @medInria_SOURCE_DIR@/utils/osx_packaging/BaseMedinriaPackage.sparseimage.gz @PROJECT_BINARY_DIR@/MedinriaPackage.sparseimage.gz


### PR DESCRIPTION
Opening the application on mac through a binary, you have error messages with these plugins: bearer, iconengines, imageformats, platforminputcontexts, platforms, printsupport, sqldrivers, styles, virtualkeyboard.
This PR avoids them.

History: it was originally done [here](https://github.com/Inria-Asclepios/medinria-superproject/blob/moreMUSIC/packaging/apple/mac_packager.sh.in).

:m: