### PR TITLE
[Notification] add new version of notification widget

### DIFF
--- a/src/app/medInria/CMakeLists.txt
+++ b/src/app/medInria/CMakeLists.txt
@@ -144,6 +144,7 @@ target_link_libraries(${TARGET_NAME}
   medWidgets
   medCoreLegacy
   medPacs
+  medLog
   )
 
 

--- a/src/app/medInria/resources/icons/cross_gray.svg
+++ b/src/app/medInria/resources/icons/cross_gray.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   viewBox="2.54312999459216E-06 -0.194655999541283 113.526997884116 113.527656182647"
+   id="svg19"
+   sodipodi:docname="cross_gray.svg"
+   inkscape:version="1.0.1 (1.0.1+r73)">
+  <metadata
+     id="metadata23">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1043"
+     id="namedview21"
+     showgrid="false"
+     inkscape:zoom="7.5928635"
+     inkscape:cx="56.7635"
+     inkscape:cy="56.763828"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg19"
+     inkscape:document-rotation="0" />
+  <defs
+     id="defs9">
+    <linearGradient
+       id="def0"
+       x1="0.499995"
+       x2="0.499995"
+       y1="1.73779E-06"
+       y2="1.00001">
+      <stop
+         offset="0"
+         stop-color="#F27E5E"
+         id="stop2" />
+      <stop
+         offset="0.5"
+         stop-color="#EB1C24"
+         id="stop4" />
+      <stop
+         offset="1"
+         stop-color="#CE2229"
+         id="stop6" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g17"
+     style="fill:#999999">
+    <path
+       d="M 2.54313e-6,87.5347 30.964,56.564 2.54313e-6,25.6013 25.7973,-0.194656 56.7627,30.7707 87.7267,-0.194656 113.527,25.6013 82.5627,56.5693 113.527,87.5347 87.7267,113.329 56.7667,82.364 25.7973,113.333 Z"
+       id="path11"
+       style="fill:#999999" />
+    <path
+       d="M 111.641,87.5341 80.6768,56.5701 111.641,25.6021 87.7261,1.69014 56.7635,32.6555 25.7968,1.69014 1.8848,25.6021 32.8501,56.5648 1.8848,87.5341 25.7968,111.447 56.7675,80.4781 87.7261,111.443 Z"
+       id="path13"
+       style="fill:#999999" />
+    <path
+       d="m 53.5507,42.1597 c 16.4266,-5.2413 32.748,-7.0813 47.4853,-5.952 L 111.64,25.6024 87.7267,1.6904 56.7627,32.6557 25.7973,1.6904 1.88534,25.6024 29.0347,52.7491 c 7.484,-4.184 15.704,-7.7774 24.516,-10.5894 z"
+       style="fill:#999999;fill-opacity:0.101961"
+       id="path15" />
+  </g>
+</svg>

--- a/src/app/medInria/resources/icons/notification_error.svg
+++ b/src/app/medInria/resources/icons/notification_error.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?><svg id="Layer_1" style="enable-background:new 0 0 128 128;" version="1.1" viewBox="0 0 128 128" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><style type="text/css">
+	.st0{fill:#C93636;}
+	.st1{fill:#FFFFFF;}
+</style><circle class="st0" cx="64" cy="64" r="64"/><path class="st1" d="M100.3,90.4L73.9,64l26.3-26.4c0.4-0.4,0.4-1,0-1.4l-8.5-8.5c-0.4-0.4-1-0.4-1.4,0L64,54.1L37.7,27.8  c-0.4-0.4-1-0.4-1.4,0l-8.5,8.5c-0.4,0.4-0.4,1,0,1.4L54,64L27.7,90.3c-0.4,0.4-0.4,1,0,1.4l8.5,8.5c0.4,0.4,1.1,0.4,1.4,0L64,73.9  l26.3,26.3c0.4,0.4,1.1,0.4,1.5,0.1l8.5-8.5C100.7,91.4,100.7,90.8,100.3,90.4z"/></svg>

--- a/src/app/medInria/resources/icons/notification_message.svg
+++ b/src/app/medInria/resources/icons/notification_message.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?><svg id="Layer_1" style="enable-background:new 0 0 128 128;" version="1.1" viewBox="0 0 128 128" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><style type="text/css">
+	.st0{fill:#267CB5;}
+	.st1{fill:#FFFFFF;}
+</style><circle class="st0" cx="64" cy="64" r="64"/><path class="st1" d="M100,37H28c-2.2,0-4,1.8-4,4v42c0,2.2,1.8,4,4,4h20v15.1c0,0.8,0.9,1.3,1.6,0.8L72,87h28c2.2,0,4-1.8,4-4V41  C104,38.8,102.2,37,100,37z"/></svg>

--- a/src/app/medInria/resources/icons/notification_success.svg
+++ b/src/app/medInria/resources/icons/notification_success.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?><svg id="Layer_1" style="enable-background:new 0 0 128 128;" version="1.1" viewBox="0 0 128 128" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><style type="text/css">
+	.st0{fill:#31AF91;}
+	.st1{fill:#FFFFFF;}
+</style><g><circle class="st0" cx="64" cy="64" r="64"/></g><g><path class="st1" d="M54.3,97.2L24.8,67.7c-0.4-0.4-0.4-1,0-1.4l8.5-8.5c0.4-0.4,1-0.4,1.4,0L55,78.1l38.2-38.2   c0.4-0.4,1-0.4,1.4,0l8.5,8.5c0.4,0.4,0.4,1,0,1.4L55.7,97.2C55.3,97.6,54.7,97.6,54.3,97.2z"/></g></svg>

--- a/src/app/medInria/resources/medInria.qrc
+++ b/src/app/medInria/resources/medInria.qrc
@@ -167,5 +167,10 @@
         <file>icons/saveScene.png</file>
         <file>icons/saveScene_grey.png</file>
         <file>icons/scene.png</file>
+
+        <file>icons/notification_message.svg</file>
+        <file>icons/notification_error.svg</file>
+        <file>icons/notification_success.svg</file>
+        <file>icons/cross_gray.svg</file>
     </qresource>
 </RCC>

--- a/src/layers/legacy/medLog/medNotificationWidget.cpp
+++ b/src/layers/legacy/medLog/medNotificationWidget.cpp
@@ -1,0 +1,118 @@
+/*
+ * medInria
+ * Copyright (c) INRIA 2013. All rights reserved.
+ * 
+ * medInria is under BSD-2-Clause license. See LICENSE.txt for details in the root of the sources or:
+ * https://github.com/medInria/medInria-public/blob/master/LICENSE.txt
+ * 
+ * This software is distributed WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <medNotificationWidget.h>
+
+namespace med
+{
+
+NotificationWidget::NotificationWidget(QWidget *parent)
+    : QWidget(parent, Qt::FramelessWindowHint)
+{
+    widgetParent = parent;
+
+    // Attributes
+    // Qt::FramelessWindowHint above removes title and borders of the widget
+    setAttribute(Qt::WA_TranslucentBackground); // Transparent background for round corners    
+    setFixedWidth(350);
+    move((parent->width()/2.0 - width()/2.0), 0); // Position the notification on middle top
+
+    QHBoxLayout *layout = new QHBoxLayout();
+    setLayout(layout);
+
+    // Icons
+    notificationIcon = new QImage;
+    imageLabel = new QLabel(""); // QImage is not a widget, we need to add it in a QLabel
+    setIcon(MESSAGE);    
+    layout->addWidget(imageLabel, 0, Qt::AlignLeft);
+
+    // Notification text area
+    notificationText = new QLabel("");
+    notificationText->setWordWrap(true);
+    notificationText->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Preferred);
+    notificationText->setContentsMargins(15,0,0,0);
+    layout->addWidget(notificationText, 0, Qt::AlignLeft);
+
+    // Close button 
+    notificationCloseButton = new QPushButton;
+    notificationCloseButton->setIcon(QIcon(":/icons/cross_gray"));
+    notificationCloseButton->setIconSize(QSize(15,15));
+    notificationCloseButton->setToolTip("Close");
+    notificationCloseButton->setContentsMargins(0,0,0,0);
+    layout->addWidget(notificationCloseButton, 0, Qt::AlignRight);
+    connect(notificationCloseButton, &QPushButton::clicked, this, &QWidget::close);
+
+    // Set auto-close timer
+    setTimer(3000);
+}
+
+void NotificationWidget::setText(QString text)
+{
+    notificationText->setText(text);
+}
+
+void NotificationWidget::setIcon(type askedType)
+{
+    QIcon newIcon;
+    switch (askedType)
+    {
+        case ERROR:
+        {
+            newIcon =  QIcon(":/icons/notification_error.svg");
+            break;
+        }
+        case SUCCESS:
+        {
+            newIcon = QIcon(":/icons/notification_success.svg");
+            break;
+        }
+        case MESSAGE:
+        default:
+        {
+            newIcon = QIcon(":/icons/notification_message.svg");
+            break;
+        }
+    }
+    QImage newImage = newIcon.pixmap(QSize(20,20)).toImage();
+    notificationIcon->swap(newImage);
+    imageLabel->setPixmap(QPixmap::fromImage(*notificationIcon));
+}
+
+void NotificationWidget::paintEvent(QPaintEvent *event)
+{
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing); // smooth borders
+    painter.setBrush(QBrush("#D9D9D9"));           // visible color of background
+    painter.setPen(Qt::transparent);               // thin border color
+
+    notificationText->setStyleSheet("color:#616161");                   // text color
+    notificationCloseButton->setStyleSheet("background-color:#D9D9D9"); // background color of button
+    
+    // Change border radius
+    QRect rect = this->rect();
+    rect.setWidth(rect.width()-1);
+    rect.setHeight(rect.height()-1);
+    painter.drawRoundedRect(rect, 8, 8);
+
+    // Move on middle top if the application has been resized
+    move((widgetParent->width()/2.0 - width()/2.0), 0);
+
+    QWidget::paintEvent(event);
+}
+
+void NotificationWidget::setTimer(int timeInMS)
+{
+    auto timer = new QTimer(this);
+    connect(timer, &QTimer::timeout, this, &QWidget::close);
+    timer->start(3000); // in ms
+}
+
+} // end namespace

--- a/src/layers/legacy/medLog/medNotificationWidget.h
+++ b/src/layers/legacy/medLog/medNotificationWidget.h
@@ -1,0 +1,65 @@
+#pragma once
+/*
+ * medInria
+ * Copyright (c) INRIA 2013. All rights reserved.
+ * 
+ * medInria is under BSD-2-Clause license. See LICENSE.txt for details in the root of the sources or:
+ * https://github.com/medInria/medInria-public/blob/master/LICENSE.txt
+ * 
+ * This software is distributed WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+#include <medLogExport.h>
+
+#include <QtWidgets>
+
+namespace med
+{
+
+class MEDLOG_EXPORT NotificationWidget: public QWidget
+{
+    Q_OBJECT
+
+public :
+
+    enum type {MESSAGE, ERROR, SUCCESS};
+
+    NotificationWidget(QWidget *parent);
+
+    /**
+     * @brief Set the notification text message
+     * 
+     * @param text
+     */
+    void setText(QString text);
+
+    /**
+     * @brief Set the icon of the type of notification
+     * 
+     * @param askedType
+     */
+    void setIcon(type askedType);
+
+    /**
+     * @brief efine the graphic behavior when the widget needs to be updated
+     * 
+     * @param event
+     */
+    void paintEvent(QPaintEvent *event);
+
+private :
+    /**
+     * @brief Set the Timer object, after X ms the notification automatically closes itself
+     * 
+     * @param timeInMS 
+     */
+    void setTimer(int timeInMS);
+
+    QWidget *widgetParent;
+    QImage *notificationIcon;
+    QLabel *imageLabel;
+    QLabel *notificationText;
+    QPushButton *notificationCloseButton;
+};
+
+} // end namespace


### PR DESCRIPTION
This PR continues the complete change of medInria notification system (which was in a bottom bar).

This PR adds the class of the notification widget itself, displayed on middle top of the application, and which close automatically after x seconds. It can be closed by the user manually also if he/she wants. The idea is to use it to display quick information to the user, not full paragraphs. The notification has 3 types: MESSAGE for quick info, SUCCESS for success messages, and ERROR for error messages.

### To test
 * add in medHomageArea.cpp for instance `include <medNotificationWidget.h>`
 * add `medLog` in `target_link_libraries` from its CMakeLists.txt
 * in `medHomepageArea::resizeEvent` for instance (just after the application has its final size), choose the type of message you want to test:
```c++
    auto notification = new med::NotificationWidget(this);
    //------------- Message test
    //notification->setText("A longer message to display a tip or information to the user");
    //notification->setIcon(med::NotificationWidget::MESSAGE);
    //------------- Success test
    //notification->setText("Segmentation succeed");
    //notification->setIcon(med::NotificationWidget::SUCCESS);
    //------------- Failure test
    notification->setText("Segmentation failed, this tool needs a mesh as input");                          
    notification->setIcon(med::NotificationWidget::ERROR);
    //------------- Show widget
    notification->show();
```

### Screenshots of example
![error](https://user-images.githubusercontent.com/3910352/136340164-a7c2e280-4384-4cf6-99dc-e39eef19547c.png)

![message](https://user-images.githubusercontent.com/3910352/136340170-13f6135a-f1db-4800-abe5-aa07158d4f34.png)

![success](https://user-images.githubusercontent.com/3910352/136340179-4de9b0a0-385c-4dfd-ad08-6b645ca9e734.png)

PS: no need to review the svg lines. Those are images, and Github does not understand them as such.
:m: