### PR TITLE
[Mesh attribute range] Compute single step, fix memleak.

### DIFF
--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSet.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSet.cxx
@@ -721,12 +721,10 @@ void vtkMetaDataSet::SetScalarNullValue(const char * arrayName, double nullValue
 }
 
 //----------------------------------------------------------------------------
-double* vtkMetaDataSet::GetScalarRange(QString attributeName)
+void vtkMetaDataSet::GetScalarRange(double range[2], QString attributeName)
 {
-    // TODO: evil, and prone to memleak. Should pass the range array as parameter
-    double* val = new double[2];
-    val[0] = VTK_DOUBLE_MAX;
-    val[1] = VTK_DOUBLE_MIN;
+    range[0] = VTK_DOUBLE_MAX;
+    range[1] = VTK_DOUBLE_MIN;
 
     if (attributeName.trimmed().isEmpty())
     {
@@ -741,22 +739,20 @@ double* vtkMetaDataSet::GetScalarRange(QString attributeName)
     {
         if (this->GetDataSet()->GetPointData()->HasArray(qPrintable(attributeName)))
         {
-            this->GetDataSet()->GetPointData()->GetArray(qPrintable(attributeName))->GetRange(val);
+            this->GetDataSet()->GetPointData()->GetArray(qPrintable(attributeName))->GetRange(range);
         }
         else if (this->GetDataSet()->GetCellData()->HasArray(qPrintable(attributeName)))
         {
-            this->GetDataSet()->GetCellData()->GetArray(qPrintable(attributeName))->GetRange(val);
+            this->GetDataSet()->GetCellData()->GetArray(qPrintable(attributeName))->GetRange(range);
         }
     }
 
-    // if all values are null values, or if we don't have a current scalar array
-    if ( val[0] == VTK_DOUBLE_MAX || val[1] == VTK_DOUBLE_MIN )
+    // if all rangeues are null rangeues, or if we don't have a current scalar array
+    if ( range[0] == VTK_DOUBLE_MAX || range[1] == VTK_DOUBLE_MIN )
     {
-        val[0] = 0;
-        val[1] = 1;
+        range[0] = 0;
+        range[1] = 1;
     }
-
-    return val;
 }
 
 //----------------------------------------------------------------------------

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSet.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSet.cxx
@@ -747,7 +747,7 @@ void vtkMetaDataSet::GetScalarRange(double range[2], QString attributeName)
         }
     }
 
-    // if all rangeues are null rangeues, or if we don't have a current scalar array
+    // if any range is null, or if we don't have a current scalar array
     if ( range[0] == VTK_DOUBLE_MAX || range[1] == VTK_DOUBLE_MIN )
     {
         range[0] = 0;

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSet.h
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSet.h
@@ -349,7 +349,7 @@ class MEDVTKDATAMESHBASE_EXPORT vtkMetaDataSet: public vtkDataObject
   virtual double GetScalarNullValue(const char * arrayName);
   virtual void SetScalarNullValue(const char * arrayName, double nullValue);
 
-  virtual double* GetScalarRange(QString attributeName = QString());
+  virtual void GetScalarRange(double range[2], QString attributeName = QString(""));
 
 
   /**

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSetSequence.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSetSequence.cxx
@@ -486,23 +486,9 @@ void vtkMetaDataSetSequence::UpdateToIndex (unsigned int id)
 }
 
 //----------------------------------------------------------------------------
-double*vtkMetaDataSetSequence::GetCurrentScalarRange()
+void vtkMetaDataSetSequence::GetCurrentScalarRange(double range[2])
 {
-    double *val = new double[2];
-    val[0] = VTK_DOUBLE_MAX;
-    val[1] = VTK_DOUBLE_MIN;
-
-    for (unsigned int i=0; i<this->MetaDataSetList.size(); i++)
-    {
-        double *range = this->MetaDataSetList[i]->GetScalarRange();
-
-        if (val[0] > range[0])
-            val[0] = range[0];
-        if (val[1] < range[1])
-            val[1] = range[1];
-    }
-
-    return val;
+    GetScalarRange(range);
 }
 
 //----------------------------------------------------------------------------
@@ -711,26 +697,23 @@ void vtkMetaDataSetSequence::ComputeTimesFromDuration()
     }
 }
 
-double* vtkMetaDataSetSequence::GetScalarRange(QString attributeName)
+void vtkMetaDataSetSequence::GetScalarRange(double range[2], QString attributeName)
 {
-    // TODO: this is evil, would be better to pass the range as parameter
-    static double* val = new double[2];
-    val[0] = VTK_DOUBLE_MAX;
-    val[1] = VTK_DOUBLE_MIN;
+    double localRange[2];
+    range[0] = VTK_DOUBLE_MAX;
+    range[1] = VTK_DOUBLE_MIN;
 
-    for (unsigned int i = 0; i < this->MetaDataSetList.size(); i++)
+    for (auto* metaData : this->MetaDataSetList)
     {
-      double* range = this->MetaDataSetList[i]->GetScalarRange(attributeName);
+        metaData->GetScalarRange(localRange, attributeName);
 
-      if (val[0] > range[0])
-      {
-        val[0] = range[0];
-      }
-      if (val[1] < range[1])
-      {
-        val[1] = range[1];
-      }
+        if (range[0] > localRange[0])
+        {
+            range[0] = localRange[0];
+        }
+        if (range[1] < localRange[1])
+        {
+            range[1] = localRange[1];
+        }
     }
-
-    return val;
 }

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSetSequence.h
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaDataSetSequence.h
@@ -206,9 +206,9 @@ class MEDVTKDATAMESHBASE_EXPORT vtkMetaDataSetSequence: public vtkMetaDataSet
   */
   void CopyInformation (vtkMetaDataSet* metadataset) override;
 
-  virtual double* GetCurrentScalarRange();
+  virtual void GetCurrentScalarRange(double range[2]);
 
-  double* GetScalarRange(QString attributeName = QString()) override;
+  void GetScalarRange(double range[2], QString attributeName = QString("")) override;
 
   vtkGetMacro (CurrentId, int);
   

--- a/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
+++ b/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
@@ -449,7 +449,9 @@ void vtkDataMeshInteractor::setAttribute(const QString & attributeName)
         mapper3d->SelectColorArray(qPrintable(attributeName));
 
         d->poLutWidget->show();
-        double* range = d->metaDataSet->GetScalarRange(attributeName);
+
+        double range[2];
+        d->metaDataSet->GetScalarRange(range, attributeName);
 
         int dataType = d->attribute->GetDataType();
         initWindowLevelParameters(range, dataType);
@@ -487,7 +489,7 @@ void vtkDataMeshInteractor::initWindowLevelParameters(double * range, int dataTy
     int nbDecimals = 0;
     if (dataType == VTK_FLOAT || dataType == VTK_DOUBLE)
     {
-        singleStep = 0.1;
+        singleStep = (range[1] - range[0]) / 1000.0;
         nbDecimals = 6;
     }
     d->minIntensityParameter->setSingleStep(singleStep);
@@ -576,14 +578,14 @@ void vtkDataMeshInteractor::setLut(vtkLookupTable * lut)
     // remove the alpha channel from the LUT, it messes up the mesh
     if (lut)
     {
-        double values[4];
+        double values[4], range[2];
         for(int i = 0; i < lut->GetNumberOfTableValues(); i++)
         {
             lut->GetTableValue(i, values);
             values[3] = 1.0;
             lut->SetTableValue(i, values);
         }
-        double * range = d->metaDataSet->GetScalarRange(d->attributesParam->value());
+        d->metaDataSet->GetScalarRange(range, d->attributesParam->value());
         lut->SetRange(range);
     }
 


### PR DESCRIPTION
- Attribute single step is now computed from the values of the array, not fixed to 0.1
- Fix memleaks by changing the GetScalarRange method: now the range array is passed as parameter