### PR TITLE
[medStatusBar] removal of wrong message

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/commonWidgets/medStatusBar.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/commonWidgets/medStatusBar.cpp
@@ -149,7 +149,7 @@ void medStatusBar::removeMessage ( medMessage* message )
     d->acccessMutex.lock();
     if ( message )
     {
-        d->messageList.removeFirst();
+        d->messageList.removeOne(message);
         d->availableSpace += (message->size().width()+d->statusBarLayout->spacing());         //update available space
         d->statusBarLayout->removeWidget(message);
         showHiddenMessage();    //space has been freed


### PR DESCRIPTION
`medStatusBar::removeMessage` assumes the message being removed is the first on the list. This is not always the case and causes a crash when it happens because the deleted message is still on the stack.