### PR TITLE
[iterativeClosestPoint] Add Export Transformation Matrix Option

### DIFF
--- a/src/plugins/legacy/iterativeClosestPoint/iterativeClosestPointProcess.h
+++ b/src/plugins/legacy/iterativeClosestPoint/iterativeClosestPointProcess.h
@@ -39,10 +39,14 @@ public slots:
     //! Parameters are set through here, channel allows to handle multiple parameters
     void setParameter(double data, int channel);
     void setParameter(int data, int channel);
+    void setParameter(QString data, int channel);
 
     //! Method to actually start the filter
     int update();
-    
+
+    //! Method to get the transformation matrix
+    void exportTransformMatrix();
+
     //! The output will be available through here
     medAbstractData *output();    
     

--- a/src/plugins/legacy/iterativeClosestPoint/iterativeClosestPointToolBox.h
+++ b/src/plugins/legacy/iterativeClosestPoint/iterativeClosestPointToolBox.h
@@ -41,9 +41,12 @@ public slots:
     void run();
     virtual void updateView();
     void resetComboBoxes();
+    void exportTransform();
     
 protected slots:
     void displayOutput();
+    void onExportTransferMatrixCheckBoxToggled(bool toggle);
+    void editTransferMatrixPath(QString newPath);
 
 private:
     iterativeClosestPointToolBoxPrivate *d;

--- a/src/plugins/legacy/meshManipulation/meshManipulationToolBox.cpp
+++ b/src/plugins/legacy/meshManipulation/meshManipulationToolBox.cpp
@@ -462,6 +462,10 @@ void meshManipulationToolBox::importTransform()
             int i = 0, j = 0;
             for(QByteArray line : matrixStr.split('\n'))
             {
+                if (line[0].operator==('#'))
+                {
+                    continue;
+                }
                 for(QByteArray num : line.split('\t'))
                 {
                     m->SetElement(i, j, num.toDouble());


### PR DESCRIPTION
Add an option to get the transformation matrix of an iterative closest point process. 
Use it to transfer points from a patient to another.