### PR TITLE
[medPython] Initialization

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -182,6 +182,7 @@ set_lib_properties_variables(
     medWidgets
     medUtilities
     medVtkDataMeshBase
+    medPython
     )
 
 if(EXISTS ${CMAKE_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in)

--- a/src/app/medInria/CMakeLists.txt
+++ b/src/app/medInria/CMakeLists.txt
@@ -144,6 +144,7 @@ target_link_libraries(${TARGET_NAME}
   medWidgets
   medCoreLegacy
   medPacs
+  medPython
   )
 
 

--- a/src/app/medInria/main.cpp
+++ b/src/app/medInria/main.cpp
@@ -26,6 +26,7 @@
 #include <medPluginManager.h>
 #include <medDataIndex.h>
 #include <medDatabaseController.h>
+#include <medPython.h>
 #include <medSettingsManager.h>
 #include <medStorage.h>
 
@@ -269,6 +270,8 @@ int main(int argc,char* argv[])
     application.setMainWindow(mainwindow);
 
     forceShow(*mainwindow);
+
+    med::python::initialize();
 
     qInfo() << "### Application is running...";
 

--- a/src/layers/CMakeLists.txt
+++ b/src/layers/CMakeLists.txt
@@ -32,3 +32,5 @@ add_subdirectory(legacy/medRegistration)
 add_subdirectory(legacy/medVtkInria)
 add_subdirectory(legacy/medUtilities)
 add_subdirectory(legacy/medVtkDataMeshBase)
+
+add_subdirectory(medPython)

--- a/src/layers/medPython/CMakeLists.txt
+++ b/src/layers/medPython/CMakeLists.txt
@@ -1,0 +1,80 @@
+################################################################################
+#
+# medInria
+#
+# Copyright (c) INRIA 2021. All rights reserved.
+#
+# See LICENSE.txt for details in the root of the sources or:
+# https://github.com/medInria/medInria-public/blob/master/LICENSE.txt
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even
+# the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.
+#
+################################################################################
+
+set(TARGET_NAME medPython)
+
+set(CMAKE_MODULE_PATH
+    ${CMAKE_MODULE_PATH}
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake
+  )
+
+include(python_utils)
+
+## #############################################################################
+## Find dependencies
+## #############################################################################
+
+find_package(dtk REQUIRED)
+include_directories(${dtk_INCLUDE_DIRS})
+
+find_package(Qt5 REQUIRED Core)
+
+## #############################################################################
+## List sources
+## #############################################################################
+
+list_source_files(${TARGET_NAME}
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/core
+    )
+
+list_header_directories_to_include(${TARGET_NAME}
+    ${${TARGET_NAME}_HEADERS}
+    )
+
+## #############################################################################
+## Add targets
+## #############################################################################
+
+add_library(${TARGET_NAME} SHARED
+    ${${TARGET_NAME}_CFILES}
+    )
+
+## #############################################################################
+## Include directories
+## #############################################################################
+
+target_include_directories(${TARGET_NAME}
+    PUBLIC
+    ${${TARGET_NAME}_INCLUDE_DIRS}
+    )
+
+## #############################################################################
+## Link
+## #############################################################################
+
+target_link_libraries(${TARGET_NAME}
+    Qt5::Core
+    ${Python3_LIBRARIES}
+    medCoreLegacy
+    )
+
+## #############################################################################
+## Install
+## #############################################################################
+
+set_lib_install_rules(${TARGET_NAME}
+    ${${TARGET_NAME}_HEADERS}
+    )

--- a/src/layers/medPython/cmake/python_utils.cmake
+++ b/src/layers/medPython/cmake/python_utils.cmake
@@ -1,0 +1,17 @@
+################################################################################
+#
+# medInria
+
+# Copyright (c) INRIA 2021. All rights reserved.
+
+# See LICENSE.txt for details in the root of the sources or:
+# https://github.com/medInria/medInria-public/blob/master/LICENSE.txt
+
+# This software is distributed WITHOUT ANY WARRANTY; without even
+# the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.
+#
+################################################################################
+
+find_package(Python3 COMPONENTS Interpreter Development)
+include_directories(${Python3_INCLUDE_DIRS})

--- a/src/layers/medPython/core/medPythonCore.h
+++ b/src/layers/medPython/core/medPythonCore.h
@@ -1,0 +1,24 @@
+#pragma once
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2021. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#undef slots
+#define slots _slots
+
+#undef _LARGEFILE_SOURCE
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#undef slots
+#define slots Q_SLOTS

--- a/src/layers/medPython/medPython.h
+++ b/src/layers/medPython/medPython.h
@@ -1,0 +1,15 @@
+#pragma once
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2021. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#include "medPythonInit.h"

--- a/src/layers/medPython/medPythonExport.h
+++ b/src/layers/medPython/medPythonExport.h
@@ -1,0 +1,23 @@
+#pragma once
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2021. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#ifdef WIN32
+    #ifdef medPython_EXPORTS
+        #define MEDPYTHON_EXPORT __declspec(dllexport)
+    #else
+        #define MEDPYTHON_EXPORT __declspec(dllimport)
+    #endif
+#else
+    #define MEDPYTHON_EXPORT
+#endif

--- a/src/layers/medPython/medPythonInit.cpp
+++ b/src/layers/medPython/medPythonInit.cpp
@@ -1,0 +1,42 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2021. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#include "medPythonInit.h"
+
+#include <QApplication>
+#include <QDebug>
+
+#include "medPythonCore.h"
+
+namespace med::python
+{
+
+void initialize()
+{
+    if (!Py_IsInitialized())
+    {
+        Py_Initialize();
+        QApplication::connect(qApp, &QApplication::aboutToQuit, &finalize);
+        qInfo() << "Python initialized: " << Py_GetVersion();
+    }
+}
+
+void finalize()
+{
+    if (Py_IsInitialized())
+    {
+        Py_Finalize();
+    }
+}
+
+} // namespace med::python

--- a/src/layers/medPython/medPythonInit.h
+++ b/src/layers/medPython/medPythonInit.h
@@ -1,0 +1,28 @@
+#pragma once
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2021. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#include "medPythonExport.h"
+
+namespace med::python
+{
+
+// Initializes the Python interpreter. This will also connect the finalize()
+// function to the application signal aboutToQuit().
+MEDPYTHON_EXPORT void initialize();
+
+// Releases all resources allocated by the Python interpreter. There is no need
+// to call this function manually except to restart the interpreter.
+MEDPYTHON_EXPORT void finalize();
+
+} // namespace med::python


### PR DESCRIPTION
Initializes the Python interpreter at the start of the application. For now this uses the Python interpreter installed on the system, which must be Python 3 (and ideally 3.9). You need the Python 3 development headers to compile, and the application will crash if the executable is run without Python 3 installed. At a later time I'll look into how we include the interpreter in the package.
_(This component is mostly empty for now but the upcoming PRs will add to it)_

