### PR TITLE
[Paint] device ratio for cursor size --master

### DIFF
--- a/src/layers/legacy/medUtilities/medUtilities.cpp
+++ b/src/layers/legacy/medUtilities/medUtilities.cpp
@@ -290,3 +290,18 @@ int medUtilities::getDevicePixelRatio(QMouseEvent* mouseEvent)
 #endif
     return devicePixelRatio;
 }
+
+/**
+ * @brief Get the screen pixel ratio according to the current view
+ * 
+ * @param view a current view to get the screen ratio from
+ * @return int the screen pixel ratio
+ */
+int medUtilities::getDevicePixelRatio(medAbstractView *view)
+{
+    auto * widgetView = view->viewWidget();
+    auto positionView = widgetView->mapToGlobal({widgetView->width()/2,0});
+    int devicePixelRatio = QGuiApplication::screenAt(positionView)->devicePixelRatio();
+
+    return devicePixelRatio;
+}

--- a/src/layers/legacy/medUtilities/medUtilities.cpp
+++ b/src/layers/legacy/medUtilities/medUtilities.cpp
@@ -23,6 +23,8 @@
 #include <QDesktopWidget>
 #include <QLineEdit>
 #include <QInputDialog>
+#include <QGuiApplication>
+#include <QScreen>
 
 #include <vtkImageView3D.h>
 #include <vtkMatrix4x4.h>
@@ -275,4 +277,16 @@ void medUtilities::computeMeanAndVariance(QList<double> samples,
 
     *mean = finalMean;
     *variance = tmpVar;
+}
+
+int medUtilities::getDevicePixelRatio(QMouseEvent* mouseEvent)
+{
+    int devicePixelRatio = 1;
+#if QT_VERSION > QT_VERSION_CHECK(5, 10, 0)
+    devicePixelRatio = QGuiApplication::screenAt(mouseEvent->globalPos())->devicePixelRatio();
+#else
+    int screenNumber = QApplication::desktop()->screenNumber(mouseEvent->globalPos());
+    devicePixelRatio = QGuiApplication::screens().at(screenNumber)->devicePixelRatio();
+#endif
+    return devicePixelRatio;
 }

--- a/src/layers/legacy/medUtilities/medUtilities.h
+++ b/src/layers/legacy/medUtilities/medUtilities.h
@@ -15,6 +15,7 @@
 #include "medUtilitiesExport.h"
 
 #include <QStringList>
+#include <QMouseEvent>
 
 class medAbstractData;
 class medAbstractView;
@@ -54,4 +55,7 @@ public:
     static void switchTo3D(medAbstractView *view, Mode3DType mode3D = VR); // Display mesh in 3D orientation
 
     static void computeMeanAndVariance(QList<double> samples, double* mean, double* variance);
+
+    static int getDevicePixelRatio(QMouseEvent* mouseEvent);
+
 };

--- a/src/layers/legacy/medUtilities/medUtilities.h
+++ b/src/layers/legacy/medUtilities/medUtilities.h
@@ -58,4 +58,6 @@ public:
 
     static int getDevicePixelRatio(QMouseEvent* mouseEvent);
 
+    static int getDevicePixelRatio(medAbstractView *view);
+
 };

--- a/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
+++ b/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
@@ -96,12 +96,7 @@ public:
         if (imageView->is2D())
         {
             // Convert mouse click to a 3D point in the image.
-#if QT_VERSION > QT_VERSION_CHECK(5, 10, 0)
-            int devicePixelRatio = QGuiApplication::screenAt(mouseEvent->globalPos())->devicePixelRatio();
-#else
-            int screenNumber = QApplication::desktop()->screenNumber(mouseEvent->globalPos());
-            int devicePixelRatio = QGuiApplication::screens().at(screenNumber)->devicePixelRatio();
-#endif
+            int devicePixelRatio = medUtilities::getDevicePixelRatio(mouseEvent);
             QPointF mousePos = mouseEvent->localPos() * devicePixelRatio;
             QVector3D posImage = imageView->mapDisplayToWorldCoordinates( mousePos );
 
@@ -158,12 +153,7 @@ public:
 
             if (imageView->is2D())
             {
-#if QT_VERSION > QT_VERSION_CHECK(5, 10, 0)
-                int devicePixelRatio = QGuiApplication::screenAt(mouseEvent->globalPos())->devicePixelRatio();
-#else
-                int screenNumber = QApplication::desktop()->screenNumber(mouseEvent->globalPos());
-                int devicePixelRatio = QGuiApplication::screens().at(screenNumber)->devicePixelRatio();
-#endif
+                int devicePixelRatio = medUtilities::getDevicePixelRatio(mouseEvent);
                 QPointF mousePos = mouseEvent->localPos() * devicePixelRatio;
                 QVector3D posImage = imageView->mapDisplayToWorldCoordinates( mousePos );
 
@@ -195,12 +185,7 @@ public:
 
         if (imageView->is2D())
         {
-#if QT_VERSION > QT_VERSION_CHECK(5, 10, 0)
-            int devicePixelRatio = QGuiApplication::screenAt(mouseEvent->globalPos())->devicePixelRatio();
-#else
-            int screenNumber = QApplication::desktop()->screenNumber(mouseEvent->globalPos());
-            int devicePixelRatio = QGuiApplication::screens().at(screenNumber)->devicePixelRatio();
-#endif
+            int devicePixelRatio = medUtilities::getDevicePixelRatio(mouseEvent);
             QPointF mousePos = mouseEvent->localPos() * devicePixelRatio;
             QVector3D posImage = imageView->mapDisplayToWorldCoordinates( mousePos );
             //Project vector onto plane

--- a/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
+++ b/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
@@ -102,6 +102,9 @@ public:
 
             if (m_paintState != PaintState::Wand)
             {
+                // Update the cursor size for painting
+                m_cb->activateCustomedCursor();
+
                 // add current state to undo stack
                 bool isInside;
                 MaskType::IndexType index;
@@ -572,8 +575,9 @@ void AlgorithmPaintToolBox::activateCustomedCursor()
     }
     else
     {
-        // Adapt radius in mm to scale of view (zoom, crop, etc)
-        qreal radiusSizeDouble = m_brushSizeSlider->value() * currentView->scale();
+        // Adapt to scale of view (zoom, crop, screen ratio, etc)
+        int devicePixelRatio = medUtilities::getDevicePixelRatio(currentView);
+        qreal radiusSizeDouble = m_brushSizeSlider->value() * currentView->scale() / devicePixelRatio;
 
         // Create shape of the new cursor
         QPixmap pix(radiusSizeDouble, radiusSizeDouble);

--- a/src/plugins/legacy/polygonRoi/polygonEventFilter.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonEventFilter.cpp
@@ -224,12 +224,7 @@ bool polygonEventFilter::mouseReleaseEvent(medAbstractView *view, QMouseEvent *m
 
 bool polygonEventFilter::mouseMoveEvent(medAbstractView *view, QMouseEvent *mouseEvent)
 {
-#if QT_VERSION > QT_VERSION_CHECK(5, 10, 0)
-    int devicePixelRatio = QGuiApplication::screenAt(mouseEvent->globalPos())->devicePixelRatio();
-#else
-    int screenNumber = QApplication::desktop()->screenNumber(mouseEvent->globalPos());
-    int devicePixelRatio = QGuiApplication::screens().at(screenNumber)->devicePixelRatio();
-#endif
+    int devicePixelRatio = medUtilities::getDevicePixelRatio(mouseEvent);
 
     savedMousePosition[0] = mouseEvent->x()*devicePixelRatio;
     savedMousePosition[1] = (currentView->viewWidget()->height()-mouseEvent->y()-1)*devicePixelRatio;
@@ -453,12 +448,7 @@ bool polygonEventFilter::rightButtonBehaviour(medAbstractView *view, QMouseEvent
 {
     QMenu mainMenu(currentView->viewWidget());
 
-#if QT_VERSION > QT_VERSION_CHECK(5, 10, 0)
-    int devicePixelRatio = QGuiApplication::screenAt(mouseEvent->globalPos())->devicePixelRatio();
-#else
-    int screenNumber = QApplication::desktop()->screenNumber(mouseEvent->globalPos());
-    int devicePixelRatio = QGuiApplication::screens().at(screenNumber)->devicePixelRatio();
-#endif
+    int devicePixelRatio = medUtilities::getDevicePixelRatio(mouseEvent);
 
     double mousePos[2];
     mousePos[0] = mouseEvent->x()*devicePixelRatio;


### PR DESCRIPTION
Based on PR:
 * https://github.com/Inria-Asclepios/medInria-public/pull/647
 * https://github.com/Inria-Asclepios/medInria-public/pull/730

Twin PR on https://github.com/medInria/medInria-public/pull/971

Compute the right cursor size in the Paint tool, taking into account some screens (for instance Retina) which have different pixel ratio.

:m: