### PR TITLE
Allow framework plugins and resources

### DIFF
--- a/src/cmake/module/set_plugin_install_rules.cmake
+++ b/src/cmake/module/set_plugin_install_rules.cmake
@@ -83,6 +83,8 @@ endif()
 install(TARGETS ${target}
   RUNTIME DESTINATION bin/plugins_legacy
   LIBRARY DESTINATION bin/plugins_legacy
+  FRAMEWORK DESTINATION bin/plugins_legacy
+  RESOURCE DESTINATION resources/${target}
   )
 endmacro()
 

--- a/src/layers/legacy/medCoreLegacy/medPluginManager.cpp
+++ b/src/layers/legacy/medCoreLegacy/medPluginManager.cpp
@@ -175,3 +175,16 @@ QStringList medPluginManager::loadErrors()
 {
     return d->loadErrors;
 }
+
+void medPluginManager::loadPlugin(const QString& path)
+{
+    QFileInfo pathInfo(path);
+    QString correctedPath = path;
+
+    if (pathInfo.isBundle())
+    {
+        correctedPath += "/" + pathInfo.baseName();
+    }
+
+    dtkPluginManager::loadPlugin(correctedPath);
+}

--- a/src/layers/legacy/medCoreLegacy/medPluginManager.h
+++ b/src/layers/legacy/medCoreLegacy/medPluginManager.h
@@ -38,6 +38,8 @@ public:
 
     QStringList loadErrors();
 
+    void loadPlugin(const QString& path) override;
+
 public slots:
     void onPluginLoaded(const QString& name);
 


### PR DESCRIPTION
I modified `set_plugin_install_rules` to allow using `add_external_resources` on plugins. When using this macro on macOS the library becomes a framework. This causes an issue when loading because QPluginLoader complains it can't find the shared library. To fix this we need to replace the framework path with the path to the library inside the framework (I don't know why QPluginLoader doesn't do this automatically).