### PR TITLE
Optional argument to workspace and toolbox creator functions

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/factories/medToolBoxFactory.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/factories/medToolBoxFactory.cpp
@@ -49,14 +49,16 @@ bool medToolBoxFactory::registerToolBox(QString identifier,
                                         QString name,
                                         QString description,
                                         QStringList categories,
-                                        medToolBoxCreator creator)
+                                        medToolBoxCreator creator,
+                                        void* creatorArgument)
 {
     if(!d->creators.contains(identifier))
     {
         medToolBoxDetails* holder = new medToolBoxDetails(name,
                                                           description,
                                                           categories,
-                                                          creator);
+                                                          creator,
+                                                          creatorArgument);
         d->creators.insert( identifier,
                             holder);
         return true;
@@ -93,7 +95,8 @@ medToolBox *medToolBoxFactory::createToolBox(QString identifier,
         return nullptr;
     }
 
-    medToolBox *toolbox = (d->creators[identifier])->creator(parent);
+    medToolBoxDetails* details = d->creators[identifier];
+    medToolBox *toolbox = details->creator(parent, details->creatorArgument);
 
     return toolbox;
 }

--- a/src/layers/legacy/medCoreLegacy/gui/factories/medToolBoxFactory.h
+++ b/src/layers/legacy/medCoreLegacy/gui/factories/medToolBoxFactory.h
@@ -47,7 +47,7 @@ class MEDCORELEGACY_EXPORT medToolBoxFactory : public dtkAbstractFactory
     Q_OBJECT
 
 public:
-    typedef medToolBox *(*medToolBoxCreator)(QWidget *parent);
+    typedef medToolBox *(*medToolBoxCreator)(QWidget *parent, void* argument);
 
 public:
     static medToolBoxFactory *instance();
@@ -69,9 +69,16 @@ public:
                                toolboxType::staticName(),
                                toolboxType::staticDescription(),
                                toolboxType::staticCategories(),
-                               creator);
+                               creator,
+                               nullptr);
     }
 
+    bool registerToolBox(QString identifier,
+                         QString name,
+                         QString description,
+                         QStringList categories,
+                         medToolBoxCreator creator,
+                         void* creatorArgument = nullptr);
 
     QList<QString> toolBoxesFromCategory(const QString& category) const;
     medToolBoxDetails* toolBoxDetailsFromId ( const QString& id ) const;
@@ -85,12 +92,6 @@ public slots:
 
 protected:
 
-    bool registerToolBox(QString identifier,
-                         QString name,
-                         QString description,
-                         QStringList categories,
-                         medToolBoxCreator creator);
-
      medToolBoxFactory();
     ~medToolBoxFactory();
 
@@ -102,7 +103,7 @@ private:
      * @warning keep it static if you don't want to freeze your brain (solution in http://www.parashift.com/c++-faq-lite/pointers-to-members.html#faq-33.5 for those interested)
      */
     template < typename T >
-    static medToolBox* create ( QWidget* parent ) {
+    static medToolBox* create(QWidget* parent, void* argument) {
     return ( new T(parent) );
     }
 private:
@@ -119,8 +120,9 @@ struct MEDCORELEGACY_EXPORT medToolBoxDetails{
     QString description; /** (tooltip) short description of the Toolbox */
     QStringList categories; /** List of categories the toolbox falls in*/
     medToolBoxFactory::medToolBoxCreator creator; /** function pointer allocating memory for the toolbox*/
+    void* creatorArgument;  /** Optional argument to the creator function*/
     medToolBoxDetails(QString name,QString description, QStringList categories,
-                     medToolBoxFactory::medToolBoxCreator creator):
+                     medToolBoxFactory::medToolBoxCreator creator, void* creatorArgument):
         name(name),description(description),categories(categories),
-        creator(creator){}
+        creator(creator), creatorArgument(creatorArgument){}
 };

--- a/src/layers/legacy/medCoreLegacy/gui/factories/medWorkspaceFactory.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/factories/medWorkspaceFactory.cpp
@@ -35,12 +35,13 @@ bool medWorkspaceFactory::registerWorkspace(QString identifier,
                                             QString description,
                                             QString category,
                                             medWorkspaceCreator creator,
+                                            void* creatorArgument,
                                             medWorkspaceIsUsable isUsable,
                                             bool isActive)
 {
     if(!d->creators.contains(identifier))
     {
-        medWorkspaceFactory::Details* holder = new medWorkspaceFactory::Details(identifier, name, description, category, creator, isUsable, isActive);
+        medWorkspaceFactory::Details* holder = new medWorkspaceFactory::Details(identifier, name, description, category, creator, creatorArgument, isUsable, isActive);
         d->creators.insert(identifier, holder);
         return true;
     }
@@ -69,7 +70,8 @@ medAbstractWorkspaceLegacy *medWorkspaceFactory::createWorkspace(QString type,QW
 
     try
     {
-        return d->creators[type]->creator(parent);
+        Details* details = d->creators[type];
+        return details->creator(parent, details->creatorArgument);
     }
     catch (const std::exception& e)
     {

--- a/src/layers/legacy/medCoreLegacy/gui/factories/medWorkspaceFactory.h
+++ b/src/layers/legacy/medCoreLegacy/gui/factories/medWorkspaceFactory.h
@@ -26,7 +26,7 @@ class MEDCORELEGACY_EXPORT medWorkspaceFactory : public dtkAbstractFactory
     Q_OBJECT
 
 public:
-    typedef medAbstractWorkspaceLegacy *(*medWorkspaceCreator)(QWidget* parent);
+    typedef medAbstractWorkspaceLegacy *(*medWorkspaceCreator)(QWidget* parent, void* argument);
     typedef bool (*medWorkspaceIsUsable)();
 
     struct Details
@@ -36,6 +36,7 @@ public:
         QString description;
         QString category;
         medWorkspaceCreator creator;
+        void* creatorArgument;
         medWorkspaceIsUsable isUsable;
         bool isActive;
         Details(QString id_,
@@ -43,6 +44,7 @@ public:
                 QString description_,
                 QString category_,
                 medWorkspaceCreator creator_,
+                void* creatorArgument_,
                 medWorkspaceIsUsable isUsable_ = nullptr,
                 bool isActive_ = true)
             : identifier(id_)
@@ -50,6 +52,7 @@ public:
             , description(description_)
             , category(category_)
             , creator(creator_)
+            , creatorArgument(creatorArgument_)
             , isUsable(isUsable_)
             , isActive(isActive_)
         {}
@@ -86,6 +89,7 @@ public:
                                  workspaceType::staticDescription(),
                                  workspaceType::staticCategory(),
                                  creator,
+                                 nullptr,
                                  workspaceType::isUsable,
                                  isActive);
     }
@@ -107,6 +111,7 @@ public:
                            QString description,
                            QString category,
                            medWorkspaceCreator creator,
+                           void* creatorArgument = nullptr,
                            medWorkspaceIsUsable isUsable = nullptr, bool isActive = true);
 
 
@@ -135,7 +140,7 @@ private:
      * @warning keep it static if you don't want to freeze your brain (solution in http://www.parashift.com/c++-faq-lite/pointers-to-members.html#faq-33.5 for those interested)
      */
     template < typename T >
-    static medAbstractWorkspaceLegacy* create ( QWidget* parent ) {
+    static medAbstractWorkspaceLegacy* create(QWidget* parent, void* argument) {
     return ( new T(parent) );
     }
 


### PR DESCRIPTION
The factory classes use functions pointers to create instances. SWIG cannot map Python functions to C function pointers, so it is not possible to register types from Python code the way it is done on the C++ side. As a workaround I created generic creator functions that take a pointer to a Python class and create an instance of that class. In order for that to work we need to add an (optional) argument to the creator functions.
(These changes should be extended to all the factories later on. I only did the ones needed for the pipeline plugin)