### PR TITLE
[medToolBox] component and value accessors

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medToolBox.h
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medToolBox.h
@@ -81,6 +81,29 @@ public:
 
     virtual void toXMLNode(QDomDocument *doc, QDomElement *currentNode);
 
+    virtual QVariant getValue(QString name) const;
+    virtual bool setValue(QString name, QVariant value);
+
+    template<class VALUE_TYPE>
+    VALUE_TYPE getValue(QString name) const
+    {
+        return getValue(name).value<VALUE_TYPE>();
+    }
+
+    template<class VALUE_TYPE>
+    bool setValue(QString name, VALUE_TYPE value)
+    {
+        return setValue(name, QVariant::fromValue<VALUE_TYPE>(value));
+    }
+
+    virtual QObject* getComponent(QString name);
+
+    template<class TYPE>
+    TYPE getComponent(QString name)
+    {
+        return dynamic_cast<TYPE>(getComponent(name));
+    }
+
 signals:
     /**
      * @brief Emitted when an action from the toolbox succeeded.
@@ -126,6 +149,13 @@ public slots:
 
 protected slots:
     void onAboutButtonClicked();
+
+protected:
+    template<class COMPONENT_TYPE, class VALUE_TYPE>
+    bool getComponentValue(QObject* component, VALUE_TYPE* value) const;
+
+    template<class COMPONENT_TYPE, class VALUE_TYPE>
+    bool setComponentValue(QObject* component, VALUE_TYPE value);
 
 private:
     medToolBoxPrivate *d;

--- a/src/layers/medPython/cmake/generate_python_resources.cmake
+++ b/src/layers/medPython/cmake/generate_python_resources.cmake
@@ -27,6 +27,10 @@ function(generate_python_resources target)
     get_target_property(modules ${target} PYTHON_MODULES)
     get_target_property(bindings ${target} PYTHON_BINDINGS)
 
+    if (NOT modules)
+        set(modules "")
+    endif()
+
     if (NOT "__init__" IN_LIST modules)
         # Create default __init__ file
         set(init_file "${modules_dir}/__init__.py")
@@ -35,12 +39,10 @@ function(generate_python_resources target)
         list(APPEND modules "__init__")
     endif()
 
-    if (modules)
-        foreach (module ${modules})
-            list(APPEND module_paths "${modules_dir}/${module}.py")
-            list(APPEND depends "${modules_dir}/${module}.py")
-        endforeach()
-    endif()
+    foreach (module ${modules})
+        list(APPEND module_paths "${modules_dir}/${module}.py")
+        list(APPEND depends "${modules_dir}/${module}.py")
+    endforeach()
 
     if (bindings)
         foreach(bindings_target ${bindings})

--- a/src/layers/medPython/tools/CMakeLists.txt
+++ b/src/layers/medPython/tools/CMakeLists.txt
@@ -92,6 +92,7 @@ generate_python_resources(${TARGET_NAME})
 target_include_directories(${TARGET_NAME}
     PUBLIC
     ${${TARGET_NAME}_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/bindings
     )
 
 target_include_directories(qt_bindings

--- a/src/layers/medPython/tools/bindings/medInria/data.i
+++ b/src/layers/medPython/tools/bindings/medInria/data.i
@@ -79,6 +79,9 @@ public:
 %rename(AbstractData) medAbstractData;
 %include "medAbstractData.h"
 
+%feature("novaluewrapper") dtkSmartPointer<medAbstractData>;
+%template() dtkSmartPointer<medAbstractData>;
+
 %pythoncode
 %{
 
@@ -127,38 +130,25 @@ public:
     $1 = medAbstractData_Check($input) ? 1 : 0;
 }
 
-%typemap(out) medAbstractData*
+%medPythonTypemaps(medAbstractData*);
+
+%typemap(in) medAbstractData* (QObject* temp)
 {
-    if ($1)
-    {
-        medAbstractMeshData* meshData = dynamic_cast<medAbstractMeshData*>($1);
-
-        if (meshData)
-        {
-            $result = SWIG_NewPointerObj(meshData, $descriptor(medAbstractMeshData*), 1);
-        }
-        else
-        {
-            medAbstractImageData* imageData = dynamic_cast<medAbstractImageData*>($1);
-
-            if (imageData)
-            {
-                $result = SWIG_NewPointerObj(imageData, $descriptor(medAbstractImageData*), 1);
-            }
-            else
-            {
-                $result = SWIG_NewPointerObj($1, $1_descriptor, 1);
-            }
-        }
-
-        $1->retain();
-    }
-    else
-    {
-        $result = Py_None;
-        Py_INCREF($result);
-    }
+    medPythonConvert($input, &temp);
+    med::python::propagateErrorIfOccurred();
+    *$1 = dynamic_cast<medAbstractData*>(temp);
 }
+
+%apply medAbstractData { dtkSmartPointer<medAbstractData> };
+
+%typemap(in) dtkSmartPointer<medAbstractData>
+{
+    $1 = ($1_ltype::ObjectType*)med::python::extractSWIGWrappedObject($input);
+    med::python::propagateErrorIfOccurred();
+}
+
+%include "medAbstractImageData.h"
+%include "medAbstractMeshData.h"
 
 %rename(DataManager) medDataManager;
 %include "medDataManager.h"

--- a/src/layers/medPython/tools/bindings/qt/header.i
+++ b/src/layers/medPython/tools/bindings/qt/header.i
@@ -42,6 +42,9 @@
 #undef Q_DECL_NOTHROW
 #define Q_DECL_NOTHROW
 
+#undef Q_DECL_OVERRIDE
+#define Q_DECL_OVERRIDE
+
 #undef Q_DECL_PURE_FUNCTION
 #define Q_DECL_PURE_FUNCTION
 
@@ -120,10 +123,16 @@
         med::python::propagateErrorIfOccurred();
     }
 
-    %typemap(directorin) TYPE
+    %typemap(directorin) TYPE (PyObject* temp)
     {
-        medPythonConvert($1, $input);
+        medPythonConvert($1, &temp);
         med::python::propagateErrorIfOccurred();
+        $input = temp;
+    }
+
+    %typemap(in, numinputs = 0) TYPE* OUTPUT (TYPE temp)
+    {
+        $1 = &temp;
     }
 
 %enddef


### PR DESCRIPTION
Aside from some minor python fixes, this PR adds a couple important functions in `medToolBox`. These are changes I made a while back to replace the hacks we made in the old pipeline code when accessing and modifying toolbox widgets (to set values, click buttons etc.). The following virtual functions are added:
- `getComponent`: used to click buttons for example
- `getValue` and `setValue`: used to access things like spinbox values.

The old pipeline code used `QObject::findChild` to achieve this, and the default implementation of these functions does the same. The old code also had parts that directly accessed some special functions in the histogram toolbox (which meant we had to link with that plugin). This is no longer possible because the pipeline code is in the core, so I have modified the histogram toolbox so that it defines it's own implementation of the above functions (not posted yet).

I initially wrote this code even before we were talking about medInria 3 (so yes, a long time ago), as a suggestion to improve the architecture of medInria 2 to make it more adapted to the pipelines. I never ended up posting it but these changes are necessary for medInria 3 specifically because of the histogram issue (and also I had already adapted the pipeline code in the upcoming version to these changes). _**These are only temporary aditions for medInria 3, they are of course not intended for medInria 4 which has an entirely different toolbox philosophy.**_