### PR TITLE
[itkProcessRegistration] doxygen param problem

### DIFF
--- a/src/layers/legacy/medRegistration/itkProcessRegistration.h
+++ b/src/layers/legacy/medRegistration/itkProcessRegistration.h
@@ -91,7 +91,6 @@ public:
      * Directly converts the inputs in <float, 3> images.
      * The output is allocated and is also a <float,3 image>
      * @param data: Pointer to an itkDataImageXXY.
-     * @param channel: 0 for the fixed image, 1 for the moving one.
     */
     virtual bool setFixedInput(medAbstractData *data);
     virtual bool setMovingInput(medAbstractData *data);


### PR DESCRIPTION
A small change on the documentation of itkProcessRegistration: `channel` is not a parameter.

:m: