### PR TITLE
[medPython] settings to allow adding python paths (for python plugins)

### DIFF
--- a/src/app/medInria/main.cpp
+++ b/src/app/medInria/main.cpp
@@ -231,6 +231,7 @@ int main(int argc,char* argv[])
     }
 
     med::python::initializeTools();
+    med::python::loadPythonPlugins();
 #endif
 
     medPluginManager::instance()->setVerboseLoading(true);

--- a/src/layers/medPython/base/core/medPythonCoreInit.cpp
+++ b/src/layers/medPython/base/core/medPythonCoreInit.cpp
@@ -177,7 +177,7 @@ bool setupEncodingsPackage()
     return success;
 }
 
-bool getModulePaths(QStringList& modulePaths)
+bool getCoreModulePaths(QStringList& modulePaths)
 {
     QString resourcesDirectory;
     QStringList resourceArchives;
@@ -235,15 +235,15 @@ bool setConfigOptions(PyConfig* config, QStringList modulePaths)
     return success;
 }
 
-bool prepareConfig(PyConfig* config)
+bool prepareConfig(PyConfig* config, QStringList additionalModulePaths)
 {
-    QStringList modulePaths;
-    bool success = getModulePaths(modulePaths);
+    QStringList coreModulePaths;
+    bool success = getCoreModulePaths(coreModulePaths);
 
     if (success)
     {
         PyConfig_InitIsolatedConfig(config);
-        success = setConfigOptions(config, modulePaths);
+        success = setConfigOptions(config, coreModulePaths + additionalModulePaths);
     }
 
     return success;
@@ -263,12 +263,12 @@ bool initializeFromConfig(PyConfig* config)
 
 } // namespace
 
-bool initializeInterpreter()
+bool initializeInterpreter(QStringList additionalModulePaths)
 {
     PyConfig config;
     bool success = setupEncodingsPackage()
                    && preInitialize()
-                   && prepareConfig(&config)
+                   && prepareConfig(&config, additionalModulePaths)
                    && initializeFromConfig(&config);
 
     if (success)

--- a/src/layers/medPython/base/core/medPythonCoreInit.h
+++ b/src/layers/medPython/base/core/medPythonCoreInit.h
@@ -17,7 +17,7 @@
 namespace med::python
 {
 
-bool initializeInterpreter();
+bool initializeInterpreter(QStringList additionalModulePaths);
 bool finalizeInterpreter();
 
 namespace test

--- a/src/layers/medPython/base/medPython.h
+++ b/src/layers/medPython/base/medPython.h
@@ -16,5 +16,5 @@
 #include "medPythonError.h"
 #include "medPythonInit.h"
 #include "medPythonObjects.h"
-#include "medPythonModules.h"
 #include "medPythonTest.h"
+#include "medPythonUtils.h"

--- a/src/layers/medPython/base/medPythonInit.cpp
+++ b/src/layers/medPython/base/medPythonInit.cpp
@@ -17,6 +17,7 @@
 
 #include "medPythonCore.h"
 #include "medPythonError.h"
+#include "medPythonUtils.h"
 
 namespace med::python
 {
@@ -32,7 +33,8 @@ bool initialize()
 {
     if (!isRunning)
     {
-        isRunning = initializeInterpreter();
+        QStringList startupPaths = getStartupPythonPaths();
+        isRunning = initializeInterpreter(startupPaths);
 
         if (isRunning)
         {

--- a/src/layers/medPython/base/medPythonUtils.cpp
+++ b/src/layers/medPython/base/medPythonUtils.cpp
@@ -13,21 +13,46 @@
 
 #include "medPythonCoreAPI.h"
 
-#include "medPythonModules.h"
+#include "medPythonUtils.h"
+
+#include <medSettingsManager.h>
 
 #include "medPythonCoreFunction.h"
-#include "medPythonObjects.h"
+#include "medPythonStandardObjects.h"
 
 namespace med::python
 {
 
-void registerModulePath(QString path)
+namespace
+{
+
+const char* STARTUP_PATHS_SETTINGS_ID = "startup_paths";
+
+} // namespace
+
+void addPythonPath(QString path)
 {
     Module sys = import("sys");
-    sys.attribute("path").append(Object(path));
+    Object pythonPath = sys.attribute("path");
+    path = QDir::toNativeSeparators(path);
+
+    if (!pythonPath.contains(Object(path)))
+    {
+        pythonPath.append(Object(path));
+    }
 }
 
-void loadPlugins()
+void setStartupPythonPaths(QStringList paths)
+{
+    medSettingsManager::instance()->setValue(PYTHON_SETTINGS_ID, STARTUP_PATHS_SETTINGS_ID, paths);
+}
+
+QStringList getStartupPythonPaths()
+{
+    return medSettingsManager::instance()->value(PYTHON_SETTINGS_ID, STARTUP_PATHS_SETTINGS_ID).toStringList();
+}
+
+void loadPythonPlugins()
 {
     Module pkgutil = import("pkgutil");
     Object moduleIterator = pkgutil.callMethod("iter_modules");
@@ -44,6 +69,13 @@ void loadPlugins()
 
         moduleInfo = coreFunction(PyIter_Next, *moduleIterator);
     }
+}
+
+Object runSourceCode(QString sourceCode)
+{
+    Object globals = dict();
+    coreFunction(PyRun_String, qUtf8Printable(sourceCode), Py_file_input, *globals, nullptr);
+    return globals;
 }
 
 } // namespace med::python

--- a/src/layers/medPython/base/medPythonUtils.h
+++ b/src/layers/medPython/base/medPythonUtils.h
@@ -14,13 +14,22 @@
 
 #include <QString>
 
+#include "medPythonObjects.h"
 #include "medPythonExport.h"
 
 namespace med::python
 {
 
-MEDPYTHON_EXPORT void registerModulePath(QString path);
+inline const char* PYTHON_SETTINGS_ID = "python";
 
-MEDPYTHON_EXPORT void loadPlugins();
+MEDPYTHON_EXPORT void addPythonPath(QString path);
+
+MEDPYTHON_EXPORT void setStartupPythonPaths(QStringList paths);
+
+MEDPYTHON_EXPORT QStringList getStartupPythonPaths();
+
+MEDPYTHON_EXPORT void loadPythonPlugins();
+
+MEDPYTHON_EXPORT Object runSourceCode(QString sourceCode);
 
 } // namespace med::python

--- a/src/layers/medPython/tools/medPythonSettingsWidget.cpp
+++ b/src/layers/medPython/tools/medPythonSettingsWidget.cpp
@@ -1,0 +1,108 @@
+#include "medPythonSettingsWidget.h"
+
+#include <QDir>
+#include <QFileDialog>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListWidget>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QStandardPaths>
+
+#include <medPython.h>
+
+namespace med::python
+{
+
+class PythonSettingsWidgetPrivate
+{
+public:
+    QListWidget* pathsList;
+    QPushButton* removePathButton;
+};
+
+PythonSettingsWidget::PythonSettingsWidget(QWidget *parent) :
+    medSettingsWidget(parent), d(new PythonSettingsWidgetPrivate())
+{
+    setTabName("Python");
+
+    QVBoxLayout* mainLayout = new QVBoxLayout(this);
+
+    d->pathsList = new QListWidget(this);
+    mainLayout->addWidget(new QLabel("External module paths:"));
+    mainLayout->addWidget(d->pathsList);
+
+    QWidget* pathButtonsWidget = new QWidget;
+    QHBoxLayout* pathButtonsLayout = new QHBoxLayout(pathButtonsWidget);
+    mainLayout->addWidget(pathButtonsWidget);
+
+    QPushButton* addPathButton = new QPushButton("Add");
+    pathButtonsLayout->addWidget(addPathButton);
+    connect(addPathButton, &QPushButton::clicked, this, &PythonSettingsWidget::addPath);
+
+    d->removePathButton = new QPushButton("Remove");
+    pathButtonsLayout->addWidget(d->removePathButton);
+    d->removePathButton->setEnabled(false);
+
+    connect(d->pathsList, &QListWidget::itemSelectionChanged, [=]() {
+        d->removePathButton->setEnabled(!d->pathsList->selectedItems().isEmpty());
+    });
+
+    connect(d->removePathButton, &QPushButton::clicked, this, [=]() {
+        foreach (QListWidgetItem* item, d->pathsList->selectedItems())
+        {
+            delete item;
+        }
+    });
+}
+
+bool PythonSettingsWidget::write()
+{
+    QStringList paths;
+
+    for (int row = 0; row < d->pathsList->count(); row++)
+    {
+        QListWidgetItem* item = d->pathsList->item(row);
+        paths << QDir::fromNativeSeparators(item->text());
+    }
+
+    setStartupPythonPaths(paths);
+
+    return true;
+}
+
+void PythonSettingsWidget::read()
+{
+    d->pathsList->clear();
+
+    foreach (QString path, getStartupPythonPaths())
+    {
+        new QListWidgetItem(QDir::toNativeSeparators(path), d->pathsList);
+    }
+}
+
+bool PythonSettingsWidget::validate()
+{
+    return true;
+}
+
+void PythonSettingsWidget::addPath()
+{
+    QString defaultPath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
+    QString path = QFileDialog::getExistingDirectory(this,
+                                                     tr("Select a path to add to Python's path variable"),
+                                                     QDir::toNativeSeparators(defaultPath),
+                                                     QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+
+    if(!path.isEmpty())
+    {
+        path = QDir::toNativeSeparators(path);
+
+        if (d->pathsList->findItems(path, Qt::MatchFixedString).isEmpty())
+        {
+            new QListWidgetItem(path, d->pathsList);
+        }
+    }
+}
+
+} // namespace med::python

--- a/src/layers/medPython/tools/medPythonSettingsWidget.h
+++ b/src/layers/medPython/tools/medPythonSettingsWidget.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <medSettingsWidget.h>
+
+#include "medPythonToolsExport.h"
+
+namespace med::python
+{
+
+class PythonSettingsWidgetPrivate;
+
+class MEDPYTHONTOOLS_EXPORT PythonSettingsWidget : public medSettingsWidget
+{
+    Q_OBJECT
+    MED_SETTINGS_INTERFACE("Python", "Python Settings")
+
+public:
+    PythonSettingsWidget(QWidget* parent = 0);
+
+    bool write() override;
+
+public slots:
+    void read() override;
+    bool validate() override;
+
+private slots:
+    void addPath();
+
+private:
+    PythonSettingsWidgetPrivate *d;
+};
+
+} // namespace med::python

--- a/src/layers/medPython/tools/medPythonTools.cpp
+++ b/src/layers/medPython/tools/medPythonTools.cpp
@@ -19,16 +19,40 @@
 
 #include <medExternalResources.h>
 #include <medPython.h>
+#include <medSettingsWidgetFactory.h>
+
+#include "medPythonSettingsWidget.h"
 
 namespace med::python
 {
 
-void initializeTools()
+namespace
 {
-    registerModulePath(getExternalResourcesDirectory(TARGET_NAME));
-    registerModulePath(getExternalResourcePath(QString(TARGET_NAME) + ".zip", TARGET_NAME));
+
+void initializeModulePaths()
+{
+    addPythonPath(getExternalResourcesDirectory(TARGET_NAME));
+    addPythonPath(getExternalResourcePath(QString(TARGET_NAME) + ".zip", TARGET_NAME));
+}
+
+void importModulesInMainNamespace()
+{
     QString command = QString("from %1 import *").arg(PYTHON_PACKAGE_NAME);
     coreFunction(PyRun_SimpleString, qUtf8Printable(command));
+}
+
+void initializeSettingsWidget()
+{
+    medSettingsWidgetFactory::instance()->registerSettingsWidget<PythonSettingsWidget>();
+}
+
+} // namespace
+
+void initializeTools()
+{
+    initializeModulePaths();
+    importModulesInMainNamespace();
+    initializeSettingsWidget();
 }
 
 void startConsole()


### PR DESCRIPTION
Adds a settings value that contains additional python paths to append to the python modules path at startup.
A python settings widget is also added to allow the user to add/remove paths.