### PR TITLE
[medDatabaseExporter] Fix problem when exporting big data

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medDataManager.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDataManager.cpp
@@ -171,7 +171,7 @@ QHash<QString, dtkAbstractDataWriter*> medDataManager::getPossibleWriters(medAbs
     return possibleWriters;
 }
 
-void medDataManager::exportData(medAbstractData* data)
+void medDataManager::exportData(dtkSmartPointer<medAbstractData> data)
 {
     if (!data)
         return;
@@ -264,7 +264,7 @@ void medDataManager::exportData(medAbstractData* data)
     delete exportDialog;
 }
 
-void medDataManager::exportDataToPath(medAbstractData *data, const QString & filename, const QString & writer)
+void medDataManager::exportDataToPath(dtkSmartPointer<medAbstractData> data, const QString & filename, const QString & writer)
 {
     medDatabaseExporter *exporter = new medDatabaseExporter (data, filename, writer);
     launchExporter(exporter, filename);

--- a/src/layers/legacy/medCoreLegacy/database/medDataManager.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDataManager.h
@@ -16,6 +16,8 @@
 #include <QPixmap>
 #include <QUuid>
 
+#include <dtkCoreSupport/dtkSmartPointer>
+
 #include <medCoreLegacyExport.h>
 #include <medDatabaseExporter.h>
 #include <medDataIndex.h>
@@ -40,8 +42,8 @@ public:
     QUuid importData(medAbstractData* data, bool persistent = false);
     QUuid importPath(const QString& dataPath, bool indexWithoutCopying, bool persistent = false);
 
-    void exportData(medAbstractData* data);
-    void exportDataToPath(medAbstractData* data, const QString& path, const QString& format = "");
+    void exportData(dtkSmartPointer<medAbstractData> data);
+    void exportDataToPath(dtkSmartPointer<medAbstractData> data, const QString& path, const QString& format = "");
 
     QUuid makePersistent(medAbstractData* data);
 

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseExporter.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseExporter.cpp
@@ -20,12 +20,12 @@
 class medDatabaseExporterPrivate
 {
 public:
-    medAbstractData *data;
+    dtkSmartPointer<medAbstractData> data;
     QString          filename;
     QString          writer;
 };
 
-medDatabaseExporter::medDatabaseExporter(medAbstractData * data, const QString & filename, const QString & writer) : medJobItemL(), d(new medDatabaseExporterPrivate)
+medDatabaseExporter::medDatabaseExporter(dtkSmartPointer<medAbstractData> data, const QString & filename, const QString & writer) : medJobItemL(), d(new medDatabaseExporterPrivate)
 {
     d->data     = data;
     d->filename = filename;

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseExporter.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseExporter.h
@@ -14,6 +14,8 @@
 
 #include <QtCore>
 
+#include <dtkCoreSupport/dtkSmartPointer>
+
 #include <medCoreLegacyExport.h>
 #include <medJobItemL.h>
 
@@ -25,7 +27,7 @@ class MEDCORELEGACY_EXPORT medDatabaseExporter : public medJobItemL
     Q_OBJECT
 
 public:
-     medDatabaseExporter(medAbstractData * data, const QString & filename, const QString & writer);
+     medDatabaseExporter(dtkSmartPointer<medAbstractData> data, const QString & filename, const QString & writer);
     ~medDatabaseExporter();
 
 protected:


### PR DESCRIPTION
- Fix problem when exporting very big medAbstractData onto disk: the object would be garbage collected before the writing would finish. Correct usage of smart pointers fixes this.