### PR TITLE
[GUI] empty widget was locked at top left of workspaces

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/factories/medWorkspaceFactory.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/factories/medWorkspaceFactory.cpp
@@ -66,6 +66,7 @@ medAbstractWorkspaceLegacy *medWorkspaceFactory::createWorkspace(QString type,QW
 
     // create a deletable parent to clean up in case of constructor failure.
     parent = new QWidget(parent);
+    parent->hide();
 
     try
     {


### PR DESCRIPTION
Since this commit https://github.com/medInria/medInria-public/commit/19da358e10bbc7a5c90358981b25bf2f8b61b56c there was an empty widget at the top left of the workspaces, which was hiding the top of the database column.

This PR hides it.

:m: