### PR TITLE
[medPython] isInstance, isSubType, directors

### DIFF
--- a/src/layers/medPython/base/conversion/medPythonQObjectConversion.cpp
+++ b/src/layers/medPython/base/conversion/medPythonQObjectConversion.cpp
@@ -14,7 +14,6 @@
 #include "medPythonQObjectConversion.h"
 
 #include "medPythonConversionUtils.h"
-#include "medPythonError.h"
 
 bool medPythonConvert(const QObject* object, PyObject** output)
 {

--- a/src/layers/medPython/base/objects/medPythonAbstractObject.h
+++ b/src/layers/medPython/base/objects/medPythonAbstractObject.h
@@ -122,6 +122,16 @@ public:
     template <class TYPE>
     TYPE* cast() const;
 
+    bool isInstance(const AbstractObject& type) const;
+
+    template <class TYPE>
+    bool isInstance() const;
+
+    bool isSubType(const AbstractObject& type) const;
+
+    template <class TYPE>
+    bool isSubType() const;
+
     // Due to ciruclar dependency issues, the following three template functions
     // are defined in the header file of their respective return types.
 
@@ -141,6 +151,9 @@ protected:
     void unsupportedFunctionError(QString functionName) const;
 
 private:
+    bool isInstance(QString cppTypeName) const;
+    bool isSubType(const QMetaObject* qMetaObject) const;
+
     void* cast(QString cppTypeName) const;
 };
 
@@ -162,6 +175,18 @@ TYPE* AbstractObject::cast() const
 {
     QString typeName = TYPE::staticMetaObject.className();
     return static_cast<TYPE*>((QObject*)cast(typeName));
+}
+
+template <class TYPE>
+bool AbstractObject::isInstance() const
+{
+    return isInstance(TYPE::staticMetaObject.className());
+}
+
+template <class TYPE>
+bool AbstractObject::isSubType() const
+{
+    return isSubType(&TYPE::staticMetaObject);
 }
 
 } // namespace med::python

--- a/src/layers/medPython/cmake/add_python_bindings.cmake
+++ b/src/layers/medPython/cmake/add_python_bindings.cmake
@@ -56,7 +56,7 @@ function(add_python_bindings cpp_target bindings_target)
         "  {\n"
         "    $action\n"
         "  }\n"
-        "  catch (med::python::Exception e)\n"
+        "  catch (med::python::Exception& e)\n"
         "  {\n"
         "    med::python::raiseError(e.nativeClass(), e.what())\;\n"
         "    SWIG_fail\;\n"

--- a/src/layers/medPython/tools/bindings/medInria/data.i
+++ b/src/layers/medPython/tools/bindings/medInria/data.i
@@ -75,7 +75,6 @@ public:
 %include "dtkCoreSupport/dtkSmartPointer.h"
 %include "dtkCoreSupport/dtkAbstractData.h"
 
-%feature("director") medAbstractData;
 %rename(AbstractData) medAbstractData;
 %include "medAbstractData.h"
 
@@ -162,5 +161,6 @@ public:
 %include "medAbstractImageData.h"
 %include "medAbstractMeshData.h"
 
+%feature("nodirector") medDataManager;
 %rename(DataManager) medDataManager;
 %include "medDataManager.h"

--- a/src/layers/medPython/tools/bindings/medInria/gui.i
+++ b/src/layers/medPython/tools/bindings/medInria/gui.i
@@ -22,7 +22,6 @@ SIGNAL(medDropSite, objectDropped, medDataIndex)
 
 %ignore medToolBoxDetails;
 
-%feature("director") medToolBox;
 %rename(ToolBox) medToolBox;
 %include "medToolBox.h"
 
@@ -72,7 +71,6 @@ SIGNAL(medDropSite, objectDropped, medDataIndex)
 
 }
 
-%feature("director") medAbstractWorkspaceLegacy;
 %rename(Workspace) medAbstractWorkspaceLegacy;
 %include "medAbstractWorkspaceLegacy.h"
 

--- a/src/layers/medPython/tools/bindings/medInria/header.i
+++ b/src/layers/medPython/tools/bindings/medInria/header.i
@@ -1,6 +1,8 @@
 #undef DTKCORESUPPORT_EXPORT
 #define DTKCORESUPPORT_EXPORT
 
+%feature("director");
+
 %pythoncode
 %{
 
@@ -21,3 +23,5 @@ void connect(SENDER_TYPE* sender, void (SENDER_TYPE::*signal)(ARGS...), PyObject
 #define signals private
 
 %include <medCoreLegacyExport.h>
+
+%medPythonTypemaps(med::python::Object)


### PR DESCRIPTION
Changes:
- Add `isInstance` and `isSubType` methods to the Python object API. This is especially useful for SWIG director classes (which allows C++ classes to be extended in Python).
- Generalise director classes instead of explicitly specifying which classes need them.
- Fix some minor bugs.