### PR TITLE
[medExternalResources] bundle object should not be freed

### DIFF
--- a/src/layers/legacy/medCoreLegacy/medExternalResources.cpp
+++ b/src/layers/legacy/medCoreLegacy/medExternalResources.cpp
@@ -47,7 +47,6 @@ QString getResourcesDirectoryForMacPackage(QString libraryName)
     {
         CFURLRef relativeResourcesDirectoryURL = CFBundleCopyResourcesDirectoryURL(bundle);
         CFURLRef resourcesDirectoryURL = CFURLCopyAbsoluteURL(relativeResourcesDirectoryURL);
-        CFRelease(bundle);
         CFRelease(relativeResourcesDirectoryURL);
 
         if (resourcesDirectoryURL)
@@ -80,7 +79,6 @@ QString getResourcePathForMacPackage(QString filename, QString libraryName)
     {
         CFStringRef resourceName = CFStringCreateWithCString(nullptr, qUtf8Printable(filename), kCFStringEncodingUTF8);
         CFURLRef resourceURL = CFBundleCopyResourceURL(bundle, resourceName, nullptr, nullptr);
-        CFRelease(bundle);
         CFRelease(resourceName);
 
         if (resourceURL)

--- a/src/layers/legacy/medCoreLegacy/medExternalResources.cpp
+++ b/src/layers/legacy/medCoreLegacy/medExternalResources.cpp
@@ -38,6 +38,39 @@ CFBundleRef getBundleOrFramework(QString libraryName)
 // On macOS the main resources are located in the bundle's resource folder and
 // the library-specific resources are located in the library's framework
 // resource folder. If 'libraryName' is empty then the bundle is searched.
+QString getResourcesDirectoryForMacPackage(QString libraryName)
+{
+    QString result;
+    CFBundleRef bundle = getBundleOrFramework(libraryName);
+
+    if (bundle)
+    {
+        CFURLRef relativeResourcesDirectoryURL = CFBundleCopyResourcesDirectoryURL(bundle);
+        CFURLRef resourcesDirectoryURL = CFURLCopyAbsoluteURL(relativeResourcesDirectoryURL);
+        CFRelease(bundle);
+        CFRelease(relativeResourcesDirectoryURL);
+
+        if (resourcesDirectoryURL)
+        {
+            CFStringRef resourcesDirectory = CFURLCopyFileSystemPath(resourcesDirectoryURL, kCFURLPOSIXPathStyle);
+            CFRelease(resourcesDirectoryURL);
+            CFIndex utf16length = CFStringGetLength(resourcesDirectory);
+            CFIndex maxUtf8length = CFStringGetMaximumSizeForEncoding(utf16length, kCFStringEncodingUTF8);
+            std::string pathString(maxUtf8length, '\0');
+
+            if (CFStringGetCString(resourcesDirectory, pathString.data(), maxUtf8length, kCFStringEncodingUTF8))
+            {
+                result = pathString.c_str();
+            }
+
+            CFRelease(resourcesDirectory);
+        }
+    }
+
+    return result;
+}
+
+// (see getResourcesDirectoryForMacPackage for implementation notes)
 QString getResourcePathForMacPackage(QString filename, QString libraryName)
 {
     QString result;
@@ -72,9 +105,9 @@ QString getResourcePathForMacPackage(QString filename, QString libraryName)
 
 #else
 
-// Search for the resource in the '../resources/[libraryName/]' directory
-// relative to the application directory.
-QString getResourcePathFromApplicationDirectory(QString filename, QString libraryName)
+// Return the '../resources/[libraryName/]' directory relative to the
+// application directory.
+QString getResourcesDirectoryFromApplicationDirectory(QString libraryName)
 {
     QString result;
     QString applicationDirectory = qApp->applicationDirPath();
@@ -87,12 +120,27 @@ QString getResourcePathFromApplicationDirectory(QString filename, QString librar
             && resourcesDirectory.cd("resources")
             && (libraryName.isEmpty() || resourcesDirectory.cd(libraryName)))
         {
-            QString resourceFilePath = resourcesDirectory.filePath(filename);
+            result = resourcesDirectory.path();
+        }
+    }
 
-            if (QFileInfo::exists(resourceFilePath))
-            {
-                result = resourceFilePath;
-            }
+    return result;
+}
+
+// Search for the resource in the '../resources/[libraryName/]' directory
+// relative to the application directory.
+QString getResourcePathFromApplicationDirectory(QString filename, QString libraryName)
+{
+    QString result;
+    QString resourcesDirectory = getResourcesDirectoryFromApplicationDirectory(libraryName);
+
+    if (!resourcesDirectory.isEmpty())
+    {
+        QString resourceFilePath = QDir(resourcesDirectory).filePath(filename);
+
+        if (QFileInfo::exists(resourceFilePath))
+        {
+            result = resourceFilePath;
         }
     }
 
@@ -102,6 +150,19 @@ QString getResourcePathFromApplicationDirectory(QString filename, QString librar
 #endif
 
 } // namespace
+
+QString getExternalResourcesDirectory(QString libraryName)
+{
+    QString result;
+
+#if defined(Q_OS_MACOS)
+    result = getResourcesDirectoryForMacPackage(libraryName);
+#else
+    result = getResourcesDirectoryFromApplicationDirectory(libraryName);
+#endif
+
+    return result;
+}
 
 QString getExternalResourcePath(QString filename, QString libraryName)
 {

--- a/src/layers/legacy/medCoreLegacy/medExternalResources.h
+++ b/src/layers/legacy/medCoreLegacy/medExternalResources.h
@@ -16,8 +16,8 @@
 // using Qt's resources system. Sometimes though it is necessary (or preferable)
 // for resources to be placed in separate files. This can be done through the
 // add_external_resources macro of the cmake project. External resources are
-// stored differently depending on the OS, so this file provides a function to
-// retrieve the path of the resource in a platform-independant way.
+// stored differently depending on the OS, so this file provides functions to
+// retrieve the external resource paths in a platform-independant way.
 // NOTE: External Qt binary resources (rcc files) must also be registered using
 // QResource::registerResource(path_to_resource).
 
@@ -26,6 +26,11 @@
 
 namespace med
 {
+
+// Returns the directory containing the external resources for the project or
+// one of its libraries. A null string is returned if the directory does not
+// exist.
+QString getExternalResourcesDirectory(QString libraryName = QString());
 
 // Returns the path of an external resource that was added using
 // add_external_resources in the cmake project. If the resource was added


### PR DESCRIPTION
(based on https://github.com/medInria/medInria-public/pull/863)
commit: https://github.com/medInria/medInria-public/commit/e173ea6550c7158f4eb3c0544f03c9071e992a41

Fixes a crash that occurs when retrieving more than one external resource for a single target.