### PR TITLE
[viewContainer] background and buttons by default without data

### DIFF
--- a/src/app/medInria/resources/medInria.qss
+++ b/src/app/medInria/resources/medInria.qss
@@ -1154,6 +1154,10 @@ medViewContainer [selected = "true"]
     border: $CONTAINER_SELECTED_BORDER;
 }
 
+QWidget#defaultWidget
+{
+    background: none;
+}
 
 /*******************************************************************************
      layerWidget
@@ -1211,15 +1215,6 @@ QLabel#previewLabel
     min-height: $STATUS_BAR_HEIGHT;
     border: 1px solid $GREY07;
     border-top: none;
-}
-
-/*******************************************************************************
-     medViewContainer
- *******************************************************************************/
-
-QWidget#defaultWidget
-{
-    background: none;
 }
 
 /*******************************************************************************

--- a/src/layers/legacy/medCoreLegacy/gui/medAbstractWorkspaceLegacy.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/medAbstractWorkspaceLegacy.cpp
@@ -562,21 +562,21 @@ void medAbstractWorkspaceLegacy::removeLayer()
     int layer = item->data(Qt::UserRole).toInt();
 
     medAbstractLayeredView *layerView = dynamic_cast<medAbstractLayeredView *>(medViewContainerManager::instance()->container(containerUuid)->view());
-    if(!layerView)
-        return;
-
-    layerView->removeLayer(layer);
-    if (layerView->layersCount() == 0)
+    if(layerView)
     {
-        if (medViewContainerManager::instance()->container(containerUuid)->closingMode()
-                == medViewContainer::CLOSE_CONTAINER)
+        layerView->removeLayer(layer);
+        if (layerView->layersCount() == 0)
         {
-            medViewContainerManager::instance()->container(containerUuid)->checkIfStillDeserveToLiveContainer();
-        }
-        else
-        {
-            // For containers that we want to keep even if there are no views/data in it, as in Filtering
-            medViewContainerManager::instance()->container(containerUuid)->removeView();
+            if (medViewContainerManager::instance()->container(containerUuid)->closingMode()
+                    == medViewContainer::CLOSE_CONTAINER)
+            {
+                medViewContainerManager::instance()->container(containerUuid)->checkIfStillDeserveToLiveContainer();
+            }
+            else
+            {
+                // For containers that we want to keep even if there are no views/data in it, as in Filtering
+                medViewContainerManager::instance()->container(containerUuid)->removeView();
+            }
         }
     }
 

--- a/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.h
+++ b/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.h
@@ -69,7 +69,14 @@ public:
     medViewContainer* splitHorizontally();
     medViewContainer* split(Qt::AlignmentFlag alignement = Qt::AlignRight);
 
-    void setDefaultWidget(QWidget *defaultWidget);
+    void changeDefaultWidget(QWidget *newDefaultWidget);
+
+    /**
+     * @brief In a view, switch between default widget (text and buttons to open data)
+     * with the data widget
+     * @param displayDefault
+     */
+    void displayDefaultWidget(bool displayDefault = true);
     QWidget* defaultWidget() const;
 
     void addColorIndicator(QColor color, QString description="");
@@ -140,8 +147,6 @@ protected:
     bool dropEventFromFile(QDropEvent * event);
 
     void closeEvent(QCloseEvent * event);
-
-    void recomputeStyleSheet();
 
     void open(const QString & path);
     void addMetadataToQDomElement(medAbstractData *data, QDomElement patientInfo, QString metadata);

--- a/src/layers/legacy/medCoreLegacy/views/medAbstractLayeredView.cpp
+++ b/src/layers/legacy/medCoreLegacy/views/medAbstractLayeredView.cpp
@@ -238,7 +238,6 @@ void medAbstractLayeredView::removeData(medAbstractData *data)
 
     if( res > 0 )
     {
-        emit layerRemoved(layer);
         emit layerRemoved(data);
     }
 }

--- a/src/layers/medWidgets/process/arithmetic_operation/medAbstractArithmeticOperationProcessPresenter.cpp
+++ b/src/layers/medWidgets/process/arithmetic_operation/medAbstractArithmeticOperationProcessPresenter.cpp
@@ -72,17 +72,31 @@ medViewContainerSplitter *medAbstractArithmeticOperationProcessPresenter::buildV
     medViewContainer * outputContainer = inputContainer1->splitVertically();
     medViewContainer* inputContainer2 = inputContainer1->splitHorizontally();
 
-    inputContainer1->setDefaultWidget(new QLabel("INPUT 1"));
+    auto viewLayout1 = static_cast<QVBoxLayout*>(inputContainer1->defaultWidget()->layout());
+    auto label1 = static_cast<QLabel*>(viewLayout1->itemAt(0)->widget());
+    if (!label1->text().contains("INPUT 1"))
+    {
+        label1->setText("INPUT 1\n\n"+label1->text());
+        label1->setAlignment(Qt::AlignCenter);
+    }
     inputContainer1->setClosingMode(medViewContainer::CLOSE_VIEW);
     inputContainer1->setUserSplittable(false);
     inputContainer1->setMultiLayered(false);
 
-    inputContainer2->setDefaultWidget(new QLabel("INPUT 2"));
+    auto viewLayout2 = static_cast<QVBoxLayout*>(inputContainer2->defaultWidget()->layout());
+    auto label2 = static_cast<QLabel*>(viewLayout2->itemAt(0)->widget());
+    if (!label2->text().contains("INPUT 2"))
+    {
+        label2->setText("INPUT 2\n\n"+label2->text());
+        label2->setAlignment(Qt::AlignCenter);
+    }
     inputContainer2->setClosingMode(medViewContainer::CLOSE_VIEW);
     inputContainer2->setUserSplittable(false);
     inputContainer2->setMultiLayered(false);
 
-    outputContainer->setDefaultWidget(new QLabel("OUTPUT"));
+    auto viewLayoutOutput = static_cast<QVBoxLayout*>(outputContainer->defaultWidget()->layout());
+    auto labelOutput = static_cast<QLabel*>(viewLayoutOutput->itemAt(0)->widget());
+    labelOutput->setText("OUTPUT");
     outputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
     outputContainer->setUserSplittable(false);
     outputContainer->setMultiLayered(false);

--- a/src/layers/medWidgets/process/diffusion_processes/medAbstractDWIMaskingProcessPresenter.cpp
+++ b/src/layers/medWidgets/process/diffusion_processes/medAbstractDWIMaskingProcessPresenter.cpp
@@ -77,12 +77,20 @@ medViewContainerSplitter *medAbstractDWIMaskingProcessPresenter::buildViewContai
 
     medViewContainer * outputContainer = inputContainer->splitVertically();
 
-    inputContainer->setDefaultWidget(new QLabel("Input DWI"));
+    auto viewLayoutInput = static_cast<QVBoxLayout*>(inputContainer->defaultWidget()->layout());
+    auto labelInput = static_cast<QLabel*>(viewLayoutInput->itemAt(0)->widget());
+    if (!labelInput->text().contains("Input DWI"))
+    {
+        labelInput->setText("Input DWI\n\n"+labelInput->text());
+        labelInput->setAlignment(Qt::AlignCenter);
+    }
     inputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
     inputContainer->setUserSplittable(false);
     inputContainer->setMultiLayered(false);
 
-    outputContainer->setDefaultWidget(new QLabel("Output mask"));
+    auto viewLayoutOutput = static_cast<QVBoxLayout*>(outputContainer->defaultWidget()->layout());
+    auto labelOutput = static_cast<QLabel*>(viewLayoutOutput->itemAt(0)->widget());
+    labelOutput->setText("Output mask");
     outputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
     outputContainer->setUserSplittable(false);
     outputContainer->setMultiLayered(false);

--- a/src/layers/medWidgets/process/diffusion_processes/medAbstractDiffusionModelEstimationProcessPresenter.cpp
+++ b/src/layers/medWidgets/process/diffusion_processes/medAbstractDiffusionModelEstimationProcessPresenter.cpp
@@ -127,7 +127,13 @@ medViewContainerSplitter *medAbstractDiffusionModelEstimationProcessPresenter::b
     medViewContainer *inputContainer = new medViewContainer;
     splitter->addViewContainer(inputContainer);
 
-    inputContainer->setDefaultWidget(new QLabel("Input DWI"));
+    auto viewLayout = static_cast<QVBoxLayout*>(inputContainer->defaultWidget()->layout());
+    auto label = static_cast<QLabel*>(viewLayout->itemAt(0)->widget());
+    if (!label->text().contains("Input DWI"))
+    {
+        label->setText("Input DWI\n\n"+label->text());
+        label->setAlignment(Qt::AlignCenter);
+    }
     inputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
     inputContainer->setUserSplittable(false);
     inputContainer->setMultiLayered(true);

--- a/src/layers/medWidgets/process/diffusion_processes/medAbstractDiffusionScalarMapsProcessPresenter.cpp
+++ b/src/layers/medWidgets/process/diffusion_processes/medAbstractDiffusionScalarMapsProcessPresenter.cpp
@@ -66,12 +66,20 @@ medViewContainerSplitter *medAbstractDiffusionScalarMapsProcessPresenter::buildV
 
     medViewContainer * outputContainer = inputContainer->splitVertically();
 
-    inputContainer->setDefaultWidget(new QLabel("Input model image"));
+    auto viewLayoutInput = static_cast<QVBoxLayout*>(inputContainer->defaultWidget()->layout());
+    auto labelInput = static_cast<QLabel*>(viewLayoutInput->itemAt(0)->widget());
+    if (!labelInput->text().contains("Input model image"))
+    {
+        labelInput->setText("Input model image\n\n"+labelInput->text());
+        labelInput->setAlignment(Qt::AlignCenter);
+    }
     inputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
     inputContainer->setUserSplittable(false);
     inputContainer->setMultiLayered(false);
 
-    outputContainer->setDefaultWidget(new QLabel("Output scalar map image"));
+    auto viewLayoutOutput = static_cast<QVBoxLayout*>(outputContainer->defaultWidget()->layout());
+    auto labelOutput = static_cast<QLabel*>(viewLayoutOutput->itemAt(0)->widget());
+    labelOutput->setText("Output scalar map image");
     outputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
     outputContainer->setUserSplittable(false);
     outputContainer->setMultiLayered(false);

--- a/src/layers/medWidgets/process/diffusion_processes/medAbstractTractographyProcessPresenter.cpp
+++ b/src/layers/medWidgets/process/diffusion_processes/medAbstractTractographyProcessPresenter.cpp
@@ -65,7 +65,13 @@ medViewContainerSplitter *medAbstractTractographyProcessPresenter::buildViewCont
     medViewContainer *inputContainer = new medViewContainer;
     splitter->addViewContainer(inputContainer);
 
-    inputContainer->setDefaultWidget(new QLabel("Input diffusion model"));
+    auto viewLayout = static_cast<QVBoxLayout*>(inputContainer->defaultWidget()->layout());
+    auto label = static_cast<QLabel*>(viewLayout->itemAt(0)->widget());
+    if (!label->text().contains("Input diffusion model"))
+    {
+        label->setText("Input diffusion model\n\n"+label->text());
+        label->setAlignment(Qt::AlignCenter);
+    }
     inputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
     inputContainer->setUserSplittable(false);
     inputContainer->setMultiLayered(true);

--- a/src/layers/medWidgets/process/diffusion_processes/medDiffusionModelEstimationMetaProcessPresenter.cpp
+++ b/src/layers/medWidgets/process/diffusion_processes/medDiffusionModelEstimationMetaProcessPresenter.cpp
@@ -139,7 +139,13 @@ medViewContainerSplitter *medDiffusionModelEstimationMetaProcessPresenter::build
     medViewContainer *inputContainer = new medViewContainer;
     splitter->addViewContainer(inputContainer);
 
-    inputContainer->setDefaultWidget(new QLabel("Input DWI"));
+    auto viewLayout = static_cast<QVBoxLayout*>(inputContainer->defaultWidget()->layout());
+    auto label = static_cast<QLabel*>(viewLayout->itemAt(0)->widget());
+    if (!label->text().contains("Input DWI"))
+    {
+        label->setText("Input DWI\n\n"+label->text());
+        label->setAlignment(Qt::AlignCenter);
+    }
     inputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
     inputContainer->setUserSplittable(false);
     inputContainer->setMultiLayered(true);

--- a/src/layers/medWidgets/process/mask_image/medAbstractMaskImageProcessPresenter.cpp
+++ b/src/layers/medWidgets/process/mask_image/medAbstractMaskImageProcessPresenter.cpp
@@ -73,17 +73,31 @@ medViewContainerSplitter *medAbstractMaskImageProcessPresenter::buildViewContain
     medViewContainer * outputContainer = inputContainer->splitVertically();
     medViewContainer * maskContainer = inputContainer->splitHorizontally();
 
-    inputContainer->setDefaultWidget(new QLabel("INPUT"));
+    auto viewLayoutInput = static_cast<QVBoxLayout*>(inputContainer->defaultWidget()->layout());
+    auto labelInput = static_cast<QLabel*>(viewLayoutInput->itemAt(0)->widget());
+    if (!labelInput->text().contains("INPUT"))
+    {
+        labelInput->setText("INPUT\n\n"+labelInput->text());
+        labelInput->setAlignment(Qt::AlignCenter);
+    }
     inputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
     inputContainer->setUserSplittable(false);
     inputContainer->setMultiLayered(false);
 
-    maskContainer->setDefaultWidget(new QLabel("MASK"));
+    auto viewLayoutMask = static_cast<QVBoxLayout*>(maskContainer->defaultWidget()->layout());
+    auto labelMask = static_cast<QLabel*>(viewLayoutMask->itemAt(0)->widget());
+    if (!labelMask->text().contains("MASK"))
+    {
+        labelMask->setText("MASK\n\n"+labelMask->text());
+        labelMask->setAlignment(Qt::AlignCenter);
+    }
     maskContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
     maskContainer->setUserSplittable(false);
     maskContainer->setMultiLayered(false);
 
-    outputContainer->setDefaultWidget(new QLabel("OUTPUT"));
+    auto viewLayoutOutput = static_cast<QVBoxLayout*>(outputContainer->defaultWidget()->layout());
+    auto labelOutput = static_cast<QLabel*>(viewLayoutOutput->itemAt(0)->widget());
+    labelOutput->setText("OUTPUT");
     outputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
     outputContainer->setUserSplittable(false);
     outputContainer->setMultiLayered(false);

--- a/src/layers/medWidgets/process/morphomath_operation/medAbstractMorphomathOperationProcessPresenter.cpp
+++ b/src/layers/medWidgets/process/morphomath_operation/medAbstractMorphomathOperationProcessPresenter.cpp
@@ -78,12 +78,20 @@ medViewContainerSplitter *medAbstractMorphomathOperationProcessPresenter::buildV
 
     medViewContainer * outputContainer = inputContainer->splitVertically();
 
-    inputContainer->setDefaultWidget(new QLabel("INPUT"));
+    auto viewLayoutInput = static_cast<QVBoxLayout*>(inputContainer->defaultWidget()->layout());
+    auto labelInput = static_cast<QLabel*>(viewLayoutInput->itemAt(0)->widget());
+    if (!labelInput->text().contains("INPUT"))
+    {
+        labelInput->setText("INPUT\n\n"+labelInput->text());
+        labelInput->setAlignment(Qt::AlignCenter);
+    }
     inputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
     inputContainer->setUserSplittable(false);
     inputContainer->setMultiLayered(false);
 
-    outputContainer->setDefaultWidget(new QLabel("OUTPUT"));
+    auto viewLayoutOutput = static_cast<QVBoxLayout*>(outputContainer->defaultWidget()->layout());
+    auto labelOutput = static_cast<QLabel*>(viewLayoutOutput->itemAt(0)->widget());
+    labelOutput->setText("OUTPUT");
     outputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
     outputContainer->setUserSplittable(false);
     outputContainer->setMultiLayered(false);

--- a/src/layers/medWidgets/process/single_filter/medAbstractSingleFilterOperationProcessPresenter.cpp
+++ b/src/layers/medWidgets/process/single_filter/medAbstractSingleFilterOperationProcessPresenter.cpp
@@ -78,12 +78,20 @@ medViewContainerSplitter *medAbstractSingleFilterOperationProcessPresenter::buil
 
     medViewContainer * outputContainer = inputContainer->splitVertically();
 
-    inputContainer->setDefaultWidget(new QLabel("INPUT"));
+    auto viewLayoutInput = static_cast<QVBoxLayout*>(inputContainer->defaultWidget()->layout());
+    auto labelInput = static_cast<QLabel*>(viewLayoutInput->itemAt(0)->widget());
+    if (!labelInput->text().contains("INPUT"))
+    {
+        labelInput->setText("INPUT\n\n"+labelInput->text());
+        labelInput->setAlignment(Qt::AlignCenter);
+    }
     inputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
     inputContainer->setUserSplittable(false);
     inputContainer->setMultiLayered(false);
 
-    outputContainer->setDefaultWidget(new QLabel("OUTPUT"));
+    auto viewLayoutOutput = static_cast<QVBoxLayout*>(outputContainer->defaultWidget()->layout());
+    auto labelOutput = static_cast<QLabel*>(viewLayoutOutput->itemAt(0)->widget());
+    labelOutput->setText("OUTPUT");
     outputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
     outputContainer->setUserSplittable(false);
     outputContainer->setMultiLayered(false);
@@ -91,7 +99,6 @@ medViewContainerSplitter *medAbstractSingleFilterOperationProcessPresenter::buil
 
     connect(inputContainer, &medViewContainer::dataAdded,
             this, &medAbstractSingleFilterOperationProcessPresenter::_setInputFromContainer);
-
 
     connect(this, SIGNAL(_outputImported(medAbstractData*)),
             outputContainer, SLOT(addData(medAbstractData*)),

--- a/src/plugins/legacy/medFilteringWorkspaceL/medFilteringWorkspaceL.cpp
+++ b/src/plugins/legacy/medFilteringWorkspaceL/medFilteringWorkspaceL.cpp
@@ -87,9 +87,13 @@ void medFilteringWorkspaceL::resetDefaultWidgetInputContainer()
 {
     if(selectorToolBox()) //null when users close the software
     {
-        QLabel *inputLabel = new QLabel("INPUT");
-        inputLabel->setAlignment(Qt::AlignCenter);
-        d->inputContainer->setDefaultWidget(inputLabel);
+        auto viewLayout = static_cast<QVBoxLayout*>(d->inputContainer->defaultWidget()->layout());
+        auto label = static_cast<QLabel*>(viewLayout->itemAt(0)->widget());
+        if (!label->text().contains("INPUT"))
+        {
+            label->setText("INPUT\n\n"+label->text());
+            label->setAlignment(Qt::AlignCenter);
+        }
         d->inputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
         d->inputContainer->setUserSplittable(false);
         d->inputContainer->setMultiLayered(false);
@@ -100,9 +104,9 @@ void medFilteringWorkspaceL::resetDefaultWidgetOutputContainer()
 {
     if(selectorToolBox()) //null when users close the software
     {
-        QLabel *outputLabel = new QLabel("OUTPUT");
-        outputLabel->setAlignment(Qt::AlignCenter);
-        d->outputContainer->setDefaultWidget(outputLabel);
+        auto viewLayout = static_cast<QVBoxLayout*>(d->outputContainer->defaultWidget()->layout());
+        auto label = static_cast<QLabel*>(viewLayout->itemAt(0)->widget());
+        label->setText("OUTPUT");
         d->outputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
         d->outputContainer->setUserSplittable(false);
         d->outputContainer->setMultiLayered(false);

--- a/src/plugins/legacy/medRegistrationWorkspace/medRegistrationWorkspace.cpp
+++ b/src/plugins/legacy/medRegistrationWorkspace/medRegistrationWorkspace.cpp
@@ -84,10 +84,13 @@ void medRegistrationWorkspace::resetDefaultWidgetFixedContainer()
 {
     if(selectorToolBox()) //null when users close the software
     {
-        QLabel *newDefaultLabel = new QLabel(tr("FIXED"));
-        newDefaultLabel->setAlignment(Qt::AlignCenter);
-        newDefaultLabel->setObjectName("defaultWidget");
-        d->containers[Fixed]->setDefaultWidget(newDefaultLabel);
+        auto viewLayout = static_cast<QVBoxLayout*>(d->containers[Fixed]->defaultWidget()->layout());
+        auto label = static_cast<QLabel*>(viewLayout->itemAt(0)->widget());
+        if (!label->text().contains("FIXED"))
+        {
+            label->setText("FIXED\n\n"+label->text());
+            label->setAlignment(Qt::AlignCenter);
+        }
         d->containers[Fixed]->setMultiLayered(false);
         d->containers[Fixed]->setUserSplittable(false);
         d->containers[Fixed]->setClosingMode(medViewContainer::CLOSE_VIEW);
@@ -98,10 +101,13 @@ void medRegistrationWorkspace::resetDefaultWidgetMovingContainer()
 {
     if(selectorToolBox()) //null when users close the software
     {
-        QLabel *newDefaultLabel = new QLabel(tr("MOVING"));
-        newDefaultLabel->setAlignment(Qt::AlignCenter);
-        newDefaultLabel->setObjectName("defaultWidget");
-        d->containers[Moving]->setDefaultWidget(newDefaultLabel);
+        auto viewLayout = static_cast<QVBoxLayout*>(d->containers[Moving]->defaultWidget()->layout());
+        auto label = static_cast<QLabel*>(viewLayout->itemAt(0)->widget());
+        if (!label->text().contains("MOVING"))
+        {
+            label->setText("MOVING\n\n"+label->text());
+            label->setAlignment(Qt::AlignCenter);
+        }
         d->containers[Moving]->setMultiLayered(false);
         d->containers[Moving]->setUserSplittable(false);
         d->containers[Moving]->setClosingMode(medViewContainer::CLOSE_VIEW);
@@ -112,10 +118,13 @@ void medRegistrationWorkspace::resetDefaultWidgetFuseContainer()
 {
     if(selectorToolBox()) //null when users close the software
     {
-        QLabel *newDefaultLabel = new QLabel(tr("FUSE"));
-        newDefaultLabel->setAlignment(Qt::AlignCenter);
-        newDefaultLabel->setObjectName("defaultWidget");
-        d->containers[Fuse]->setDefaultWidget(newDefaultLabel);
+        auto viewLayout = static_cast<QVBoxLayout*>(d->containers[Fuse]->defaultWidget()->layout());
+        auto label = static_cast<QLabel*>(viewLayout->itemAt(0)->widget());
+        if (!label->text().contains("FUSE"))
+        {
+            label->setText("FUSE\n\n"+label->text());
+            label->setAlignment(Qt::AlignCenter);
+        }
         d->containers[Fuse]->setUserSplittable(false);
         d->containers[Fuse]->setAcceptDrops(false); // only addition from the app
         d->containers[Fuse]->setClosingMode(medViewContainer::CLOSE_BUTTON_HIDDEN);

--- a/src/plugins/legacy/reformat/resliceToolBox.cpp
+++ b/src/plugins/legacy/reformat/resliceToolBox.cpp
@@ -193,7 +193,7 @@ void resliceToolBox::startReformat()
                 connect(d->resliceViewer,SIGNAL(imageReformatedGenerated()),this,SLOT(saveReformatedImage()));
                 medViewContainer * container = getWorkspace()->tabbedViewContainers()->insertNewTab(0, "Reslice");
                 getWorkspace()->tabbedViewContainers()->setCurrentIndex(0);
-                container->setDefaultWidget(d->resliceViewer->viewWidget());
+                container->changeDefaultWidget(d->resliceViewer->viewWidget());
                 connect(container, SIGNAL(viewRemoved()),this, SLOT(stopReformat()), Qt::UniqueConnection);
 
                 connect(d->spacingX, SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));


### PR DESCRIPTION
This PR:

 * fix https://github.com/medInria/medInria-public/issues/633 where we were loosing the default background color/buttons after removing a data in a view in fix containers workspace (Filtering, Registration for instance).
 * fix https://github.com/medInria/medInria-public/issues/912 where the Tools button were locked on an empty view in the same fix containers.
 * fix the "Unable to retrieve data at layer: 0 from: \"medVtkView\"" warning after removing a data

PS: this PR has been made on master branch since medInria3.2 was temporary not compiling on my side due to a change in pre-requisites, but these fixes are really interesting for med3.2 aswell.
 
:m: