### PR TITLE
add "shallow" loading option when retrieving data

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medAbstractDbController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medAbstractDbController.h
@@ -48,7 +48,7 @@ signals:
     void dataRemoved(const medDataIndex& index);
 
 public slots:
-    virtual medAbstractData* retrieve(const medDataIndex& index, bool fullData) const = 0;
+    virtual medAbstractData* retrieve(const medDataIndex& index, bool readFullData = true) const = 0;
 
     virtual void importData(medAbstractData* data, const QUuid& importUuid) = 0;
     virtual void importPath(const QString& file, const QUuid& importUuid, bool indexWithoutCopying) = 0;

--- a/src/layers/legacy/medCoreLegacy/database/medAbstractDbController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medAbstractDbController.h
@@ -48,7 +48,7 @@ signals:
     void dataRemoved(const medDataIndex& index);
 
 public slots:
-    virtual medAbstractData* retrieve(const medDataIndex& index) const = 0;
+    virtual medAbstractData* retrieve(const medDataIndex& index, bool fullData) const = 0;
 
     virtual void importData(medAbstractData* data, const QUuid& importUuid) = 0;
     virtual void importPath(const QString& file, const QUuid& importUuid, bool indexWithoutCopying) = 0;

--- a/src/layers/legacy/medCoreLegacy/database/medDataManager.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDataManager.cpp
@@ -94,7 +94,19 @@ medDataManager * medDataManager::instance()
     return s_instance;
 }
 
-medAbstractData* medDataManager::retrieveData(const medDataIndex& index, bool fullData)
+medAbstractData* medDataManager::retrieveData(const medDataIndex& index)
+{
+    return retrieveData(index, true);
+}
+
+const QMetaObject* medDataManager::getDataType(const medDataIndex& index)
+{
+    medAbstractData* data = retrieveData(index, false);
+
+    return data ? data->metaObject() : nullptr;
+}
+
+medAbstractData* medDataManager::retrieveData(const medDataIndex& index, bool readFullData)
 {
     Q_D(medDataManager);
     QMutexLocker locker(&(d->mutex));
@@ -110,15 +122,15 @@ medAbstractData* medDataManager::retrieveData(const medDataIndex& index, bool fu
 
     // No existing ref, we need to load from the file DB, then the non-persistent DB
     if (d->dbController->contains(index)) {
-        dataObjRef = d->dbController->retrieve(index, fullData);
+        dataObjRef = d->dbController->retrieve(index, readFullData);
     } else if(d->nonPersDbController->contains(index)) {
-        dataObjRef = d->nonPersDbController->retrieve(index, fullData);
+        dataObjRef = d->nonPersDbController->retrieve(index, readFullData);
     }
 
     if (dataObjRef) {
         dataObjRef->setDataIndex(index);
 
-        if (fullData)
+        if (readFullData)
         {
             d->loadedDataObjectTracker.insert(index, dataObjRef);
         }

--- a/src/layers/legacy/medCoreLegacy/database/medDataManager.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDataManager.cpp
@@ -94,7 +94,7 @@ medDataManager * medDataManager::instance()
     return s_instance;
 }
 
-medAbstractData* medDataManager::retrieveData(const medDataIndex& index)
+medAbstractData* medDataManager::retrieveData(const medDataIndex& index, bool fullData)
 {
     Q_D(medDataManager);
     QMutexLocker locker(&(d->mutex));
@@ -110,15 +110,18 @@ medAbstractData* medDataManager::retrieveData(const medDataIndex& index)
 
     // No existing ref, we need to load from the file DB, then the non-persistent DB
     if (d->dbController->contains(index)) {
-        dataObjRef = d->dbController->retrieve(index);
+        dataObjRef = d->dbController->retrieve(index, fullData);
     } else if(d->nonPersDbController->contains(index)) {
-        dataObjRef = d->nonPersDbController->retrieve(index);
+        dataObjRef = d->nonPersDbController->retrieve(index, fullData);
     }
 
     if (dataObjRef) {
         dataObjRef->setDataIndex(index);
 
-        d->loadedDataObjectTracker.insert(index, dataObjRef);
+        if (fullData)
+        {
+            d->loadedDataObjectTracker.insert(index, dataObjRef);
+        }
         return dataObjRef;
     }
     return nullptr;

--- a/src/layers/legacy/medCoreLegacy/database/medDataManager.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDataManager.h
@@ -35,7 +35,7 @@ public:
     static void initialize();
     static medDataManager * instance();
 
-    medAbstractData* retrieveData(const medDataIndex& index);
+    medAbstractData* retrieveData(const medDataIndex& index, bool fullData = true);
 
     QHash<QString, dtkAbstractDataWriter*> getPossibleWriters(medAbstractData* data);
 

--- a/src/layers/legacy/medCoreLegacy/database/medDataManager.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDataManager.h
@@ -35,7 +35,9 @@ public:
     static void initialize();
     static medDataManager * instance();
 
-    medAbstractData* retrieveData(const medDataIndex& index, bool fullData = true);
+    medAbstractData* retrieveData(const medDataIndex& index);
+
+    const QMetaObject* getDataType(const medDataIndex& index);
 
     QHash<QString, dtkAbstractDataWriter*> getPossibleWriters(medAbstractData* data);
 
@@ -87,6 +89,8 @@ protected:
 private:
     medDataManager();
     virtual ~medDataManager();
+
+    medAbstractData* retrieveData(const medDataIndex& index, bool readFullData);
 
     static medDataManager * s_instance;
     void launchExporter(medDatabaseExporter* exporter, const QString & filename);

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseController.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseController.cpp
@@ -998,7 +998,7 @@ bool medDatabaseController::contains(const medDataIndex &index) const
     return false;
 }
 
-medAbstractData* medDatabaseController::retrieve(const medDataIndex &index, bool fullData) const
+medAbstractData* medDatabaseController::retrieve(const medDataIndex &index, bool readFullData) const
 {
     QScopedPointer<medDatabaseReader> reader(new medDatabaseReader(index));
     medMessageProgress *message = medMessageController::instance()->showProgress("Opening database item");
@@ -1010,7 +1010,7 @@ medAbstractData* medDatabaseController::retrieve(const medDataIndex &index, bool
     connect(reader.data(), SIGNAL(failure(QObject *)), this, SLOT(showOpeningError(QObject *)));
 
     medAbstractData* data;
-    reader->setFullDataMode(fullData);
+    reader->setReadMode(readFullData ? medDatabaseReader::READ_ALL : medDatabaseReader::READ_INFORMATION);
     data = reader->run();
     return data;
 }

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseController.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseController.cpp
@@ -998,7 +998,7 @@ bool medDatabaseController::contains(const medDataIndex &index) const
     return false;
 }
 
-medAbstractData* medDatabaseController::retrieve(const medDataIndex &index) const
+medAbstractData* medDatabaseController::retrieve(const medDataIndex &index, bool fullData) const
 {
     QScopedPointer<medDatabaseReader> reader(new medDatabaseReader(index));
     medMessageProgress *message = medMessageController::instance()->showProgress("Opening database item");
@@ -1010,6 +1010,7 @@ medAbstractData* medDatabaseController::retrieve(const medDataIndex &index) cons
     connect(reader.data(), SIGNAL(failure(QObject *)), this, SLOT(showOpeningError(QObject *)));
 
     medAbstractData* data;
+    reader->setFullDataMode(fullData);
     data = reader->run();
     return data;
 }

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseController.h
@@ -72,7 +72,7 @@ public:
 
 public slots:
 
-    medAbstractData *retrieve(const medDataIndex &index) const;
+    medAbstractData *retrieve(const medDataIndex &index, bool fullData = true) const;
 
     void importPath(const QString& file, const QUuid& importUuid, bool indexWithoutCopying = false);
     void importData(medAbstractData *data, const QUuid & importUuid);

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseController.h
@@ -72,7 +72,7 @@ public:
 
 public slots:
 
-    medAbstractData *retrieve(const medDataIndex &index, bool fullData = true) const;
+    medAbstractData *retrieve(const medDataIndex &index, bool readFullData = true) const;
 
     void importPath(const QString& file, const QUuid& importUuid, bool indexWithoutCopying = false);
     void importData(medAbstractData *data, const QUuid & importUuid);

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseNonPersistentController.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseNonPersistentController.cpp
@@ -585,7 +585,7 @@ medDataIndex medDatabaseNonPersistentController::moveSeries(const medDataIndex& 
     return newIndex;
 }
 
-medAbstractData* medDatabaseNonPersistentController::retrieve(const medDataIndex& index) const
+medAbstractData* medDatabaseNonPersistentController::retrieve(const medDataIndex& index, bool fullData) const
 {
     // Lookup item in hash table.
     medDatabaseNonPersistentControllerPrivate::DataHashMapType::const_iterator it( d->items.find(index) );

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseNonPersistentController.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseNonPersistentController.cpp
@@ -585,7 +585,7 @@ medDataIndex medDatabaseNonPersistentController::moveSeries(const medDataIndex& 
     return newIndex;
 }
 
-medAbstractData* medDatabaseNonPersistentController::retrieve(const medDataIndex& index, bool fullData) const
+medAbstractData* medDatabaseNonPersistentController::retrieve(const medDataIndex& index, bool readFullData) const
 {
     // Lookup item in hash table.
     medDatabaseNonPersistentControllerPrivate::DataHashMapType::const_iterator it( d->items.find(index) );

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseNonPersistentController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseNonPersistentController.h
@@ -60,7 +60,7 @@ public:
     virtual bool setMetaData(const medDataIndex& index, const QString& key, const QString& value);
 
 public slots:
-    virtual medAbstractData* retrieve(const medDataIndex& index, bool fullData = true) const;
+    virtual medAbstractData* retrieve(const medDataIndex& index, bool readFullData = true) const;
 
     void importData(medAbstractData *data, const QUuid & callerUuid);
     void importPath(const QString& file, const QUuid & callerUuid, bool indexWithoutCopying);

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseNonPersistentController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseNonPersistentController.h
@@ -60,7 +60,7 @@ public:
     virtual bool setMetaData(const medDataIndex& index, const QString& key, const QString& value);
 
 public slots:
-    virtual medAbstractData* retrieve(const medDataIndex& index) const;
+    virtual medAbstractData* retrieve(const medDataIndex& index, bool fullData = true) const;
 
     void importData(medAbstractData *data, const QUuid & callerUuid);
     void importPath(const QString& file, const QUuid & callerUuid, bool indexWithoutCopying);

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
@@ -27,11 +27,13 @@ class medDatabaseReaderPrivate
 {
 public:
     medDataIndex index;
+    bool fullDataMode;
 };
 
 medDatabaseReader::medDatabaseReader ( const medDataIndex& index ) : QObject(), d ( new medDatabaseReaderPrivate )
 {
     d->index = index;
+    d->fullDataMode = true;
 }
 
 medDatabaseReader::~medDatabaseReader()
@@ -39,6 +41,16 @@ medDatabaseReader::~medDatabaseReader()
     delete d;
 
     d = nullptr;
+}
+
+void medDatabaseReader::setFullDataMode(bool value)
+{
+    d->fullDataMode = value;
+}
+
+bool medDatabaseReader::fullDataMode()
+{
+    return d->fullDataMode;
 }
 
 #define FAILURE(msg) do {qDebug() <<  "medDatabaseReader::run: "<<(msg);emit failure(this);return nullptr;} while(0)
@@ -224,7 +236,14 @@ medAbstractData *medDatabaseReader::readFile( const QStringList& filenames )
         connect ( dataReader, SIGNAL ( progressed ( int ) ), this, SIGNAL ( progressed ( int ) ) );
         if ( dataReader->canRead ( filenames ) )
         {
-            dataReader->read ( filenames );
+            if (!d->fullDataMode)
+            {
+                dataReader->readInformation(filenames);
+            }
+            else
+            {
+                dataReader->read(filenames);
+            }
             dataReader->enableDeferredDeletion ( false );
             medData = dynamic_cast<medAbstractData*>(dataReader->data());
 

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
@@ -27,13 +27,13 @@ class medDatabaseReaderPrivate
 {
 public:
     medDataIndex index;
-    bool fullDataMode;
+    medDatabaseReader::ReadMode readMode;
 };
 
 medDatabaseReader::medDatabaseReader ( const medDataIndex& index ) : QObject(), d ( new medDatabaseReaderPrivate )
 {
     d->index = index;
-    d->fullDataMode = true;
+    d->readMode = READ_ALL;
 }
 
 medDatabaseReader::~medDatabaseReader()
@@ -43,14 +43,14 @@ medDatabaseReader::~medDatabaseReader()
     d = nullptr;
 }
 
-void medDatabaseReader::setFullDataMode(bool value)
+void medDatabaseReader::setReadMode(ReadMode readMode)
 {
-    d->fullDataMode = value;
+    d->readMode = readMode;
 }
 
-bool medDatabaseReader::fullDataMode()
+medDatabaseReader::ReadMode medDatabaseReader::getReadMode() const
 {
-    return d->fullDataMode;
+    return d->readMode;
 }
 
 #define FAILURE(msg) do {qDebug() <<  "medDatabaseReader::run: "<<(msg);emit failure(this);return nullptr;} while(0)
@@ -236,7 +236,7 @@ medAbstractData *medDatabaseReader::readFile( const QStringList& filenames )
         connect ( dataReader, SIGNAL ( progressed ( int ) ), this, SIGNAL ( progressed ( int ) ) );
         if ( dataReader->canRead ( filenames ) )
         {
-            if (!d->fullDataMode)
+            if (d->readMode == READ_INFORMATION)
             {
                 dataReader->readInformation(filenames);
             }

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.h
@@ -27,17 +27,19 @@ class MEDCORELEGACY_EXPORT medDatabaseReader : public QObject
     Q_OBJECT
 
 public:
+    enum ReadMode
+    {
+        READ_ALL,
+        READ_INFORMATION
+    };
+
     medDatabaseReader(const medDataIndex& index);
     ~medDatabaseReader();
 
-    void setFullDataMode(bool value);
-    bool fullDataMode();
+    void setReadMode(ReadMode readMode);
+    ReadMode getReadMode() const;
 
     medAbstractData *run();
-
-    QString getFilePath();
-
-    qint64 getDataSize();
 
 protected:
     medAbstractData* readFile(const QStringList& filenames);

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.h
@@ -30,6 +30,9 @@ public:
     medDatabaseReader(const medDataIndex& index);
     ~medDatabaseReader();
 
+    void setFullDataMode(bool value);
+    bool fullDataMode();
+
     medAbstractData *run();
 
     QString getFilePath();


### PR DESCRIPTION
_(edited after refactoring)_

This adds the possibility to get information on the type of a data in the database. This is done by adding a `medDataManager::getDataType` method that returns the `QMetaObject` instance of the data class. In order for this to work I have added an option in the DB loading mechanism that retrieves empty `medAbstractData` instances (the actual data is not loaded, only the `dtkAbstractDataReader::readInformation` method is used to obtain the instance.