### PR TITLE
[StatsROI] useless call to empty()

### DIFF
--- a/src/layers/legacy/medUtilities/statsROI.cpp
+++ b/src/layers/legacy/medUtilities/statsROI.cpp
@@ -2,12 +2,14 @@
 
  medInria
 
- Copyright (c) INRIA 2013 - 2020. All rights reserved.
- See LICENSE.txt for details.
+ Copyright (c) INRIA 2013. All rights reserved.
 
-  This software is distributed WITHOUT ANY WARRANTY; without even
-  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-  PURPOSE.
+ See LICENSE.txt for details in the root of the sources or:
+ https://github.com/medInria/medInria-public/blob/master/LICENSE.txt
+
+ This software is distributed WITHOUT ANY WARRANTY; without even
+ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ PURPOSE.
 
 =========================================================================*/
 
@@ -216,7 +218,6 @@ private:
 
 statsROI::statsROI()
 {
-    this->computedOutput.empty();
     chooseFct = MEAN_STDDEVIATION;
     outsideValue = 0;
 }


### PR DESCRIPTION
From a compilation from scratch i saw a warning `ignoring return value of 'bool std::vector<_Tp, _Alloc>::empty() const [with _Tp = double; _Alloc = std::allocator<double>]', declared with attribute nodiscard [-Wunused-result]`. 

The call to `this->computedOutput.empty();` is wrong because it does not clear the vector (we should use `clear()` instead), it only tests if the vector is empty or not. However, here, it is not needed to test if the vector is empty, or to clear it, so i removed the line.

:m: