### PR TITLE
1st step to build with python on windows 

### DIFF
--- a/src/layers/legacy/medCoreLegacy/medExternalResources.h
+++ b/src/layers/legacy/medCoreLegacy/medExternalResources.h
@@ -23,6 +23,7 @@
 
 
 #include <QString>
+#include <medCoreLegacyExport.h>
 
 namespace med
 {
@@ -30,12 +31,12 @@ namespace med
 // Returns the directory containing the external resources for the project or
 // one of its libraries. A null string is returned if the directory does not
 // exist.
-QString getExternalResourcesDirectory(QString libraryName = QString());
+    MEDCORELEGACY_EXPORT QString getExternalResourcesDirectory(QString libraryName = QString());
 
 // Returns the path of an external resource that was added using
 // add_external_resources in the cmake project. If the resource was added
 // through a library target then the library name must be provided. A null
 // string is returned if the resource is not found.
-QString getExternalResourcePath(QString filename, QString libraryName = QString());
+    MEDCORELEGACY_EXPORT QString getExternalResourcePath(QString filename, QString libraryName = QString());
 
 } // namespace med

--- a/src/layers/medPython/base/conversion/medPythonConversionUtils.h
+++ b/src/layers/medPython/base/conversion/medPythonConversionUtils.h
@@ -39,25 +39,25 @@ MEDPYTHON_EXPORT PyObject* wrapObjectWithSWIG(const QObject* object, bool takeOw
 } // namespace med::python
 
 #define MED_PYTHON_STANDARD_VALUE_CONVERSIONS(TYPE) \
-    MEDPYTHON_EXPORT bool medPythonConvert(const TYPE& value, PyObject** output) \
+    bool medPythonConvert(const TYPE& value, PyObject** output) \
     { \
         TYPE* valueCopy = new TYPE(value); \
         *output = med::python::wrapObjectWithSWIG(valueCopy, QString(#TYPE) + "*", true); \
         return !med::python::errorOccurred(); \
     } \
-    MEDPYTHON_EXPORT bool medPythonConvert(const PyObject* object, TYPE* output) \
+    bool medPythonConvert(const PyObject* object, TYPE* output) \
     { \
         *output = *(TYPE*)med::python::extractSWIGWrappedObject(object); \
         return !med::python::errorOccurred(); \
     }
 
 #define MED_PYTHON_STANDARD_POINTER_CONVERSIONS(TYPE) \
-    MEDPYTHON_EXPORT bool medPythonConvert(const TYPE* object, PyObject** output) \
+    bool medPythonConvert(const TYPE* object, PyObject** output) \
     { \
         *output = med::python::wrapObjectWithSWIG(object, QString(#TYPE) + "*"); \
         return !med::python::errorOccurred(); \
     } \
-    MEDPYTHON_EXPORT bool medPythonConvert(const PyObject* object, TYPE** output) \
+    bool medPythonConvert(const PyObject* object, TYPE** output) \
     { \
         *output = (TYPE*)med::python::extractSWIGWrappedObject(nativeObject); \
         return !med::python::errorOccurred(); \

--- a/src/layers/medPython/base/conversion/medPythonQListConversion.h
+++ b/src/layers/medPython/base/conversion/medPythonQListConversion.h
@@ -35,7 +35,7 @@ void clearList(QList<TYPE*> list)
     }
 }
 
-void clearList(QList<PyObject*> list);
+void MEDPYTHON_EXPORT clearList(QList<PyObject*> list);
 
 } // namespace med::python
 

--- a/src/layers/medPython/base/medPythonExport.h
+++ b/src/layers/medPython/base/medPythonExport.h
@@ -13,7 +13,7 @@
 ==============================================================================*/
 
 #ifdef WIN32
-    #ifdef medPython_EXPORTS
+    #ifdef medPythonBase_EXPORTS
         #define MEDPYTHON_EXPORT __declspec(dllexport)
     #else
         #define MEDPYTHON_EXPORT __declspec(dllimport)

--- a/src/layers/medPython/base/objects/medPythonModule.cpp
+++ b/src/layers/medPython/base/objects/medPythonModule.cpp
@@ -72,7 +72,14 @@ PyObject* Module::getModuleObject(QString name)
 
     if (!moduleObject)
     {
-        moduleObject = coreFunction(PyImport_ImportModuleLevel, qUtf8Printable(name), nullptr, nullptr, *list(), 0);
+        try
+        {
+            moduleObject = coreFunction(PyImport_ImportModuleLevel, qUtf8Printable(name), nullptr, nullptr, *list(), 0);
+        }
+        catch (med::python::BaseException &e)
+        {
+            qDebug() << e.what();
+        }
     }
 
     return moduleObject;

--- a/src/layers/medPython/base/objects/medPythonModule.h
+++ b/src/layers/medPython/base/objects/medPythonModule.h
@@ -38,6 +38,6 @@ private:
     static PyObject* getModuleObject(QString name);
 };
 
-Module import(QString name);
+MEDPYTHON_EXPORT Module import(QString name);
 
 } // namespace med::python

--- a/src/layers/medPython/cmake/embed_python.cmake
+++ b/src/layers/medPython/cmake/embed_python.cmake
@@ -78,13 +78,13 @@ function(embed_python target)
 
     if (APPLE)
         add_custom_command(OUTPUT ${copied_library}
-          COMMAND ${CMAKE_COMMAND} ARGS -E copy "${python_main_library}" "${CMAKE_BINARY_DIR}/lib/"
+          COMMAND ${CMAKE_COMMAND} ARGS -E copy_if_different "${python_main_library}" "${CMAKE_BINARY_DIR}/lib/"
           COMMAND ${CMAKE_INSTALL_NAME_TOOL} -id "${copied_library}" "${copied_library}"
           DEPENDS "${python_main_library}"
           )
     else()
         add_custom_command(OUTPUT ${copied_library}
-          COMMAND ${CMAKE_COMMAND} ARGS -E copy "${python_main_library}" "${CMAKE_BINARY_DIR}/lib/"
+          COMMAND ${CMAKE_COMMAND} ARGS -E copy_if_different "${python_main_library}" "${CMAKE_BINARY_DIR}/lib/"
           DEPENDS "${python_main_library}"
           )
     endif()
@@ -97,7 +97,12 @@ function(embed_python target)
 
     target_include_directories(${target} PUBLIC "${working_dir}/${PYTHON_HEADERS_DIR}")
     target_sources(${target} PRIVATE ${python_headers} ${copied_library})
-    target_link_libraries(${TARGET_NAME} PUBLIC "${copied_library}")
+	IF(NOT WIN32)
+        target_link_libraries(${TARGET_NAME} PUBLIC "${copied_library}")
+	ELSE()
+        #target_link_libraries(${TARGET_NAME} PUBLIC "${CMAKE_BINARY_DIR}/lib/$<$<CONFIG:debug>:PYTHON_STUB_LIBRARY_DEBUG>$<$<CONFIG:release>:PYTHON_STUB_LIBRARY>$<$<CONFIG:MinSizeRel>:PYTHON_STUB_LIBRARY>$<$<CONFIG:RelWithDebInfo>:PYTHON_STUB_LIBRARY>)
+	    target_link_directories(${TARGET_NAME} PUBLIC "${working_dir}/${PYTHON_LIBRARIES_DIR}")
+	ENDIF()
 
     target_compile_definitions(${target} PUBLIC PYTHON_VERSION_MINOR=${PYTHON_VERSION_MINOR})
 

--- a/src/layers/medPython/cmake/python_files_info_win.cmake
+++ b/src/layers/medPython/cmake/python_files_info_win.cmake
@@ -15,6 +15,9 @@
 
 set(PYTHON_VERSION_MINOR 9)
 set(PYTHON_MAIN_LIBRARY python39.dll)
+set(PYTHON_MAIN_LIBRARY_DEBUG python39_d.dll)
+set(PYTHON_STUB_LIBRARY python39.lib)
+set(PYTHON_STUB_LIBRARY_DEBUG python39_d.lib)
 set(PYTHON_HEADERS_DIR headers/python3.9)
 set(PYTHON_LIBRARIES_DIR libraries/python3.9)
 set(PYTHON_MODULES_DIR modules/python3.9)

--- a/src/layers/medPython/tools/bindings/medInria/header.i
+++ b/src/layers/medPython/tools/bindings/medInria/header.i
@@ -9,7 +9,7 @@
 %}
 
 %{
-template <class... ARGS, class SENDER_TYPE>
+template <class SENDER_TYPE, class... ARGS>
 void connect(SENDER_TYPE* sender, void (SENDER_TYPE::*signal)(ARGS...), PyObject* receiver)
 {
     med::python::Object object = med::python::Object::borrowed(receiver);

--- a/src/layers/medPython/tools/bindings/qt/object.i
+++ b/src/layers/medPython/tools/bindings/qt/object.i
@@ -20,7 +20,7 @@ struct QMetaObject
 };
 
 %{
-template <class... ARGS, class SENDER_TYPE>
+template <class SENDER_TYPE, class... ARGS>
 void connect(SENDER_TYPE* sender, void (SENDER_TYPE::*signal)(ARGS...), PyObject* receiver)
 {
     med::python::Object object = med::python::Object::borrowed(receiver);


### PR DESCRIPTION
change add_external_resources.cmake to reduce size of post-build script of medPythonBase on windows.

Add    **MEDCORELEGACY_EXPORT** macro on medExternalResources.h
Remove **MEDPYTHON_EXPORT** macro on some templates and macros
Add    **MEDPYTHON_EXPORT** on some functions and methods
Change **medPython_EXPORTS** to **medPythonBase_EXPORTS** in medPythonExport.h
Add target_link_directories for win32 in embed_python.cmake to find the python static lib stub for python dll implicit load.
Many changes in python_files_info_win.cmake but changes are not already used for the moment. changes are related to the line above.
Change template substitution type order in .i for a good  compilation.