### PR TITLE
Removed selection toolbox, refactored toolbox addition/removal

### DIFF
--- a/src/app/medInria/areas/browser/medBrowserArea.cpp
+++ b/src/app/medInria/areas/browser/medBrowserArea.cpp
@@ -141,13 +141,3 @@ void medBrowserArea::addDataSource( medAbstractDataSource* dataSource )
     }
     onSourceIndexChanged(d->stack->currentIndex());
 }
-
-void medBrowserArea::addToolBox(medToolBox *toolbox)
-{
-    d->toolboxContainer->addToolBox(toolbox);
-}
-
-void medBrowserArea::removeToolBox(medToolBox *toolbox)
-{
-    d->toolboxContainer->removeToolBox(toolbox);
-}

--- a/src/app/medInria/areas/browser/medBrowserArea.h
+++ b/src/app/medInria/areas/browser/medBrowserArea.h
@@ -32,19 +32,6 @@ public:
 public slots:
     void onSourceIndexChanged(int index);
 
-    /**
-* @brief Adds a medToolBox to the medToolBoxContainer.
-*
-* @param toolbox
-*/
-    void addToolBox(medToolBox *toolbox);
-    /**
-* @brief Removes a medToolBox from the medToolBoxContainer.
-*
-* @param toolbox
-*/
-    void removeToolBox(medToolBox *toolbox);
-
 protected:
     void setToolBoxesVisible(int index, bool visible);
     void addDataSource(medAbstractDataSource* dataSource);

--- a/src/app/medInria/areas/workspaces/medWorkspaceArea.cpp
+++ b/src/app/medInria/areas/workspaces/medWorkspaceArea.cpp
@@ -314,33 +314,6 @@ void medWorkspaceArea::runExportVideoProcess(medAbstractProcessLegacy *process, 
     process->setParameter(pixelListOfCurrentScreenshot.data(), screenshotCount);
 }
 
-void medWorkspaceArea::addToolBox(medToolBox *toolbox)
-{
-    if(!toolbox)
-        return;
-
-    d->toolBoxContainer->addToolBox(toolbox);
-    toolbox->show();
-}
-
-void medWorkspaceArea::insertToolBox(int index, medToolBox *toolbox)
-{
-    if(!toolbox)
-        return;
-
-    d->toolBoxContainer->insertToolBox(index, toolbox);
-    toolbox->show();
-}
-
-void medWorkspaceArea::removeToolBox(medToolBox *toolbox)
-{
-    if(!toolbox)
-        return;
-
-    toolbox->hide();
-    d->toolBoxContainer->removeToolBox(toolbox);
-}
-
 bool medWorkspaceArea::setCurrentWorkspace(medAbstractWorkspaceLegacy *workspace)
 {
     if (d->currentWorkspace == workspace)
@@ -354,10 +327,13 @@ bool medWorkspaceArea::setCurrentWorkspace(medAbstractWorkspaceLegacy *workspace
         }
     }
 
-    this->disconnect(this, SIGNAL(open(medDataIndex)), d->currentWorkspace, 0);
+    disconnect(this, SIGNAL(open(medDataIndex)), d->currentWorkspace, 0);
+    disconnect(d->currentWorkspace, nullptr, this, nullptr);
 
     d->currentWorkspace = workspace;
     connect(this, SIGNAL(open(medDataIndex)), d->currentWorkspace, SLOT(open(medDataIndex)));
+    connect(d->currentWorkspace, &medAbstractWorkspaceLegacy::toolBoxInserted, d->toolBoxContainer, &medToolBoxContainer::insertToolBox);
+    connect(d->currentWorkspace, &medAbstractWorkspaceLegacy::toolBoxRemoved, d->toolBoxContainer, &medToolBoxContainer::removeToolBox);
 
     //clean toolboxes
     d->toolBoxContainer->hide();
@@ -368,13 +344,9 @@ bool medWorkspaceArea::setCurrentWorkspace(medAbstractWorkspaceLegacy *workspace
     d->navigatorContainer->setVisible(workspace->isDatabaseVisible());
 
     // add toolboxes
-    d->toolBoxContainer->addToolBox(workspace->selectionToolBox());
-    workspace->selectionToolBox()->show();
-
     for(medToolBox * toolbox : workspace->toolBoxes())
     {
         d->toolBoxContainer->addToolBox(toolbox);
-        toolbox->show();
     }
     d->toolBoxContainer->setVisible(workspace->areToolBoxesVisible());
 

--- a/src/app/medInria/areas/workspaces/medWorkspaceArea.h
+++ b/src/app/medInria/areas/workspaces/medWorkspaceArea.h
@@ -58,10 +58,6 @@ public:
 
     bool setupWorkspace(const QString& id);
 
-    void addToolBox(medToolBox *toolbox);
-    void insertToolBox(int index, medToolBox *toolbox);
-    void removeToolBox(medToolBox *toolbox);
-
     bool setCurrentWorkspace(medAbstractWorkspaceLegacy* workspace);
     bool setCurrentWorkspace(const QString& id);
 

--- a/src/layers/legacy/medCoreLegacy/gui/medAbstractWorkspaceLegacy.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/medAbstractWorkspaceLegacy.cpp
@@ -49,12 +49,12 @@ public:
     QHash <QListWidgetItem*, QUuid> containerForLayerWidgetsItem;
 
     QList<medToolBox*> toolBoxes;
-    medToolBox *selectionToolBox;
     medToolBox *layersToolBox;
     medToolBox *layerListToolBox;
     medToolBox *interactorToolBox;
     medToolBox *navigatorToolBox;
     medToolBox *mouseInteractionToolBox;
+    medToolBox* progressionStackToolBox;
     medListWidget* layerListWidget;
 
     QList<QListWidgetItem*> selectedLayers;
@@ -73,11 +73,6 @@ medAbstractWorkspaceLegacy::medAbstractWorkspaceLegacy(QWidget *parent)
 {
     d->parent = parent;
 
-    d->selectionToolBox = new medToolBox(parent);
-    d->selectionToolBox->setTitle("Selection");
-    d->selectionToolBox->header()->hide();
-    d->selectionToolBox->hide();
-
     d->viewContainerStack = new medTabbedViewContainers(this, parent);
 
     connect(d->viewContainerStack, SIGNAL(containersSelectedChanged()), this, SLOT(updateNavigatorsToolBox()), Qt::UniqueConnection);
@@ -88,12 +83,12 @@ medAbstractWorkspaceLegacy::medAbstractWorkspaceLegacy(QWidget *parent)
     d->mouseInteractionToolBox = new medToolBox;
     d->mouseInteractionToolBox->setTitle("Mouse Interaction");
     d->mouseInteractionToolBox->hide();
-    d->selectionToolBox->addWidget(d->mouseInteractionToolBox);
+    addToolBox(d->mouseInteractionToolBox);
 
     d->navigatorToolBox = new medToolBox;
     d->navigatorToolBox->setTitle("View settings");
     d->navigatorToolBox->hide();
-    d->selectionToolBox->addWidget(d->navigatorToolBox);
+    addToolBox(d->navigatorToolBox);
 
     d->layersToolBox = new medToolBox;
     d->layersToolBox->setTitle("Layer settings");
@@ -107,10 +102,13 @@ medAbstractWorkspaceLegacy::medAbstractWorkspaceLegacy(QWidget *parent)
     d->interactorToolBox->header()->hide();
     d->layersToolBox->addWidget(d->interactorToolBox);
 
-    d->selectionToolBox->addWidget(d->layersToolBox);
+    addToolBox(d->layersToolBox);
 
     d->progressionStack = new medProgressionStack();
-    d->selectionToolBox->addWidget(d->progressionStack);
+    d->progressionStackToolBox = new medToolBox;
+    d->progressionStackToolBox->header()->hide();
+    d->progressionStackToolBox->addWidget(d->progressionStack);
+    addToolBox(d->progressionStackToolBox);
 
     d->layerListToolBox->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 
@@ -134,26 +132,27 @@ medAbstractWorkspaceLegacy::~medAbstractWorkspaceLegacy(void)
 
 void medAbstractWorkspaceLegacy::addToolBox(medToolBox *toolbox)
 {
-    toolbox->setWorkspace(this);
-    d->toolBoxes.append(toolbox);
-    d->selectionToolBox->addWidget(toolbox);
+    insertToolBox(toolBoxes().count(), toolbox);
 }
 
-void medAbstractWorkspaceLegacy::removeToolBox(medToolBox *toolbox)
+ void medAbstractWorkspaceLegacy::insertToolBox(int index, medToolBox* toolbox)
+{
+    toolbox->setWorkspace(this);
+    toolbox->setParent(d->parent);
+    d->toolBoxes.insert(index, toolbox);
+    emit toolBoxInserted(index, toolbox);
+ }
+
+ void medAbstractWorkspaceLegacy::removeToolBox(medToolBox *toolbox)
 {
     toolbox->setWorkspace(nullptr);
     d->toolBoxes.removeOne(toolbox);
-    d->selectionToolBox->removeWidget(toolbox);
+    emit toolBoxRemoved(toolbox);
 }
 
 QList<medToolBox*> medAbstractWorkspaceLegacy::toolBoxes() const
 {
     return d->toolBoxes;
-}
-
-medToolBox* medAbstractWorkspaceLegacy::selectionToolBox() const
-{
-    return d->selectionToolBox;
 }
 
 void medAbstractWorkspaceLegacy::setDatabaseVisibility(bool visibility)
@@ -171,12 +170,25 @@ medTabbedViewContainers* medAbstractWorkspaceLegacy::tabbedViewContainers() cons
     return d->viewContainerStack;
 }
 
-void medAbstractWorkspaceLegacy::clear()
+medToolBox* medAbstractWorkspaceLegacy::getMouseInteractionToolBox() const
+ {
+     return d->mouseInteractionToolBox;
+ }
+
+medToolBox* medAbstractWorkspaceLegacy::getNavigatorToolBox() const
 {
-    this->setupTabbedViewContainer();
-    this->clearWorkspaceToolBoxes();
-    return;
+    return d->navigatorToolBox;
 }
+
+medToolBox* medAbstractWorkspaceLegacy::getLayersToolBox() const
+ {
+     return d->layersToolBox;
+ }
+
+ medToolBox* medAbstractWorkspaceLegacy::getProgressionStackToolBox() const
+ {
+     return d->progressionStackToolBox;
+ }
 
 void medAbstractWorkspaceLegacy::setupTabbedViewContainer()
 {
@@ -196,14 +208,6 @@ void medAbstractWorkspaceLegacy::setToolBoxesVisibility (bool value)
 bool medAbstractWorkspaceLegacy::areToolBoxesVisible() const
 {
     return d->toolBoxesVisibility;
-}
-
-void medAbstractWorkspaceLegacy::clearWorkspaceToolBoxes()
-{
-    for(medToolBox* tb : d->toolBoxes)
-    {
-        tb->body()->clear();
-    }
 }
 
 void medAbstractWorkspaceLegacy::addNewTab()
@@ -406,7 +410,7 @@ void medAbstractWorkspaceLegacy::updateLayersToolBox()
                 }
 
                 layerWidget->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed);
-                layerWidget->resize(d->selectionToolBox->sizeHint().width(), 25);
+                layerWidget->resize(d->layersToolBox->sizeHint().width(), 25);
 
                 QListWidgetItem * item = new QListWidgetItem;
                 item->setData(Qt::UserRole, layer);

--- a/src/layers/legacy/medCoreLegacy/gui/medAbstractWorkspaceLegacy.h
+++ b/src/layers/legacy/medCoreLegacy/gui/medAbstractWorkspaceLegacy.h
@@ -61,13 +61,17 @@ public:
     virtual QString category() const =0;
 
     QList <medToolBox*> toolBoxes() const;
-    medToolBox* selectionToolBox() const;
     void setDatabaseVisibility(bool);
     bool isDatabaseVisible() const;
     void setToolBoxesVisibility(bool);
     bool areToolBoxesVisible() const;
     virtual void setupTabbedViewContainer();
     medTabbedViewContainers * tabbedViewContainers() const;
+
+    medToolBox* getMouseInteractionToolBox() const;
+    medToolBox* getNavigatorToolBox() const;
+    medToolBox* getLayersToolBox() const;
+    medToolBox* getProgressionStackToolBox() const;
 
     void setUserLayerPoolable(bool poolable);
     void setUserViewPoolable(bool poolable);
@@ -82,14 +86,13 @@ public:
     medProgressionStack *getProgressionStack();
 
 public slots:
-    virtual void clear();
     virtual void addNewTab();
     void updateNavigatorsToolBox();
     void updateMouseInteractionToolBox();
     void updateLayersToolBox();
     void updateInteractorsToolBox();
-    void clearWorkspaceToolBoxes();
     void addToolBox(medToolBox *toolbox);
+    void insertToolBox(int index, medToolBox* toolbox);
     void removeToolBox(medToolBox *toolbox);
 
     virtual void open(const medDataIndex& index);
@@ -125,6 +128,8 @@ private slots:
 
 signals:
     void layerSelectionChanged(QList<int> selectedLayersIndices);
+    void toolBoxInserted(int index, medToolBox* toolbox);
+    void toolBoxRemoved(medToolBox* toolbox);
 
 private:
     QWidget* buildViewLinkMenu();

--- a/src/layers/legacy/medCoreLegacy/gui/medToolBoxContainer.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/medToolBoxContainer.cpp
@@ -57,10 +57,10 @@ void medToolBoxContainer::insertToolBox(int index, medToolBox* toolBox)
     if (toolBox)
     {
         d->toolboxes.insert(index, toolBox);
-        toolBox->setParent(d->container);
         d->layout->setStretch(d->layout->count()-1, 0);
         d->layout->insertWidget(index, toolBox, 0, Qt::AlignTop);
         d->layout->addStretch(1);
+        toolBox->show();
     }
 }
 

--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medToolBox.h
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medToolBox.h
@@ -83,21 +83,6 @@ public:
 
 signals:
     /**
-     * @brief Tells the world to add a new toolbox to the medToolboxContainer.
-     * Typically used when a generic toolbox adds a custom toolbox.
-     *
-     * @param toolbox
-    */
-    void addToolBox(medToolBox *toolbox);
-
-    /**
-     * @brief Tells the world to remove a toolbox from the medToolBoxContainer.
-     *
-     * @param toolbox
-    */
-    void removeToolBox(medToolBox *toolbox);
-
-    /**
      * @brief Emitted when an action from the toolbox succeeded.
      * Typically used when a dtkProcess returned.
      *


### PR DESCRIPTION
This PR makes changes to improve the way toolboxes are added and removed from workspaces, and to give more control over the default toolboxes:

- Remove the "selection" toolbox which serves no purpose except to group the toolboxes into one parent toolbox.
- Place the progression stack widget into its own toolbox.
- Add getters for the default toolboxes (mouse interaction, navigator, layers, progression stack)
- Remove unused methods to add and remove toolboxes in `medBrowserArea`, `medWorkspaceArea` and `medToolBox`, and keep only the ones in `medAbstractWorkspaceLegacy` (and add an `insertToolBox` method to mirror the one in `medToolBoxContainer`).
- Use signal/slot mechanics to connect the methods to `medToolBoxContainer`.
- Properly disconnect the workspaces from all signals when switching workspaces.
- Remove `clear` and `clearWorkspaceToolBoxes` (not used and not needed)