### PR TITLE
Default toolbox title, non-plugin selectable toolbox, move some slots to normal functions

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/medAbstractWorkspaceLegacy.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/medAbstractWorkspaceLegacy.cpp
@@ -140,6 +140,12 @@ void medAbstractWorkspaceLegacy::addToolBox(medToolBox *toolbox)
     toolbox->setWorkspace(this);
     toolbox->setParent(d->parent);
     d->toolBoxes.insert(index, toolbox);
+
+    if (toolbox->header()->title().isEmpty())
+    {
+        toolbox->setTitle(toolbox->name());
+    }
+
     emit toolBoxInserted(index, toolbox);
  }
 

--- a/src/layers/legacy/medCoreLegacy/gui/medAbstractWorkspaceLegacy.h
+++ b/src/layers/legacy/medCoreLegacy/gui/medAbstractWorkspaceLegacy.h
@@ -85,15 +85,16 @@ public:
 
     medProgressionStack *getProgressionStack();
 
+    void addToolBox(medToolBox *toolbox);
+    void insertToolBox(int index, medToolBox* toolbox);
+    void removeToolBox(medToolBox *toolbox);
+
 public slots:
     virtual void addNewTab();
     void updateNavigatorsToolBox();
     void updateMouseInteractionToolBox();
     void updateLayersToolBox();
     void updateInteractorsToolBox();
-    void addToolBox(medToolBox *toolbox);
-    void insertToolBox(int index, medToolBox* toolbox);
-    void removeToolBox(medToolBox *toolbox);
 
     virtual void open(const medDataIndex& index);
 

--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medAbstractSelectableToolBox.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medAbstractSelectableToolBox.cpp
@@ -34,6 +34,11 @@ medAbstractSelectableToolBox::~medAbstractSelectableToolBox()
     d = nullptr;
 }
 
+dtkPlugin* medAbstractSelectableToolBox::plugin()
+{
+    return nullptr;
+}
+
 void medAbstractSelectableToolBox::setSelectorToolBox(medSelectorToolBox *toolbox)
 {
     d->selectorToolBox = toolbox;

--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medAbstractSelectableToolBox.h
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medAbstractSelectableToolBox.h
@@ -28,7 +28,7 @@ public:
     medAbstractSelectableToolBox(QWidget *parent = nullptr);
     ~medAbstractSelectableToolBox() override;
 
-    virtual dtkPlugin* plugin() = 0;
+    virtual dtkPlugin* plugin();
 
     virtual medAbstractData *processOutput() = 0;
 

--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medSelectorToolBox.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medSelectorToolBox.cpp
@@ -134,8 +134,12 @@ void medSelectorToolBox::changeCurrentToolBox(const QString &identifier)
         d->currentToolBox->header()->hide();
 
         dtkPlugin *plugin = d->currentToolBox->plugin();
-        this->setAboutPluginButton(plugin);
-        this->setAboutPluginVisibility(true);
+
+        if (plugin)
+        {
+            this->setAboutPluginButton(plugin);
+            this->setAboutPluginVisibility(true);
+        }
 
         d->currentToolBox->show();
         d->mainLayout->addWidget(d->currentToolBox);


### PR DESCRIPTION
The following changes came about from working on the pipelines:
- By default a toolbox's title is now equal to its name (before this it was empty if not set explicitly).
- The functions to add and remove toolboxes from a workspace are no longer slots.
- A selectable toolbox is no longer assumed to be part of a plugin.
