### PR TITLE
[Authors] txt file to fit the other (licence, release notes, etc) & solve Sonarqube error

### DIFF
--- a/src/app/medInria/areas/homepage/medHomepageArea.cpp
+++ b/src/app/medInria/areas/homepage/medHomepageArea.cpp
@@ -164,7 +164,7 @@ medHomepageArea::medHomepageArea ( QWidget * parent ) : QWidget ( parent ), d ( 
     aboutTextEdit->setFocusPolicy ( Qt::NoFocus );
 
     QTextBrowser * aboutAuthorTextBrowser = new QTextBrowser(this);
-    aboutAuthorTextBrowser->setSource(QUrl("qrc:authors.html" ));
+    aboutAuthorTextBrowser->setSource(QUrl("qrc:authors.txt" ));
     aboutAuthorTextBrowser->setFocusPolicy ( Qt::NoFocus );
 
     QTextEdit * aboutLicenseTextEdit = new QTextEdit(this);

--- a/src/app/medInria/resources/authors.txt
+++ b/src/app/medInria/resources/authors.txt
@@ -1,8 +1,4 @@
-<!DOCTYPE html>
-<html>
-<body>
-
-<h3>Developers</h3>
+Developers:<br/><br/>
 
 Alexandre Abadie (medInria)<br/>
 Benoit Bleuze (medInria)<br/>
@@ -33,6 +29,3 @@ Rene-Paul Debroize (medInria)<br/>
 Sergio Medina (medInria)<br/>
 Theodore Papadopoulo (medInria)<br/>
 Stephan Schmitt (medInria)<br/>
-
-</body>
-</html>

--- a/src/app/medInria/resources/medInria.qrc
+++ b/src/app/medInria/resources/medInria.qrc
@@ -124,7 +124,7 @@
         <file>icons/stop.png</file>
         <file>icons/pause.png</file>
         <file>icons/play.png</file>
-        <file>authors.html</file>
+        <file>authors.txt</file>
         <file>icons/fullscreenExpand.png</file>
         <file>icons/fullscreenReduce.png</file>
         <file>icons/medInriaPlugin.png</file>

--- a/src/doc/css/medInria.css
+++ b/src/doc/css/medInria.css
@@ -50,8 +50,7 @@ code {
     border-color: rgb(221, 221, 221);
     border-style: solid;
     border-width: 1px;
-    padding: 2px; 10px; 2px; 10px;
-    display: block;
+    padding: 2px 10px 2px 10px
 }
 
 .memname tr {


### PR DESCRIPTION
The "Developer" title on the Author tab was a bit strange when you look at the other tabs: release notes, licenses, etc. I looked at this file because it created also 2 html Sonarqube bugs, since the file was not completely how an html should be.

:m: