### PR TITLE
[medSelectorTlbx]choose the current tlbx in selector do not run clear()

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medSelectorToolBox.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medSelectorToolBox.cpp
@@ -22,6 +22,7 @@ class medSelectorToolBoxPrivate
 public:
     medComboBox *chooseComboBox;
     medAbstractSelectableToolBox *currentToolBox;
+    QString currentIdentifier;
     QHash<QString, medAbstractSelectableToolBox*> toolBoxes;
     QVBoxLayout *mainLayout;
 
@@ -32,6 +33,7 @@ medSelectorToolBox::medSelectorToolBox(QWidget *parent, QString tlbxId)
     : medToolBox(parent), d(new medSelectorToolBoxPrivate)
 {
     d->currentToolBox = nullptr;
+    d->currentIdentifier = "";
 
     d->chooseComboBox = new medComboBox;
     d->chooseComboBox->addItem("* Choose a toolbox *");
@@ -95,7 +97,11 @@ void medSelectorToolBox::changeCurrentToolBox(int index)
 {
     // Get current toolbox identifier from combobox
     QString identifier = d->chooseComboBox->itemData(index).toString();
-    this->changeCurrentToolBox(identifier);
+
+    if (identifier != d->currentIdentifier)
+    {
+        this->changeCurrentToolBox(identifier);
+    }
 }
 
 void medSelectorToolBox::changeCurrentToolBox(const QString &identifier)
@@ -126,12 +132,14 @@ void medSelectorToolBox::changeCurrentToolBox(const QString &identifier)
 
         d->mainLayout->removeWidget(d->currentToolBox);
         d->currentToolBox = nullptr;
+        d->currentIdentifier = "";
     }
 
     if(toolbox)
     {
         d->currentToolBox = toolbox;
         d->currentToolBox->header()->hide();
+        d->currentIdentifier = identifier;
 
         dtkPlugin *plugin = d->currentToolBox->plugin();
 


### PR DESCRIPTION
Clicking on the medSelectorToolBox combobox and choosing the same current toolbox was running the `clear()` method of toolboxes. This PR avoids that.

:m: