### PR TITLE
[medSelectorTlbx]choose the current tlbx in selector do not run clear()

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medSelectorToolBox.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medSelectorToolBox.cpp
@@ -22,6 +22,7 @@ class medSelectorToolBoxPrivate
 public:
     medComboBox *chooseComboBox;
     medAbstractSelectableToolBox *currentToolBox;
+    QString currentIdentifier;
     QHash<QString, medAbstractSelectableToolBox*> toolBoxes;
     QVBoxLayout *mainLayout;
 
@@ -41,6 +42,7 @@ medSelectorToolBox::medSelectorToolBox(QWidget *parent, QString tlbxId)
     addWidget(mainWidget);
 
     d->currentToolBox = nullptr;
+    d->currentIdentifier = "";
 
     d->chooseComboBox = new medComboBox;
     d->chooseComboBox->addItem("* Choose a toolbox *");
@@ -109,7 +111,11 @@ void medSelectorToolBox::changeCurrentToolBox(int index)
 {
     // Get current toolbox identifier from combobox
     QString identifier = d->chooseComboBox->itemData(index).toString();
-    this->changeCurrentToolBox(identifier);
+
+    if (identifier != d->currentIdentifier)
+    {
+        this->changeCurrentToolBox(identifier);
+    }
 }
 
 void medSelectorToolBox::changeCurrentToolBox(const QString &identifier)
@@ -140,12 +146,14 @@ void medSelectorToolBox::changeCurrentToolBox(const QString &identifier)
 
         d->mainLayout->removeWidget(d->currentToolBox);
         d->currentToolBox = nullptr;
+        d->currentIdentifier = "";
     }
 
     if(toolbox)
     {
         d->currentToolBox = toolbox;
         d->currentToolBox->header()->hide();
+        d->currentIdentifier = identifier;
 
         dtkPlugin *plugin = d->currentToolBox->plugin();
         this->setAboutPluginButton(plugin, d->helpButton);

--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medSelectorToolBox.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medSelectorToolBox.cpp
@@ -42,7 +42,6 @@ medSelectorToolBox::medSelectorToolBox(QWidget *parent, QString tlbxId)
     addWidget(mainWidget);
 
     d->currentToolBox = nullptr;
-    d->currentIdentifier = "";
 
     d->chooseComboBox = new medComboBox;
     d->chooseComboBox->addItem("* Choose a toolbox *");
@@ -112,9 +111,10 @@ void medSelectorToolBox::changeCurrentToolBox(int index)
     // Get current toolbox identifier from combobox
     QString identifier = d->chooseComboBox->itemData(index).toString();
 
-    if (identifier != d->currentIdentifier)
+    if (!d->currentToolBox || identifier != d->currentIdentifier)
     {
         this->changeCurrentToolBox(identifier);
+        d->currentIdentifier = identifier;
     }
 }
 
@@ -146,14 +146,12 @@ void medSelectorToolBox::changeCurrentToolBox(const QString &identifier)
 
         d->mainLayout->removeWidget(d->currentToolBox);
         d->currentToolBox = nullptr;
-        d->currentIdentifier = "";
     }
 
     if(toolbox)
     {
         d->currentToolBox = toolbox;
         d->currentToolBox->header()->hide();
-        d->currentIdentifier = identifier;
 
         dtkPlugin *plugin = d->currentToolBox->plugin();
         this->setAboutPluginButton(plugin, d->helpButton);

--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medSelectorToolBox.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medSelectorToolBox.cpp
@@ -22,10 +22,8 @@ class medSelectorToolBoxPrivate
 public:
     medComboBox *chooseComboBox;
     medAbstractSelectableToolBox *currentToolBox;
-    QString currentIdentifier;
     QHash<QString, medAbstractSelectableToolBox*> toolBoxes;
     QVBoxLayout *mainLayout;
-
     medAbstractData *inputData;
 
     QPushButton *helpButton;
@@ -111,10 +109,9 @@ void medSelectorToolBox::changeCurrentToolBox(int index)
     // Get current toolbox identifier from combobox
     QString identifier = d->chooseComboBox->itemData(index).toString();
 
-    if (!d->currentToolBox || identifier != d->currentIdentifier)
+    if (!d->currentToolBox || identifier != d->currentToolBox->identifier())
     {
         this->changeCurrentToolBox(identifier);
-        d->currentIdentifier = identifier;
     }
 }
 


### PR DESCRIPTION
Same as https://github.com/medInria/medInria-public/pull/967 on master branch.

> Clicking on the medSelectorToolBox combobox and choosing the same current toolbox was running the clear() method of toolboxes. This PR avoids that.

:m: