### PR TITLE
[ClutEditor] rm warning with QGraphicsItem and QObject

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/lookUpTables/medClutEditor.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/lookUpTables/medClutEditor.cpp
@@ -52,7 +52,7 @@ public:
 
 medClutEditorVertex::medClutEditorVertex(QPointF value, QPointF coord,
                                          QColor color, QGraphicsItem * parent)
-    : QObject(), QGraphicsItem(parent)
+    : QGraphicsObject(parent)
 {
     d = new medClutEditorVertexPrivate;
     d->value = value;
@@ -91,7 +91,7 @@ medClutEditorVertex::medClutEditorVertex(QPointF value, QPointF coord,
 
 medClutEditorVertex::medClutEditorVertex( const medClutEditorVertex & other,
                                           QGraphicsItem * parent)
-    : QObject(), QGraphicsItem( parent )
+    : QGraphicsObject( parent )
 {
     if ( parent == nullptr )
     {
@@ -431,7 +431,7 @@ public:
 
 medClutEditorTable::medClutEditorTable(const QString & title,
                                        QGraphicsItem *parent)
-    :QObject(), QGraphicsItem(parent)
+    : QGraphicsObject(parent)
 {
     d = new medClutEditorTablePrivate;
     d->title = title;
@@ -444,7 +444,7 @@ medClutEditorTable::medClutEditorTable(const QString & title,
 }
 
 medClutEditorTable::medClutEditorTable(const medClutEditorTable & table)
-    :QObject(),  QGraphicsItem( static_cast< QGraphicsItem *>( table.parentItem() ) )
+    : QGraphicsObject( static_cast< QGraphicsItem *>( table.parentItem() ) )
 {
     d = new medClutEditorTablePrivate;
     d->title = table.title();

--- a/src/layers/legacy/medCoreLegacy/gui/lookUpTables/medClutEditor.h
+++ b/src/layers/legacy/medCoreLegacy/gui/lookUpTables/medClutEditor.h
@@ -12,6 +12,7 @@
 
 =========================================================================*/
 
+#include <QGraphicsObject>
 #include <QtGui>
 #include <QtWidgets>
 
@@ -26,8 +27,7 @@ class medAbstractImageView;
 
 class medClutEditorVertexPrivate;
 
-// TODO use QGraphicsObjectItem noobs.
-class MEDCORELEGACY_EXPORT medClutEditorVertex : public QObject, public QGraphicsItem
+class MEDCORELEGACY_EXPORT medClutEditorVertex : public QGraphicsObject
 {
     Q_OBJECT
 
@@ -81,7 +81,7 @@ private :
 // /////////////////////////////////////////////////////////////////
 class medClutEditorTablePrivate;
 
-class MEDCORELEGACY_EXPORT medClutEditorTable : public QObject, public QGraphicsItem
+class MEDCORELEGACY_EXPORT medClutEditorTable : public QGraphicsObject
 {
     Q_OBJECT
 


### PR DESCRIPTION
Remove a warning in ClutEditor and a TODO comment in the code

`AutoMoc: /home/[...]/medInria-public/src/layers/legacy/medCoreLegacy/gui/lookUpTables/medClutEditor.h:76: Warning: Class medClutEditorVertex implements the interface QGraphicsItem but does not list it in Q_INTERFACES. qobject_cast to QGraphicsItem will not work!`


:m: