### PR TITLE
[VariationalSeg] solve crash avec 3D->2D view segmentation

### DIFF
--- a/src/plugins/legacy/voiCutter/voiCutterToolBox.cpp
+++ b/src/plugins/legacy/voiCutter/voiCutterToolBox.cpp
@@ -291,7 +291,7 @@ void voiCutterToolBox::activateButtons(bool param)
     if (!param)
     {
         // No valid data is in the container, or not in 3D
-        d->explanation->setText(tr("Drop a volume in the view, or switch the current one to 3D."));
+        d->explanation->setText(tr("Drop a volume in the view or switch the current one to 3D"));
         d->scissorButton->setEnabled(false);
     }
     else


### PR DESCRIPTION
Fix #919

This PR:
 * Change the display of the output at the end of the process in `VarSegToolBox::displayOutput()`, which was crashing with a 3D/2D view
 * Remove 2 non-used variable (mprOn was always set to false, and originalView not used if mprOn is set at false)
 * The `d->currentView->property("Orientation")` line created a warning since there are no Orientation property here
 * Handle `updateView` if the view is empty
 * The explanation text is smaller because it created a small graphic bug with the information button

:m: