### PR TITLE
[medPython] fix issue with python headers not found

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,11 +109,6 @@ if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.10.0")
     cmake_policy(SET CMP0071 NEW)
 endif()
 
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.20.0")
-    # Make the GENERATED source file property visible in all directories
-    cmake_policy(SET CMP0118 NEW)
-endif()
-
 ## #############################################################################
 ## Additionals modules
 ## #############################################################################

--- a/src/layers/medPython/cmake/embed_python.cmake
+++ b/src/layers/medPython/cmake/embed_python.cmake
@@ -89,7 +89,7 @@ function(embed_python target)
 ## #############################################################################
 
     target_include_directories(${target} PUBLIC "${working_dir}/${PYTHON_HEADERS_DIR}")
-    target_sources(${target} PUBLIC ${python_headers} ${copied_library})
+    target_sources(${target} PRIVATE ${python_headers} ${copied_library})
     target_link_libraries(${TARGET_NAME} PUBLIC "${copied_library}")
 
     target_compile_definitions(${target} PUBLIC PYTHON_VERSION_MINOR=${PYTHON_VERSION_MINOR})


### PR DESCRIPTION
Making the python headers private sources of medPython solves the issue of the files not being found elsewhere (and as a consequence there is no need for the policy that required version 3.20)