### PR TITLE
[medDoubleParameterL]: fix wrong (0,0) shown values when attributes has only one value for all mesh

### DIFF
--- a/src/layers/legacy/medCoreLegacy/parameters/medDoubleParameterL.cpp
+++ b/src/layers/legacy/medCoreLegacy/parameters/medDoubleParameterL.cpp
@@ -122,19 +122,16 @@ void medDoubleParameterL::setRange(double min, double max)
     d->min = min;
     d->max = max;
 
-    if(min != max)
+    if(d->spinBox)
     {
-        if(d->spinBox)
-        {
-            d->spinBox->setRange(min, max);
-        }
-        if(d->slider)
-        {
-            d->slider->setRange(0, convertToInt(max));
-        }
-
-        updateInternWigets();
+        d->spinBox->setRange(min, max);
     }
+    if(d->slider)
+    {
+        d->slider->setRange(0, convertToInt(max));
+    }
+
+    updateInternWigets();
 }
 
 void medDoubleParameterL::setSingleStep(double step)


### PR DESCRIPTION
- open test_mesh.vtk go to attributes Zones -> min and max intensity are at 0 but they should not the true value is 1
[test_mesh.zip](https://github.com/medInria/medInria-public/files/6692796/test_mesh.zip)
