### PR TITLE
[medPython] handle errors during init and plugin loading

### DIFF
--- a/src/layers/medPython/base/CMakeLists.txt
+++ b/src/layers/medPython/base/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(${TARGET_NAME} SHARED
 target_compile_definitions(${TARGET_NAME} PRIVATE
     TARGET_NAME="${TARGET_NAME}"
     PYTHON_PLUGIN_PREFIX="${PYTHON_PLUGIN_PREFIX}"
+    PROJECT_NAME="${PROJECT_NAME}"
     )
 
 ## #############################################################################

--- a/src/layers/medPython/base/core/medPythonCoreInit.cpp
+++ b/src/layers/medPython/base/core/medPythonCoreInit.cpp
@@ -41,7 +41,7 @@ bool getResourcesDirectory(QString& resourcesDirectory)
     }
     else
     {
-        qWarning() << "Cannot find the resources directory for " << TARGET_NAME;
+        qCritical() << QString("Cannot find the resources directory for %1.").arg(TARGET_NAME);
     }
 
     return success;
@@ -88,7 +88,8 @@ bool getEncodingsParentDirectory(QString& parentDirectory)
 
         if (!success)
         {
-            qWarning() << "Cannot create temporary directory for the encodings package: " << temporaryEncodingsParentDirectory->errorString();
+            qCritical() << QString("Cannot create temporary directory for the Python encodings package: %1")
+                           .arg(temporaryEncodingsParentDirectory->errorString());
         }
     }
 
@@ -118,7 +119,7 @@ bool getEncodingsDirectory(QString& encodingsDirectory)
             }
             else
             {
-                qWarning() << "Cannot create encodings package directory";
+                qCritical() << "Cannot create the Python encodings package directory";
             }
         }
     }
@@ -154,7 +155,8 @@ bool createEncodingsLink(QFileInfo encodingsFile)
 
         if (!success)
         {
-            qWarning() << "Cannot create symbolic link " << filePath << " -> " << linkPath;
+            qCritical() << QString("Cannot create the symbolic link %1 -> %2.")
+                           .arg(filePath, linkPath);
         }
     }
 
@@ -201,7 +203,8 @@ bool checkStatus(PyStatus status)
 
     if (!success)
     {
-        qWarning() << "Error during initialization of Python: " << status.err_msg;
+        qCritical() << QString("Error during initialization of Python: %1")
+                       .arg(status.err_msg);
     }
 
     return success;
@@ -277,7 +280,7 @@ bool initializeInterpreter(QStringList additionalModulePaths)
     }
     else
     {
-        qWarning() << "Initialization of the embedded Python failed";
+        qCritical() << "Initialization of the embedded Python failed";
         finalizeInterpreter();
     }
 

--- a/src/layers/medPython/base/medPythonUtils.h
+++ b/src/layers/medPython/base/medPythonUtils.h
@@ -22,14 +22,34 @@ namespace med::python
 
 inline const char* PYTHON_SETTINGS_ID = "python";
 
+/// Appends 'path' to sys.path.
+/// (this function may throw Python-related exceptions)
+///
 MEDPYTHON_EXPORT void addPythonPath(QString path);
 
+/// Specifies paths to be appended to sys.path at startup.
+/// The paths are saved in the application settings.
+///
 MEDPYTHON_EXPORT void setStartupPythonPaths(QStringList paths);
 
+/// Retrieves the list of paths that were added to the application settings
+/// through the addPythonPath function.
+///
 MEDPYTHON_EXPORT QStringList getStartupPythonPaths();
 
+/// Loads all top-level packages in sys.path that have the prefix 'medInria_' in
+/// their name. All exceptions are handled. Successfully loaded plugins are
+/// added to the 'loaded_plugins' dict of the medInria module ('med' in the
+/// Python console) and failed plugin errors are added to 'failed_plugins' dict.
+///
 MEDPYTHON_EXPORT void loadPythonPlugins();
 
+/// Executes Python code and returns a dict containing all global objects
+/// resulting from the execution.
+/// (this function may throw Python-related exceptions)
+///
 MEDPYTHON_EXPORT Object runSourceCode(QString sourceCode);
+
+MEDPYTHON_EXPORT void print(QString text);
 
 } // namespace med::python

--- a/src/layers/medPython/tools/CMakeLists.txt
+++ b/src/layers/medPython/tools/CMakeLists.txt
@@ -14,7 +14,7 @@
 ################################################################################
 
 set(TARGET_NAME ${PYTHON_PROJECT_NAME}Tools)
-set(PYTHON_PACKAGE_NAME ${TARGET_NAME})
+set(PYTHON_PACKAGE_NAME ${PROJECT_NAME})
 
 ## #############################################################################
 ## List sources

--- a/src/layers/medPython/tools/medPythonTools.cpp
+++ b/src/layers/medPython/tools/medPythonTools.cpp
@@ -29,41 +29,112 @@ namespace med::python
 namespace
 {
 
-void initializeModulePaths()
+bool initializeModulePaths()
 {
-    addPythonPath(getExternalResourcesDirectory(TARGET_NAME));
-    addPythonPath(getExternalResourcePath(QString(TARGET_NAME) + ".zip", TARGET_NAME));
+    bool success = false;
+    QString pythonToolsDirectory = getExternalResourcesDirectory(TARGET_NAME);
+
+    if (pythonToolsDirectory.isEmpty())
+    {
+        qCritical() << QString("Cannot find the resources directory for %1.")
+                       .arg(TARGET_NAME);
+    }
+    else
+    {
+        QString zipName = QString("%1.zip").arg(TARGET_NAME);
+        QString pythonToolsZip = getExternalResourcePath(zipName, TARGET_NAME);
+
+        if (pythonToolsZip.isEmpty())
+        {
+            qCritical() << QString("Cannot find %1 in %2 resources.")
+                           .arg(zipName, TARGET_NAME);
+        }
+        else
+        {
+            try
+            {
+                addPythonPath(pythonToolsDirectory);
+                addPythonPath(pythonToolsZip);
+                success = true;
+            }
+            catch (Exception& e)
+            {
+                qCritical() << QString("Error while adding Python paths for %1: %2")
+                               .arg(TARGET_NAME, e.what());
+            }
+        }
+    }
+
+    return success;
 }
 
-void importModulesInMainNamespace()
+bool importToolsModule()
 {
-    QString command = QString("from %1 import *").arg(PYTHON_PACKAGE_NAME);
-    coreFunction(PyRun_SimpleString, qUtf8Printable(command));
+    bool success = false;
+
+    try
+    {
+        import(PYTHON_PACKAGE_NAME);
+    }
+    catch (Exception& e)
+    {
+        qCritical() << QString("Error while importing %1: %2")
+                       .arg(PYTHON_PACKAGE_NAME, e.what());
+    }
+
+    return success;
 }
 
-void initializeSettingsWidget()
+bool initializeSettingsWidget()
 {
-    medSettingsWidgetFactory::instance()->registerSettingsWidget<PythonSettingsWidget>();
+    bool success = medSettingsWidgetFactory::instance()->registerSettingsWidget<PythonSettingsWidget>();
+
+    if (!success)
+    {
+        qCritical() << QString("Cannot register %1.").arg(PythonSettingsWidget::staticName());
+    }
+
+    return success;
 }
 
 } // namespace
 
-void initializeTools()
+bool initializeTools()
 {
-    initializeModulePaths();
-    importModulesInMainNamespace();
-    initializeSettingsWidget();
+    bool success = initializeModulePaths() && importToolsModule();
+
+    success &= initializeSettingsWidget();
+    // bitwise AND intended here because we always want the settings widget even
+    // if the tools module was not successfully imported.
+
+    return success;
 }
 
 void startConsole()
 {
-    Module toolsModule = import(PYTHON_PACKAGE_NAME);
-    Object console = toolsModule.attribute("Console").callMethod("createInstance")
-                     .kwarg("title", QString(CONSOLE_TITLE))
-                     .kwarg("size", list<int>({CONSOLE_WIDTH, CONSOLE_HEIGHT}));
-    console.callMethod("setShortcut", QString(CONSOLE_SHORTCUT));
-    console.callMethod("run");
-    qInfo() << "The Python console can be accessed with " << CONSOLE_SHORTCUT;
+    try
+    {
+        Module toolsModule = import(PYTHON_PACKAGE_NAME);
+
+        Object console = toolsModule.attribute("Console").callMethod("createInstance")
+                         .kwarg("title", QString(CONSOLE_TITLE))
+                         .kwarg("size", list<int>({CONSOLE_WIDTH, CONSOLE_HEIGHT}));
+        console.callMethod("setShortcut", QString(CONSOLE_SHORTCUT));
+        console.callMethod("run");
+        qInfo() << "The Python console can be accessed with " << CONSOLE_SHORTCUT;
+
+        Object failedPlugins = toolsModule.attribute("failed_plugins");
+
+        if (failedPlugins)
+        {
+            print("** Some medInria plugins failed to load. Type \"med.plugins()\" for details. **\n\n");
+        }
+    }
+    catch (Exception& e)
+    {
+        qCritical() << QString("Error while starting the Python console: %1")
+                       .arg(e.what());
+    }
 }
 
 } // namespace med::python

--- a/src/layers/medPython/tools/medPythonTools.h
+++ b/src/layers/medPython/tools/medPythonTools.h
@@ -24,7 +24,7 @@ inline const char* CONSOLE_SHORTCUT = "Ctrl+Shift+P";
 inline const int CONSOLE_WIDTH = 800;
 inline const int CONSOLE_HEIGHT = 600;
 
-MEDPYTHONTOOLS_EXPORT void initializeTools();
+MEDPYTHONTOOLS_EXPORT bool initializeTools();
 
 MEDPYTHONTOOLS_EXPORT void startConsole();
 

--- a/src/layers/medPython/tools/python/__init__.py
+++ b/src/layers/medPython/tools/python/__init__.py
@@ -1,7 +1,22 @@
 import sys
-from . import qt_bindings as qt
-from . import medInria_bindings as med
+from . import qt_bindings
+from .medInria_bindings import *
 from .console import Console
 
-sys.modules['medInria'] = med
-sys.modules['qt'] = qt
+sys.modules['qt'] = qt_bindings
+sys.modules['__main__'].__dict__['qt'] = qt_bindings
+sys.modules['__main__'].__dict__['med'] = sys.modules[__name__]
+
+loaded_plugins = dict()
+failed_plugins = dict()
+
+def plugins():
+    if loaded_plugins:
+        print("Successfully loaded plugins:\n\t")
+        for plugin in loaded_plugins.items():
+            print(f"{plugin} ");
+        print("\n")
+    if failed_plugins:
+        print(f"{len(failed_plugins)} plugins(s) failed to load:\n")
+        for plugin, message in failed_plugins.items():
+            print(f"{plugin}:\n{message}\n")

--- a/src/layers/medPython/tools/python/console.py
+++ b/src/layers/medPython/tools/python/console.py
@@ -77,6 +77,7 @@ class Console(qt.QWidget):
         self.outputWidget = qt.QLabel()
         self.outputWidget.setAlignment(qt.AlignLeft | qt.AlignBottom)
         self.outputWidget.setWordWrap(True)
+        self.outputWidget.setTextFormat(qt.PlainText)
         self.scrollArea = qt.QScrollArea()
         self.scrollArea.setWidget(self.outputWidget)
         self.scrollArea.setWidgetResizable(True)
@@ -129,7 +130,7 @@ class Console(qt.QWidget):
     def printWelcomeText(self):
         print(f"Python {sys.version} on {sys.platform}")
         print(logo)
-        print('Type "help", "copyright", "credits" or "license" for more information.\n\n')
+        print('Type "help", "copyright", "credits" or "license" for more information on the embedded Python.\n\n')
   
     def resetInputBuffer(self):
         self.inputBuffer = []


### PR DESCRIPTION
This PR introduces the following changes:

- Add try-catch blocks to handle any Python-related exceptions that might occur during initialisation of medPython.
- Improve documentation, in particular to warn which externally accessible medPython functions can throw exceptions.
- At startup, loop over all the top-level packages found in the Python paths and loads the ones with the prefix `medInria_` in their name (this is how other Python libraries such as Flask load their plugins.
- In the medInria module, add two dicts `loaded_plugins` and `failed_plugins` and a function `plugins()` to get information on the loaded plugins (and any errors).
- Add a message in the console to warn of failed plugins.
- Add a C++ function to allow printing text to the Python console.
- Some changes in how the medPythonTools module is named and loaded.