### PR TITLE
[medPythonBaseException] fix exception message bug

### DIFF
--- a/src/layers/medPython/base/error/medPythonBaseException.cpp
+++ b/src/layers/medPython/base/error/medPythonBaseException.cpp
@@ -22,7 +22,7 @@ namespace med::python
 
 struct BaseExceptionPrivate
 {
-    QString message;
+    QByteArray message;
 };
 
 PyObject* BaseException::nativeClass()
@@ -50,7 +50,7 @@ BaseException::~BaseException()
 
 const char* BaseException::what() const throw()
 {
-    return qUtf8Printable(d->message);
+    return d->message;
 }
 
 PyObject* BaseException::createNativeException(PyObject* nativeClass, QString message)
@@ -66,7 +66,7 @@ void BaseException::initializeFromNativeException(PyObject* nativeException)
 {
     if (nativeException)
     {
-        d->message = formatExceptionTraceback(nativeException);
+        d->message = formatExceptionTraceback(nativeException).toUtf8();
         Py_CLEAR(nativeException);
     }
     else


### PR DESCRIPTION
The `qUtf8Printable` macro is the recommended way to convert a `QString` to a UTF8-encoded `const char` pointer (it is equivalent to calling `str.toUtf8().constData()`). The problem is the `toUtf8()` call creates a temporary `QByteArray`, and therefore the macro is not suitable for return values (as is done in `medPythonBaseException::what()`) because the pointer will not be valid after. To fix this problem we store the `QByteArray` in the exception instance instead of the initial `QString`.