### PR TITLE
[GUI] empty widget was locked at top left of workspaces

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/factories/medWorkspaceFactory.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/factories/medWorkspaceFactory.cpp
@@ -67,6 +67,7 @@ medAbstractWorkspaceLegacy *medWorkspaceFactory::createWorkspace(QString type,QW
 
     // create a deletable parent to clean up in case of constructor failure.
     parent = new QWidget(parent);
+    parent->hide();
 
     try
     {


### PR DESCRIPTION
Cherry-pick from https://github.com/medInria/medInria-public/pull/942

Hide an empty widget in workspaces.

:m: