### PR TITLE
[add_external_resources] option to generate RCC files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,13 +21,14 @@ endif()
 
 project(medInria VERSION ${medInria_VERSION})
 
-
-## #############################################################################
-## Set version
-## #############################################################################
-
 string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UP)
-add_definitions(-D${PROJECT_NAME_UP}_VERSION="${${PROJECT_NAME}_VERSION}")
+
+set(${PROJECT_NAME}_IDENTIFIER fr.inria.${PROJECT_NAME})
+
+add_compile_definitions(
+  ${PROJECT_NAME_UP}_VERSION="${${PROJECT_NAME}_VERSION}"
+  ${PROJECT_NAME_UP}_IDENTIFIER="${${PROJECT_NAME}_IDENTIFIER}"
+  )
 
 ## #############################################################################
 ## Options
@@ -107,6 +108,7 @@ include(set_exe_install_rules)
 include(set_lib_install_rules)
 include(set_lib_properties_variables)
 include(set_plugin_install_rules)
+include(add_external_resources)
 
 include(add_plugins)
 if(APPLE)
@@ -152,6 +154,17 @@ endif()
 if (WIN32)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /wd4068")
+endif()
+
+## #############################################################################
+## Setup resources directory (for Windows and Linux)
+## #############################################################################
+
+if (NOT APPLE)
+  set(${PROJECT_NAME}_RESOURCES_DIR "${CMAKE_BINARY_DIR}/resources")
+  add_custom_target(make_resource_dir ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${${PROJECT_NAME}_RESOURCES_DIR}"
+    )
 endif()
 
 ## #############################################################################

--- a/src/app/medInria/CMakeLists.txt
+++ b/src/app/medInria/CMakeLists.txt
@@ -114,6 +114,7 @@ add_executable(${TARGET_NAME} ${DEPLOYMENT_SYSTEM} # Empty for Linux
 
 if (APPLE)
   set_target_properties(${TARGET_NAME} PROPERTIES MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/cmake/MedInriaOSXBundleInfo.plist.in")
+  add_external_resources(${TARGET_NAME} "${CMAKE_CURRENT_SOURCE_DIR}/resources/${TARGET_NAME}.icns")
 endif()
 
 ## #############################################################################

--- a/src/cmake/module/add_external_resources.cmake
+++ b/src/cmake/module/add_external_resources.cmake
@@ -1,0 +1,81 @@
+################################################################################
+#
+# medInria
+#
+# Copyright (c) INRIA 2021. All rights reserved.
+# See LICENSE.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.
+#
+################################################################################
+
+macro(add_external_resources target resource1)
+
+################################################################################
+#
+# Usage: add_external_resources(target resource1 resource2 ...)
+#
+# External resources will he handled as follows:
+#
+#   macOS:    The files will be placed in the resource folder of the bundle
+#             (for the exectuble) or the framework (for shared libraries).
+#
+#   other OS: At build time the files will be copied to
+#             ${PROJECT_NAME}_RESOURCES_DIR (and inside a subfolder if target is
+#             a libray). When making the package, a 'resources' folder with
+#             the same structure will be created in the package root.
+#
+################################################################################
+
+  get_target_property(target_type ${target} TYPE)
+
+  if ((NOT target_type STREQUAL "EXECUTABLE")
+      AND
+      (NOT target_type STREQUAL "SHARED_LIBRARY"))
+    message(FATAL_ERROR "Target must be an executable or a shared library")
+  endif()
+
+  set(resources "${resource1}" ${ARGN})
+  target_sources(${target} PRIVATE ${resources})
+  set_target_properties(${target} PROPERTIES RESOURCE "${resources}")
+
+  if (APPLE)
+### MACOS RULES
+
+    # if the target is a library, we must build it as a framework to contain
+    # the resources.
+    if (target_type STREQUAL "SHARED_LIBRARY")
+      set_target_properties(${target} PROPERTIES
+        FRAMEWORK TRUE
+        MACOSX_BUNDLE_BUNDLE_NAME ${target}
+        MACOSX_FRAMEWORK_IDENTIFIER ${${PROJECT_NAME}_IDENTIFIER}.${target}
+        )
+    endif()
+
+  else()
+### LINUX AND WINDOWS RULES
+
+    set(build_dir "${${PROJECT_NAME}_RESOURCES_DIR}")
+
+    # use subfolders for library-specific resources to avoid name collisions
+    if (target_type STREQUAL "SHARED_LIBRARY")
+      set(build_dir "${build_dir}/${target}")
+    endif()
+
+    foreach(resource ${resources})
+      get_filename_component(filename "${resource}" NAME)
+      set(output_file "${build_dir}/${filename}")
+      add_custom_command(
+        OUTPUT "${output_file}"
+        COMMAND ${CMAKE_COMMAND} ARGS -E copy "${resource}" "${output_file}"
+        )
+      string(REPLACE " " "_" target_suffix "${filename}")
+      add_custom_target(${target}_resource_${target_suffix} ALL
+        DEPENDS "${resource}" "${output_file}")
+    endforeach()
+
+  endif()
+
+endmacro()

--- a/src/cmake/module/add_external_resources.cmake
+++ b/src/cmake/module/add_external_resources.cmake
@@ -11,11 +11,11 @@
 #
 ################################################################################
 
-macro(add_external_resources target resource1)
+macro(add_external_resources target)
 
 ################################################################################
 #
-# Usage: add_external_resources(target resource1 resource2 ...)
+# Usage: add_external_resources(target [RCC name] [PREFIX prefix] resources...)
 #
 # External resources will he handled as follows:
 #
@@ -27,7 +27,24 @@ macro(add_external_resources target resource1)
 #             a libray). When making the package, a 'resources' folder with
 #             the same structure will be created in the package root.
 #
+#   The following options can be used:
+#
+#   RCC: When this option is used, the input resources must be directories, and
+#        their contents will be compiled into a single Qt binary resource file
+#        called "name.rcc". This file can then be registered using code like:
+
+#        QResource::registerResource(med::getExternalResourcePath("name.rcc"...)
+
+#        This allows the resources to be accessed in the same way as compiled-in
+#        resources i.e. QFile(:/prefix/my_resource.foo)
+#
+#   PREFIX: Add a resource prefix to the qrc used to generate the rcc file (to
+#           use with the RCC option).
+#
 ################################################################################
+
+  cmake_parse_arguments(resources "" "RCC;PREFIX" "" ${ARGN})
+  set(resources ${resources_UNPARSED_ARGUMENTS})
 
   get_target_property(target_type ${target} TYPE)
 
@@ -37,45 +54,94 @@ macro(add_external_resources target resource1)
     message(FATAL_ERROR "Target must be an executable or a shared library")
   endif()
 
-  set(resources "${resource1}" ${ARGN})
-  target_sources(${target} PRIVATE ${resources})
-  set_target_properties(${target} PROPERTIES RESOURCE "${resources}")
+  if (resources)
 
-  if (APPLE)
+    # make the rcc file if requested
+    if (resources_RCC)
+      set(qrc_file "${CMAKE_CURRENT_BINARY_DIR}/resources/${resources_RCC}/${resources_RCC}.qrc")
+      set(rcc_file "${CMAKE_CURRENT_BINARY_DIR}/resources/${resources_RCC}/${resources_RCC}.rcc")
+      set(dependency_files)
+
+      file(WRITE "${qrc_file}" "<RCC><qresource")
+
+      if (resources_PREFIX)
+        file(APPEND "${qrc_file}" " prefix=\"/" ${resources_PREFIX} "\"")
+      endif()
+
+      file(APPEND "${qrc_file}" ">")
+
+      foreach (resource_dir ${resources})
+        file(GLOB_RECURSE resource_files "${resource_dir}"
+                "${resource_dir}/*"
+                )
+        foreach(resource_file ${resource_files})
+          file(RELATIVE_PATH relative_resource_file "${resource_dir}" "${resource_file}")
+          file(APPEND "${qrc_file}" "<file>${relative_resource_file}</file>")
+
+          # create a target to copy the resource file to a location relative to the qrc file
+          set(output_file "${CMAKE_CURRENT_BINARY_DIR}/resources/${resources_RCC}/${relative_resource_file}")
+          add_custom_command(
+            OUTPUT "${output_file}"
+            COMMAND ${CMAKE_COMMAND} ARGS -E copy "${resource_file}" "${output_file}"
+            )
+          list(APPEND dependency_files "${resource_file}" "${output_file}")
+        endforeach()
+      endforeach()
+
+      file(APPEND "${qrc_file}" "</qresource></RCC>")
+
+      qt5_add_binary_resources(${target}_${resources_RCC}_RCC ${qrc_file}
+        DESTINATION ${rcc_file}
+        )
+
+      # add dependencies to regenerate the rcc file if the resources change
+      add_custom_target(${target}_${resources_RCC}_FILES ALL
+        DEPENDS ${dependency_files})
+      add_dependencies(${target}_${resources_RCC}_RCC ${target}_${resources_RCC}_FILES)
+
+      # now the only resource will be the rcc file
+      set(resources ${rcc_file})
+    endif()
+
+    target_sources(${target} PRIVATE ${resources})
+    set_target_properties(${target} PROPERTIES RESOURCE "${resources}")
+
+    if (APPLE)
 ### MACOS RULES
 
-    # if the target is a library, we must build it as a framework to contain
-    # the resources.
-    if (target_type STREQUAL "SHARED_LIBRARY")
-      set_target_properties(${target} PROPERTIES
-        FRAMEWORK TRUE
-        MACOSX_BUNDLE_BUNDLE_NAME ${target}
-        MACOSX_FRAMEWORK_IDENTIFIER ${${PROJECT_NAME}_IDENTIFIER}.${target}
-        )
-    endif()
+      # if the target is a library, we must build it as a framework to contain
+      # the resources.
+      if (target_type STREQUAL "SHARED_LIBRARY")
+        set_target_properties(${target} PROPERTIES
+          FRAMEWORK TRUE
+          MACOSX_BUNDLE_BUNDLE_NAME ${target}
+          MACOSX_FRAMEWORK_IDENTIFIER ${${PROJECT_NAME}_IDENTIFIER}.${target}
+          )
+      endif()
 
-  else()
+    else()
 ### LINUX AND WINDOWS RULES
 
-    set(build_dir "${${PROJECT_NAME}_RESOURCES_DIR}")
+      set(build_dir "${${PROJECT_NAME}_RESOURCES_DIR}")
 
-    # use subfolders for library-specific resources to avoid name collisions
-    if (target_type STREQUAL "SHARED_LIBRARY")
-      set(build_dir "${build_dir}/${target}")
+      # use subfolders for library-specific resources to avoid name collisions
+      if (target_type STREQUAL "SHARED_LIBRARY")
+        set(build_dir "${build_dir}/${target}")
+      endif()
+
+      foreach(resource ${resources})
+        get_filename_component(filename "${resource}" NAME)
+        set(output_file "${build_dir}/${filename}")
+        add_custom_command(
+          OUTPUT "${output_file}"
+          COMMAND ${CMAKE_COMMAND} ARGS -E copy "${resource}" "${output_file}"
+          )
+        string(REPLACE " " "_" target_suffix "${filename}")
+        add_custom_target(${target}_resource_${target_suffix} ALL
+          DEPENDS "${resource}" "${output_file}")
+      endforeach()
+
     endif()
-
-    foreach(resource ${resources})
-      get_filename_component(filename "${resource}" NAME)
-      set(output_file "${build_dir}/${filename}")
-      add_custom_command(
-        OUTPUT "${output_file}"
-        COMMAND ${CMAKE_COMMAND} ARGS -E copy "${resource}" "${output_file}"
-        )
-      string(REPLACE " " "_" target_suffix "${filename}")
-      add_custom_target(${target}_resource_${target_suffix} ALL
-        DEPENDS "${resource}" "${output_file}")
-    endforeach()
-
   endif()
 
 endmacro()

--- a/src/cmake/module/set_exe_install_rules.cmake
+++ b/src/cmake/module/set_exe_install_rules.cmake
@@ -32,7 +32,8 @@ endif()
 
 install(TARGETS ${target}
   RUNTIME DESTINATION bin
-  BUNDLE  DESTINATION bin
+  BUNDLE DESTINATION bin
+  RESOURCE DESTINATION resources
   )
 
 ## #############################################################################
@@ -54,13 +55,6 @@ if (APPLE)
     )
   set(MACOSX_BUNDLE_LONG_VERSION_STRING
     "Version ${${target}_VERSION}"
-    )
-  set(${target}_RESOURCE_DIR
-    ${CMAKE_BINARY_DIR}/bin/${target}.app/Contents/Resources
-    )
-  add_custom_command(TARGET ${target} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} ARGS -E make_directory ${${target}_RESOURCE_DIR}
-    COMMAND ${CMAKE_COMMAND} ARGS -E copy ${CMAKE_CURRENT_SOURCE_DIR}/resources/${target}.icns ${${target}_RESOURCE_DIR}
     )
 
   install(CODE "

--- a/src/cmake/module/set_lib_install_rules.cmake
+++ b/src/cmake/module/set_lib_install_rules.cmake
@@ -48,6 +48,8 @@ install(TARGETS ${target}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
+  FRAMEWORK DESTINATION lib
+  RESOURCE DESTINATION resources/${target}
   )
 
 ## #############################################################################

--- a/src/layers/legacy/medCoreLegacy/medExternalResources.cpp
+++ b/src/layers/legacy/medCoreLegacy/medExternalResources.cpp
@@ -1,0 +1,119 @@
+#include "medExternalResources.h"
+
+#if defined(Q_OS_MACOS)
+#include <CoreFoundation/CFBundle.h>
+#endif
+
+#include <QApplication>
+#include <QDir>
+
+namespace med
+{
+
+namespace
+{
+
+#if defined(Q_OS_MACOS)
+
+// Frameworks are accessed as bundles.
+CFBundleRef getBundleOrFramework(QString libraryName)
+{
+    CFBundleRef bundle;
+
+    if (libraryName.isEmpty())
+    {
+        bundle = CFBundleGetMainBundle();
+    }
+    else
+    {
+        QString frameworkId = QString("%1.%2").arg(MEDINRIA_IDENTIFIER).arg(libraryName);
+        CFStringRef frameworkIdRef = CFStringCreateWithCString(nullptr, qUtf8Printable(frameworkId), kCFStringEncodingUTF8);
+        bundle = CFBundleGetBundleWithIdentifier(frameworkIdRef);
+        CFRelease(frameworkIdRef);
+    }
+
+    return bundle;
+}
+
+// On macOS the main resources are located in the bundle's resource folder and
+// the library-specific resources are located in the library's framework
+// resource folder. If 'libraryName' is empty then the bundle is searched.
+QString getResourcePathForMacPackage(QString filename, QString libraryName)
+{
+    QString result;
+    CFBundleRef bundle = getBundleOrFramework(libraryName);
+
+    if (bundle)
+    {
+        CFStringRef resourceName = CFStringCreateWithCString(nullptr, qUtf8Printable(filename), kCFStringEncodingUTF8);
+        CFURLRef resourceURL = CFBundleCopyResourceURL(bundle, resourceName, nullptr, nullptr);
+        CFRelease(bundle);
+        CFRelease(resourceName);
+
+        if (resourceURL)
+        {
+            CFStringRef resourcePath = CFURLCopyFileSystemPath(resourceURL, kCFURLPOSIXPathStyle);
+            CFRelease(resourceURL);
+            CFIndex utf16length = CFStringGetLength(resourcePath);
+            CFIndex maxUtf8length = CFStringGetMaximumSizeForEncoding(utf16length, kCFStringEncodingUTF8);
+            std::string pathString(maxUtf8length, '\0');
+
+            if (CFStringGetCString(resourcePath, pathString.data(), maxUtf8length, kCFStringEncodingUTF8))
+            {
+                result = pathString.c_str();
+            }
+
+            CFRelease(resourcePath);
+        }
+    }
+
+    return result;
+}
+
+#else
+
+// Search for the resource in the '../resources/[libraryName/]' directory
+// relative to the application directory.
+QString getResourcePathFromApplicationDirectory(QString filename, QString libraryName)
+{
+    QString result;
+    QString applicationDirectory = qApp->applicationDirPath();
+
+    if (!applicationDirectory.isEmpty())
+    {
+        QDir resourcesDirectory = applicationDirectory;
+
+        if (resourcesDirectory.cdUp()
+            && resourcesDirectory.cd("resources")
+            && (libraryName.isEmpty() || resourcesDirectory.cd(libraryName)))
+        {
+            QString resourceFilePath = resourcesDirectory.filePath(filename);
+
+            if (QFileInfo::exists(resourceFilePath))
+            {
+                result = resourceFilePath;
+            }
+        }
+    }
+
+    return result;
+}
+
+#endif
+
+} // namespace
+
+QString getExternalResourcePath(QString filename, QString libraryName)
+{
+    QString result;
+
+#if defined(Q_OS_MACOS)
+    result = getResourcePathForMacPackage(filename, libraryName);
+#else
+    result = getResourcePathFromApplicationDirectory(filename, libraryName);
+#endif
+
+    return result;
+}
+
+} // namespace med

--- a/src/layers/legacy/medCoreLegacy/medExternalResources.h
+++ b/src/layers/legacy/medCoreLegacy/medExternalResources.h
@@ -1,0 +1,36 @@
+#pragma once
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2021. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+// Resources are generally compiled into the executable or library binaries
+// using Qt's resources system. Sometimes though it is necessary (or preferable)
+// for resources to be placed in separate files. This can be done through the
+// add_external_resources macro of the cmake project. External resources are
+// stored differently depending on the OS, so this file provides a function to
+// retrieve the path of the resource in a platform-independant way.
+// NOTE: External Qt binary resources (rcc files) must also be registered using
+// QResource::registerResource(path_to_resource).
+
+
+#include <QString>
+
+namespace med
+{
+
+// Returns the path of an external resource that was added using
+// add_external_resources in the cmake project. If the resource was added
+// through a library target then the library name must be provided. A null
+// string is returned if the resource is not found.
+QString getExternalResourcePath(QString filename, QString libraryName = QString());
+
+} // namespace med


### PR DESCRIPTION
(based on https://github.com/medInria/medInria-public/pull/848)
(adds commit https://github.com/medInria/medInria-public/commit/e331d189761c23b04e2349c74d5bdd7a44ca3607)

This PR extends the `add_external_resources` macro with an option to compile a set of resources into an external Qt binary resource file (rcc). This allows the resources to be registered with Qt's resources system so that they can be used exactly the same way as compiled-in resources.