### PR TITLE
[MeshManipulation] Undo redo and transformation list

### DIFF
--- a/src/plugins/legacy/meshManipulation/meshManipulationToolBox.cpp
+++ b/src/plugins/legacy/meshManipulation/meshManipulationToolBox.cpp
@@ -29,6 +29,7 @@
 #include <vtkActor.h>
 #include <vtkBoxWidget.h>
 #include <vtkCommand.h>
+#include <vtkDoubleArray.h>
 #include <vtkFieldData.h>
 #include <vtkMatrix4x4.h>
 #include <vtkMetaDataSet.h>
@@ -517,6 +518,18 @@ vtkPointSet* meshManipulationToolBox::transformDataSet(vtkMetaDataSet *dataset,
 
     vtkPointSet *newPointset = pointset->NewInstance();
     newPointset->DeepCopy(transformFilter->GetOutput());
+
+    // save the transformation matrix
+    vtkMatrix4x4* m = t->GetMatrix();
+    auto mArray = vtkSmartPointer<vtkDoubleArray>::New();
+    mArray->SetNumberOfTuples(16);
+    mArray->SetNumberOfComponents(1);
+    mArray->SetName("TransformMatrix");
+    double* data = mArray->GetPointer(0);
+    double* mat  = m->GetData();
+    std::memcpy(data, mat, 16 * sizeof(*data));
+
+    newPointset->GetFieldData()->AddArray(mArray);
 
     return newPointset;
 }

--- a/src/plugins/legacy/meshManipulation/meshManipulationToolBox.cpp
+++ b/src/plugins/legacy/meshManipulation/meshManipulationToolBox.cpp
@@ -819,12 +819,6 @@ void meshManipulationToolBox::applySelectedTransformationInverted()
 
 void meshManipulationToolBox::applyTransformationMatrix(vtkSmartPointer<vtkMatrix4x4> matrix)
 {
-    double* p = matrix->GetData();
-    std::cout<<"[ "<<p[0]<<", "<<p[1]<<", "<<p[2]<<", "<<p[3]<<"]"<<std::endl;
-    std::cout<<"[ "<<p[4]<<", "<<p[5]<<", "<<p[6]<<", "<<p[7]<<"]"<<std::endl;
-    std::cout<<"[ "<<p[8]<<", "<<p[9]<<", "<<p[10]<<", "<<p[11]<<"]"<<std::endl;
-    std::cout<<"[ "<<p[12]<<", "<<p[13]<<", "<<p[14]<<", "<<p[15]<<"]"<<std::endl;
-
     addTransformationMatrixToUndoStack(matrix);
     _callback->applyExternalMatrix(matrix);
     if (_view)

--- a/src/plugins/legacy/meshManipulation/meshManipulationToolBox.cpp
+++ b/src/plugins/legacy/meshManipulation/meshManipulationToolBox.cpp
@@ -114,11 +114,10 @@ meshManipulationToolBox::meshManipulationToolBox(QWidget *parent)
     QVBoxLayout* toolboxLayout = new QVBoxLayout();
     w->setLayout(toolboxLayout);
     
-    QLabel *explanation = new QLabel("Drop one or multiple meshes in the view.\n\n"
-                                     "Scaling: hold <right-click> on the bounding box\n\n"
-                                     "Rotation: hold <left-click> on the sides of the bounding box\n\n"
-                                     "Translation: hold <mouse-wheel button>, or <left-click> on the central sphere of the bounding box\n\n\n"
-                                     "Registration matrices are automatically retrieved from the input datasets if available.\n\n", this);
+    QLabel *explanation = new QLabel("Select one or multiple layers to manually adjust.\n\n"
+                                     "Scaling: hold <right-click> on the bounding box\n"
+                                     "Rotation: hold <left-click> on the sides of the bounding box\n"
+                                     "Translation: hold <mouse-wheel button>, or <left-click> on the central sphere of the bounding box\n\n", this);
     explanation->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
     explanation->setWordWrap(true);
     explanation->setStyleSheet("font: italic");
@@ -166,18 +165,16 @@ meshManipulationToolBox::meshManipulationToolBox(QWidget *parent)
     _availableMatricesWidget = new QListWidget(this);
     _availableMatricesWidget->setToolTip("Lists all the imported registration matrices.");
     _availableMatricesWidget->setObjectName("availableMatricesWidget");
-    _availableMatricesWidget->setMaximumHeight(156);
+    _availableMatricesWidget->setMaximumHeight(96);
     _availableMatricesWidget->setSelectionMode(QAbstractItemView::SingleSelection);
     toolboxLayout->addWidget(_availableMatricesWidget);
 
     QHBoxLayout* applyLayout = new QHBoxLayout();
     _applyButton = new QPushButton("Apply", this);
     _applyButton->setToolTip("Apply selected transformation.");
-//    _applyButton->setEnabled(false);
 
     _applyInverseButton = new QPushButton("Apply inverse", this);
-    _applyInverseButton->setToolTip("Apply the invers transformation");
-//    _applyInverseButton->setEnabled(false);
+    _applyInverseButton->setToolTip("Apply the inverse transformation");
 
     applyLayout->addWidget(_applyButton);
     applyLayout->addWidget(_applyInverseButton);
@@ -736,7 +733,6 @@ void meshManipulationToolBox::addTransformationMatrixToUndoStack(vtkMatrix4x4* m
     if (_undoStackPos != _undoStack.end())
     {
          // there are elements that need to be removed
-        std::cout<<" must remove last transforms"<<std::endl;
         _undoStack.erase(_undoStackPos, _undoStack.end());
         _undoStackPos = _undoStack.end();
     }

--- a/src/plugins/legacy/meshManipulation/meshManipulationToolBox.cpp
+++ b/src/plugins/legacy/meshManipulation/meshManipulationToolBox.cpp
@@ -646,12 +646,6 @@ void meshManipulationToolBox::exportTransform()
 
 void meshManipulationToolBox::importTransform()
 {
-    auto showError = [=](QString errorMessage, QFile& f)
-    {
-        qDebug() << metaObject()->className() << "::" << errorMessage;
-        medMessageController::instance()->showError(errorMessage, 3000);
-    };
-
     QString filePath = QFileDialog::getOpenFileName(this, "Import the matrix file");
     if (!filePath.isEmpty())
     {
@@ -685,7 +679,7 @@ void meshManipulationToolBox::importTransform()
                 if (i != 4)
                 {
                     // the line does not contain 4 values
-                    showError("Matrix has wrong formatting", f);
+                    medToolBox::displayMessageError("Matrix has wrong formatting.");
                     f.close();
                     return;
                 }
@@ -699,11 +693,11 @@ void meshManipulationToolBox::importTransform()
             }
             else
             {
-                showError("Not a 4x4 matrix.", f);
+                medToolBox::displayMessageError("Not a 4x4 matrix.");
             }
 
-            f.close();
         }
+        f.close();
     }
 }
 


### PR DESCRIPTION
- Add undo, redo functionality to mesh manipulation
- Robustify import mechanism of matrices, i.e. won't crash when importing something else than perfectly formatted matrices
- Imported matrices will be shown in a list
- The applied transformation matrix is saved in the data itself (in vtk FieldData). This was already done for EPmaps.
- These saved matrices are retrieved automatically and displayed in the list
- Users can apply the inverse of the imported transformation matrices
