### PR TITLE
[medPythonTools] improve bindings and add QHash

### DIFF
--- a/src/layers/medPython/tools/CMakeLists.txt
+++ b/src/layers/medPython/tools/CMakeLists.txt
@@ -33,6 +33,7 @@ set(qt_bindings_sources
     qt/string.i
     qt/variant.i
     qt/list.i
+    qt/hash.i
     qt/base.i
     qt/object.i
     qt/widgets.i

--- a/src/layers/medPython/tools/bindings/medInria/data.i
+++ b/src/layers/medPython/tools/bindings/medInria/data.i
@@ -139,12 +139,24 @@ public:
     *$1 = dynamic_cast<medAbstractData*>(temp);
 }
 
-%apply medAbstractData { dtkSmartPointer<medAbstractData> };
+%apply medAbstractData* { dtkSmartPointer<medAbstractData> };
 
 %typemap(in) dtkSmartPointer<medAbstractData>
 {
     $1 = ($1_ltype::ObjectType*)med::python::extractSWIGWrappedObject($input);
     med::python::propagateErrorIfOccurred();
+}
+
+%typemap(in, numinputs = 0) dtkSmartPointer<medAbstractData>* OUTPUT (dtkSmartPointer<medAbstractData> temp)
+{
+    $1 = &temp;
+}
+
+%typemap(argout) dtkSmartPointer<medAbstractData>* OUTPUT
+{
+    PyObject* output;
+    medPythonConvert($1->data(), &output);
+    $result = SWIG_Python_AppendOutput($result, output);
 }
 
 %include "medAbstractImageData.h"

--- a/src/layers/medPython/tools/bindings/qt/hash.i
+++ b/src/layers/medPython/tools/bindings/qt/hash.i
@@ -1,0 +1,49 @@
+%{
+#include "medPythonError.h"
+#include "medPythonQHashConversion.h"
+%}
+
+%define %qHashTypemaps(KEY_TYPE, VALUE_TYPE, PRECEDENCE)
+
+    %feature("novaluewrapper") QHash<KEY_TYPE, VALUE_TYPE >;
+    class QHash<KEY_TYPE, VALUE_TYPE >;
+
+    %typecheck(PRECEDENCE) QHash<KEY_TYPE, VALUE_TYPE >
+    {
+        $1 = PyMapping_Check($input) ? 1 : 0;
+    }
+
+    %typemap(in) QHash<KEY_TYPE, VALUE_TYPE >
+    {
+        medPythonConvert<KEY_TYPE, VALUE_TYPE >($input, &$1);
+        med::python::propagateErrorIfOccurred();
+    }
+
+    %typemap(directorout) QHash<KEY_TYPE, VALUE_TYPE >
+    {
+        medPythonConvert<KEY_TYPE, VALUE_TYPE >($input, &$result);
+        med::python::propagateErrorIfOccurred();
+    }
+
+    %typemap(out) QHash<KEY_TYPE, VALUE_TYPE >
+    {
+        medPythonConvert<KEY_TYPE, VALUE_TYPE >($1, &$result);
+        med::python::propagateErrorIfOccurred();
+    }
+
+    %typemap(directorin) QHash<KEY_TYPE, VALUE_TYPE >
+    {
+        medPythonConvert<KEY_TYPE, VALUE_TYPE >($1, $input);
+        med::python::propagateErrorIfOccurred();
+    }
+
+    %typemap(argout) QHash<KEY_TYPE, VALUE_TYPE >* OUTPUT
+    {
+        PyObject* output;
+        medPythonConvert<KEY_TYPE, VALUE_TYPE >(*$1, &output);
+        $result = SWIG_Python_AppendOutput($result, output);
+    }
+
+%enddef
+
+%qHashTypemaps(QString, QString, SWIG_TYPECHECK_MAP)

--- a/src/layers/medPython/tools/bindings/qt/header.i
+++ b/src/layers/medPython/tools/bindings/qt/header.i
@@ -135,6 +135,13 @@
         $1 = &temp;
     }
 
+    %typemap(argout) TYPE* OUTPUT
+    {
+        PyObject* output;
+        medPythonConvert(*$1, &output);
+        $result = SWIG_Python_AppendOutput($result, output);
+    }
+
 %enddef
 
 %pythoncode

--- a/src/layers/medPython/tools/bindings/qt/list.i
+++ b/src/layers/medPython/tools/bindings/qt/list.i
@@ -37,6 +37,13 @@
         med::python::propagateErrorIfOccurred();
     }
 
+    %typemap(argout) QList<CTYPE >* OUTPUT
+    {
+        PyObject* output;
+        medPythonConvert<CTYPE >(*$1, &output);
+        $result = SWIG_Python_AppendOutput($result, output);
+    }
+
 %enddef
 
 %qListTypemaps(bool, SWIG_TYPECHECK_BOOL_ARRAY)


### PR DESCRIPTION
- adds bindings for QHash
- corrects bindings for `medAbstractData` smart pointers
- allows binding of output arguments