### PR TITLE
[Tooltip] remove useless space, standardize format

### DIFF
--- a/src/app/medInria/areas/homepage/medHomepageArea.cpp
+++ b/src/app/medInria/areas/homepage/medHomepageArea.cpp
@@ -318,7 +318,7 @@ void medHomepageArea::initPage()
         if (!(medWorkspaceFactory::instance()->isUsable(detail->identifier)))
         {
             button->setDisabled(true);
-            button->setToolTip("No useful plugin has been found for this workspace.");
+            button->setToolTip("No useful plugin has been found for this workspace");
         }
         if(!detail->category.compare("Basic")) 
         {

--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medActionsToolBox.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medActionsToolBox.cpp
@@ -70,7 +70,7 @@ medActionsToolBox::medActionsToolBox( QWidget *parent /*= 0*/, bool FILE_SYSTEM 
     d->viewBt = new QPushButton(d->buttonsWidget);
     d->viewBt->setAccessibleName("View");
     d->viewBt->setText(tr("View"));
-    d->viewBt->setToolTip(tr("Temporarily import (if the data is not already in the database)\nand visualize the currently selected item."));
+    d->viewBt->setToolTip(tr("Temporarily import (if the data is not already in the database)\nand visualize the currently selected item"));
     d->viewBt->setIcon(QIcon(":icons/eye_white.svg"));
     connect(d->viewBt, SIGNAL(clicked()), this, SIGNAL(viewClicked()));
 
@@ -79,13 +79,13 @@ medActionsToolBox::medActionsToolBox( QWidget *parent /*= 0*/, bool FILE_SYSTEM 
         d->loadBt = new QPushButton(d->buttonsWidget);
         d->loadBt->setAccessibleName("Temporary Import");
         d->loadBt->setText(tr("Temporary Import"));
-        d->loadBt->setToolTip(tr("Temporarily import the item(s) so as they can be used inside the application,\nbut do not include them in the database."));
+        d->loadBt->setToolTip(tr("Temporarily import the item(s) so as they can be used inside the application,\nbut do not include them in the database"));
         d->loadBt->setIcon(QIcon(":/icons/import_temporary_white.svg"));
 
         d->importBt = new QPushButton(d->buttonsWidget);
         d->importBt->setAccessibleName("Import");
         d->importBt->setText(tr("Import"));
-        d->importBt->setToolTip(tr("Import (copy) item(s) into the database."));
+        d->importBt->setToolTip(tr("Import (copy) item(s) into the database"));
         d->importBt->setIcon(QIcon(":/icons/import_permanent_white.svg"));
 
         connect(d->importBt, SIGNAL(clicked()), this, SIGNAL(importClicked()));
@@ -101,37 +101,37 @@ medActionsToolBox::medActionsToolBox( QWidget *parent /*= 0*/, bool FILE_SYSTEM 
         d->saveBt = new QPushButton(d->buttonsWidget);
         d->saveBt->setAccessibleName("Save");
         d->saveBt->setText(tr("Save"));
-        d->saveBt->setToolTip(tr("Save selected item into the database."));
+        d->saveBt->setToolTip(tr("Save selected item into the database"));
         d->saveBt->setIcon(QIcon(":/icons/save_white.svg"));
 
         d->newPatientBt = new QPushButton(d->buttonsWidget);
         d->newPatientBt->setAccessibleName("New Patient");
         d->newPatientBt->setText("Patient");
-        d->newPatientBt->setToolTip(tr("Create a new patient."));
+        d->newPatientBt->setToolTip(tr("Create a new patient"));
         d->newPatientBt->setIcon(QIcon(":/icons/user_add_white.svg"));
 
         d->newStudyBt = new QPushButton(d->buttonsWidget);
         d->newStudyBt->setAccessibleName("New Study");
         d->newStudyBt->setText("Study");
-        d->newStudyBt->setToolTip(tr("Create a new study."));
+        d->newStudyBt->setToolTip(tr("Create a new study"));
         d->newStudyBt->setIcon(QIcon(":/icons/study_add_white.svg"));
 
         d->editBt = new QPushButton(d->buttonsWidget);
         d->editBt->setAccessibleName("Edit");
         d->editBt->setText("Edit");
-        d->editBt->setToolTip(tr("Edit item."));
+        d->editBt->setToolTip(tr("Edit item"));
         d->editBt->setIcon(QIcon(":/icons/edit_white.svg"));
 
         d->exportBt = new QPushButton(d->buttonsWidget);
         d->exportBt->setAccessibleName("Export");
         d->exportBt->setText(tr("Export"));
-        d->exportBt->setToolTip(tr("Export the series."));
+        d->exportBt->setToolTip(tr("Export the series"));
         d->exportBt->setIcon(QIcon(":/icons/export_white.svg"));
 
         d->removeBt = new QPushButton(d->buttonsWidget);
         d->removeBt->setAccessibleName("Remove");
         d->removeBt->setText(tr("Remove"));
-        d->removeBt->setToolTip(tr("Remove selected item from the database."));
+        d->removeBt->setToolTip(tr("Remove selected item from the database"));
         d->removeBt->setIcon(QIcon(":/icons/cross_red.svg"));
 
         connect(d->removeBt, SIGNAL(clicked()), this, SIGNAL(removeClicked()));

--- a/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.cpp
@@ -196,7 +196,7 @@ medViewContainer::medViewContainer(medViewContainerSplitter *parent): QFrame(par
 
     // Scene
     d->saveSceneAction = new QAction(tr("Save scene"), d->toolBarMenu);
-    d->saveSceneAction->setToolTip(tr("Save container content as is."));
+    d->saveSceneAction->setToolTip(tr("Save container content as is"));
     d->saveSceneAction->setIcon(QIcon(":icons/save_scene_white.svg"));
     d->saveSceneAction->setIconVisibleInMenu(true);
     connect(d->saveSceneAction, SIGNAL(triggered()), this, SLOT(saveScene()), Qt::UniqueConnection);

--- a/src/plugins/legacy/diffeomorphicDemons/diffeomorphicDemonsToolBox.cpp
+++ b/src/plugins/legacy/diffeomorphicDemons/diffeomorphicDemonsToolBox.cpp
@@ -63,7 +63,7 @@ diffeomorphicDemonsToolBox::diffeomorphicDemonsToolBox(QWidget *parent)
     d->maxStepLengthBox->setToolTip(tr(
                                         "Maximum length of an update vector (voxel units)."
                                         " Setting it to 0 implies no restrictions will be made"
-                                        " on the step length."));
+                                        " on the step length"));
 
     d->updateFieldStdDevBox = new QDoubleSpinBox();
     d->updateFieldStdDevBox->setMinimum(0);
@@ -73,7 +73,7 @@ diffeomorphicDemonsToolBox::diffeomorphicDemonsToolBox(QWidget *parent)
     d->updateFieldStdDevBox->setToolTip(tr(
                                             "Standard deviation of the Gaussian smoothing"
                                             " of the update field (voxel units). Setting it below 0.1"
-                                            " means no smoothing will be performed (default 0.0)."));
+                                            " means no smoothing will be performed (default 0.0)"));
 
     d->disFieldStdDevBox = new QDoubleSpinBox();
     d->disFieldStdDevBox->setMinimum(0);
@@ -83,7 +83,7 @@ diffeomorphicDemonsToolBox::diffeomorphicDemonsToolBox(QWidget *parent)
     d->disFieldStdDevBox->setToolTip(tr(
                                          "Standard deviation of the Gaussian smoothing of"
                                          " the displacement field (voxel units). Setting it below 0.1"
-                                         " means no smoothing will be performed (default 1.5)."));
+                                         " means no smoothing will be performed (default 1.5)"));
     d->updateRuleBox = new QComboBox();
     QStringList updateRules;
     updateRules<< tr("Diffeomorphic") << tr ("Additive") << tr("Compositive");
@@ -95,7 +95,7 @@ diffeomorphicDemonsToolBox::diffeomorphicDemonsToolBox(QWidget *parent)
 
     d->gradientTypeBox = new QComboBox();
     d->gradientTypeBox->setToolTip(tr(
-                                       "Type of gradient used for computing the demons force."));
+                                       "Type of gradient used for computing the demons force"));
     QStringList gradientTypes;
     gradientTypes<< tr("Symmetrized") << tr ("Fixed Image")
                  << tr("Warped Moving Image")

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
@@ -289,7 +289,7 @@ void medVtkViewItkDataImageInteractor::initParameters(medAbstractImageData* data
     connect(d->enableWindowLevelParameter, SIGNAL(valueChanged(bool)), this, SLOT(enableWindowLevel(bool)));
 
     d->enableInterpolation = new medBoolParameterL("Interpolate", this);
-    d->enableInterpolation->setToolTip("Active interpolation\n shortcut is :\n key 'n'");
+    d->enableInterpolation->setToolTip("Active interpolation\n shortcut is :\nkey 'n'");
     d->enableInterpolation->setValue(true);
     connect(d->enableInterpolation, SIGNAL(valueChanged(bool)), this, SLOT(interpolation(bool)));
     connect(d->view2d->qtSignalHandler, SIGNAL(interpolate(bool, int)), this, SLOT(updateInterpolateStatus(bool, int)));

--- a/src/plugins/legacy/itkFilters/itkMorphologicalFiltersToolBox.cpp
+++ b/src/plugins/legacy/itkFilters/itkMorphologicalFiltersToolBox.cpp
@@ -61,12 +61,12 @@ itkMorphologicalFiltersToolBox::itkMorphologicalFiltersToolBox ( QWidget *parent
     QHBoxLayout *kernelSizeLayout = new QHBoxLayout;
     d->mmButton = new QRadioButton(tr("mm"), this);
     d->mmButton->setObjectName("mm");
-    d->mmButton->setToolTip(tr("If \"mm\" is selected, the dimensions of the structuring element will be calculated in mm."));
+    d->mmButton->setToolTip(tr("If \"mm\" is selected, the dimensions of the structuring element will be calculated in mm"));
     d->mmButton->setChecked(true);
 
     d->pixelButton = new QRadioButton(tr("pixels"), this);
     d->pixelButton->setObjectName("pixels");
-    d->pixelButton->setToolTip(tr("If \"pixels\" is selected, the dimensions of the structuring element will be calculated in pixels."));
+    d->pixelButton->setToolTip(tr("If \"pixels\" is selected, the dimensions of the structuring element will be calculated in pixels"));
     connect(d->pixelButton, SIGNAL(toggled(bool)), this, SLOT(roundSpinBox(bool)), Qt::UniqueConnection);
 
     kernelSizeLayout->addWidget ( kernelSizeLabel );

--- a/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
+++ b/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
@@ -271,7 +271,7 @@ AlgorithmPaintToolBox::AlgorithmPaintToolBox(QWidget *parent ) :
     QVBoxLayout *layout = new QVBoxLayout(displayWidget);
 
     m_strokeButton = new QPushButton( tr("Paint / Erase") );
-    m_strokeButton->setToolTip(tr("Left-click: Start painting with specified label.\nRight-click: Erase painted voxels."));
+    m_strokeButton->setToolTip(tr("Left-click: Start painting with specified label.\nRight-click: Erase painted voxels"));
     m_strokeButton->setCheckable(true);
     m_strokeButton->setObjectName("paintButton");
 
@@ -282,7 +282,7 @@ AlgorithmPaintToolBox::AlgorithmPaintToolBox(QWidget *parent ) :
     QPixmap pixmap(":medSegmentation/pixmaps/magic_wand_white.svg");
     QIcon buttonIcon(pixmap);
     m_magicWandButton->setIcon(buttonIcon);
-    m_magicWandButton->setToolTip(tr("Magic wand to automatically paint similar voxels."));
+    m_magicWandButton->setToolTip(tr("Magic wand to automatically paint similar voxels"));
     m_magicWandButton->setCheckable(true);
 
     QHBoxLayout *ButtonLayout = new QHBoxLayout();
@@ -294,7 +294,7 @@ AlgorithmPaintToolBox::AlgorithmPaintToolBox(QWidget *parent ) :
     // Brush radius label/slider/spinbox
     QHBoxLayout *brushSizeLayout = new QHBoxLayout();
     m_brushSizeSlider = new medIntParameterL("Brush Radius (mm)");
-    m_brushSizeSlider->setToolTip(tr("Changes the brush radius."));
+    m_brushSizeSlider->setToolTip(tr("Changes the brush radius"));
     m_brushSizeSlider->setValue(4);
     m_brushSizeSlider->setRange(1, 30);
     m_brushSizeSlider->getSlider()->setPageStep(1);
@@ -319,7 +319,7 @@ AlgorithmPaintToolBox::AlgorithmPaintToolBox(QWidget *parent ) :
     // Magic wand's widgets
     m_wandUpperThresholdSlider = new medDoubleParameterL("Upper Threshold", this);
     m_wandUpperThresholdSlider->setObjectName("Upper Threshold");
-    m_wandUpperThresholdSlider->setToolTip(tr("Changes the upper threshold."));
+    m_wandUpperThresholdSlider->setToolTip(tr("Changes the upper threshold"));
     m_wandUpperThresholdSlider->setValue(0);
     m_wandUpperThresholdSlider->setRange(0, 10000);
     m_wandUpperThresholdSlider->getSlider()->setPageStep(1000);
@@ -330,7 +330,7 @@ AlgorithmPaintToolBox::AlgorithmPaintToolBox(QWidget *parent ) :
 
     m_wandLowerThresholdSlider = new medDoubleParameterL("Lower Threshold", this);
     m_wandLowerThresholdSlider->setObjectName("Lower Threshold");
-    m_wandLowerThresholdSlider->setToolTip(tr("Changes the lower threshold."));
+    m_wandLowerThresholdSlider->setToolTip(tr("Changes the lower threshold"));
     m_wandLowerThresholdSlider->setValue(0);
     m_wandLowerThresholdSlider->setRange(0, 10000);
     m_wandLowerThresholdSlider->getSlider()->setPageStep(1000);
@@ -396,7 +396,7 @@ AlgorithmPaintToolBox::AlgorithmPaintToolBox(QWidget *parent ) :
 
     int defaultLabelValue = 1;
     m_strokeLabelSpinBox = new QSpinBox();
-    m_strokeLabelSpinBox->setToolTip(tr("Changes the painted label."));
+    m_strokeLabelSpinBox->setToolTip(tr("Changes the painted label"));
     m_strokeLabelSpinBox->setValue(defaultLabelValue);
     m_strokeLabelSpinBox->setMinimum(1);
     m_strokeLabelSpinBox->setMaximum(23);
@@ -423,12 +423,12 @@ AlgorithmPaintToolBox::AlgorithmPaintToolBox(QWidget *parent ) :
     layout->addLayout( labelSelectionLayout );
 
     m_addButton = new QPushButton( tr("Add") );
-    m_addButton->setToolTip(tr("Append mask to existing mask."));
+    m_addButton->setToolTip(tr("Append mask to existing mask"));
     m_addButton->setObjectName("addButton");
     m_addButton->setDisabled(true);
     m_addButton->hide();
     m_eraseButton = new QPushButton( tr("Erase") );
-    m_eraseButton->setToolTip(tr("Delete mask from existing mask."));
+    m_eraseButton->setToolTip(tr("Delete mask from existing mask"));
     m_eraseButton->setObjectName("eraseButton");
     m_eraseButton->setDisabled(true);
     m_eraseButton->hide();
@@ -443,7 +443,7 @@ AlgorithmPaintToolBox::AlgorithmPaintToolBox(QWidget *parent ) :
     m_applyButton->setDisabled(true);
 
     m_clearMaskButton = new QPushButton( tr("Clear Mask") );
-    m_clearMaskButton->setToolTip(tr("Resets the mask."));
+    m_clearMaskButton->setToolTip(tr("Resets the mask"));
     m_clearMaskButton->setObjectName("clearMaskButton");
     QHBoxLayout * dataButtonsLayout = new QHBoxLayout();
     dataButtonsLayout->addWidget(m_applyButton);

--- a/src/plugins/legacy/medBinaryOperation/medBinaryOperationToolBox.cpp
+++ b/src/plugins/legacy/medBinaryOperation/medBinaryOperationToolBox.cpp
@@ -51,20 +51,20 @@ medBinaryOperationToolBox::medBinaryOperationToolBox(QWidget *parent)
     d->dropsite->setCanAutomaticallyChangeAppereance(false);
 
     d->clearDropsiteButton = new QPushButton("Clear", widget);
-    d->clearDropsiteButton->setToolTip(tr("Clear previously loaded mask."));
+    d->clearDropsiteButton->setToolTip(tr("Clear previously loaded mask"));
 
     d->xorButton  = new QRadioButton(tr("XOR"), widget);
-    d->xorButton->setToolTip(tr("\"XOR\" keeps pixels which are positive on a volume and not on the other."));
+    d->xorButton->setToolTip(tr("\"XOR\" keeps pixels which are positive on a volume and not on the other"));
     d->xorButton->setChecked(true);
 
     d->andButton  = new QRadioButton(tr("AND"), widget);
-    d->andButton->setToolTip(tr("\"AND\" keeps pixels which are positive on both volumes."));
+    d->andButton->setToolTip(tr("\"AND\" keeps pixels which are positive on both volumes"));
 
     d->orButton  = new QRadioButton(tr("OR"), widget);
-    d->orButton->setToolTip(tr("\"OR\" keeps keep positive pixels from both volumes."));
+    d->orButton->setToolTip(tr("\"OR\" keeps keep positive pixels from both volumes"));
 
     d->notButton  = new QRadioButton(tr("NOT"), widget);
-    d->notButton->setToolTip(tr("\"NOT\" does an inversion of the volume."));
+    d->notButton->setToolTip(tr("\"NOT\" does an inversion of the volume"));
 
     QVBoxLayout *roiButtonLayout = new QVBoxLayout;
     roiButtonLayout->addWidget(d->dropsite);

--- a/src/plugins/legacy/medMaskApplication/medMaskApplicationToolBox.cpp
+++ b/src/plugins/legacy/medMaskApplication/medMaskApplicationToolBox.cpp
@@ -53,7 +53,7 @@ medMaskApplicationToolBox::medMaskApplicationToolBox(QWidget *parent) :
     bundlingLayout->addWidget(d->maskDropSite);
 
     QPushButton *clearMaskButton = new QPushButton("Clear mask", widget);
-    clearMaskButton->setToolTip(tr("Clear previously loaded mask."));
+    clearMaskButton->setToolTip(tr("Clear previously loaded mask"));
     clearMaskButton->setFixedWidth(d->maskDropSite->sizeHint().width());
     connect (clearMaskButton, SIGNAL(clicked()), this, SLOT(clearMask()));
     bundlingLayout->addWidget(clearMaskButton);

--- a/src/plugins/legacy/medN4BiasCorrection/medN4BiasCorrectionToolBox.cpp
+++ b/src/plugins/legacy/medN4BiasCorrection/medN4BiasCorrectionToolBox.cpp
@@ -55,7 +55,7 @@ medN4BiasCorrectionToolBox::medN4BiasCorrectionToolBox(QWidget *parent)
 
     QLabel *widthLabel = new QLabel (tr("Bias Field Full Width at Half Maximum: "));
     widthLabel->setToolTip(
-        "Parameter characterizing the width of the Gaussian deconvolution.\n Zero implies use of the default value = 0.15.");
+        "Parameter characterizing the width of the Gaussian deconvolution.\nZero implies use of the default value = 0.15");
     d->widthSpinBox = new QDoubleSpinBox;
     d->widthSpinBox->setMaximum(10);
     d->widthSpinBox->setMinimum(0);
@@ -77,7 +77,7 @@ medN4BiasCorrectionToolBox::medN4BiasCorrectionToolBox(QWidget *parent)
 
     QLabel *convThresholdLabel = new QLabel (tr("Convergence threshold: "));
     convThresholdLabel->setToolTip(
-        "Convergence is determined by the coefficient of variation of the\ndifference image between the current bias field estimate and the previous estimate.\n If this value is less than the specified threshold, the algorithm\nproceeds to the next fitting level or terminates if it is at the last level. ");
+        "Convergence is determined by the coefficient of variation of the\ndifference image between the current bias field estimate and the previous estimate.\nIf this value is less than the specified threshold, the algorithm\nproceeds to the next fitting level or terminates if it is at the last level");
     d->convThresholdSpinBox = new QDoubleSpinBox;
     d->convThresholdSpinBox->setMaximum(1);
     d->convThresholdSpinBox->setMinimum(0);
@@ -90,7 +90,7 @@ medN4BiasCorrectionToolBox::medN4BiasCorrectionToolBox(QWidget *parent)
 
     QLabel *bsplineOrderLabel = new QLabel (tr("B-Spline Order: "));
     bsplineOrderLabel->setToolTip(
-        "Spline order defining the bias field estimate.\nCubic splines (order = 3) are typically used.");
+        "Spline order defining the bias field estimate.\nCubic splines (order = 3) are typically used");
     d->bsplineOrderSpinBox = new QSpinBox;
     d->bsplineOrderSpinBox->setMaximum(10);
     d->bsplineOrderSpinBox->setMinimum(0);
@@ -102,7 +102,7 @@ medN4BiasCorrectionToolBox::medN4BiasCorrectionToolBox(QWidget *parent)
 
     QLabel *shrinkFactorLabel = new QLabel (tr("Shrink Factor: "));
     shrinkFactorLabel->setToolTip(
-        "To lessen computation time, the input image can be resampled.\nThe shrink factor, specified as a single integer, describes\nthis resampling.  Shrink factors <= 4 are commonly used.");
+        "To lessen computation time, the input image can be resampled.\nThe shrink factor, specified as a single integer, describes\nthis resampling.  Shrink factors <= 4 are commonly used");
     d->shrinkFactorSpinBox = new QSpinBox;
     d->shrinkFactorSpinBox->setMaximum(10);
     d->shrinkFactorSpinBox->setMinimum(0);
@@ -114,7 +114,7 @@ medN4BiasCorrectionToolBox::medN4BiasCorrectionToolBox(QWidget *parent)
 
     QLabel *nbHistogramBinsLabel = new QLabel (tr("Number of Histogram Bins: "));
     nbHistogramBinsLabel->setToolTip(
-        "Number of bins defining the log input intensity histogram.\nZero implies use of the default value = 200.");
+        "Number of bins defining the log input intensity histogram.\nZero implies use of the default value = 200");
     d->nbHistogramBinsSpinBox = new QSpinBox;
     d->nbHistogramBinsSpinBox->setMaximum(1000);
     d->nbHistogramBinsSpinBox->setMinimum(0);
@@ -126,7 +126,7 @@ medN4BiasCorrectionToolBox::medN4BiasCorrectionToolBox(QWidget *parent)
 
     QLabel *wienerNoiseLabel = new QLabel (tr("Wiener Filter Noise: "));
     wienerNoiseLabel->setToolTip(
-        "Noise estimate defining the Wiener filter.\nZero implies use of the default value = 0.01.");
+        "Noise estimate defining the Wiener filter.\nZero implies use of the default value = 0.01");
     d->wienerNoiseSpinBox = new QDoubleSpinBox;
     d->wienerNoiseSpinBox->setMaximum(1);
     d->wienerNoiseSpinBox->setMinimum(0);

--- a/src/plugins/legacy/medRemeshing/medRemeshingToolBox.cpp
+++ b/src/plugins/legacy/medRemeshing/medRemeshingToolBox.cpp
@@ -81,7 +81,7 @@ medRemeshingToolBox::medRemeshingToolBox(QWidget *parent)
     displayLayout->addLayout(layoutDecimate);
 
     d->topologyRadioButton = new QRadioButton(tr("Preserve topology during decimation"));
-    d->topologyRadioButton->setToolTip("Turn on/off whether to preserve the mesh topology.\n If on, splitting and hole elimination will not occur.\n Can limit the maximum reduction that may be achieved.");
+    d->topologyRadioButton->setToolTip("Turn on/off whether to preserve the mesh topology.\nIf on, splitting and hole elimination will not occur.\nCan limit the maximum reduction that may be achieved");
     d->topologyRadioButton->setChecked(true);
     d->topologyRadioButton->setObjectName("topologyRadioButton");
     displayLayout->addWidget(d->topologyRadioButton);

--- a/src/plugins/legacy/medVtkFibersData/interactors/medVtkFibersDataInteractor.cpp
+++ b/src/plugins/legacy/medVtkFibersData/interactors/medVtkFibersDataInteractor.cpp
@@ -248,7 +248,7 @@ medVtkFibersDataInteractor::medVtkFibersDataInteractor(medAbstractView *parent):
     d->bundleToolboxWidget = nullptr;
 
     d->colorFiberParameter = new medStringListParameterL("colorFiberParameter", this);
-    d->colorFiberParameter->setToolTip(tr("Choose the coloring method of the fibers."));
+    d->colorFiberParameter->setToolTip(tr("Choose the coloring method of the fibers"));
     d->colorFiberParameter->getLabel()->setText(tr("Color fibers by:"));
     d->colorFiberParameter->addItem("Local orientation");
     d->colorFiberParameter->addItem("Global orientation");
@@ -264,20 +264,20 @@ medVtkFibersDataInteractor::medVtkFibersDataInteractor(medAbstractView *parent):
     d->parameters << d->LutFiberParameter;
 
     d->alphaTransparencyParameter = new medBoolParameterL("ActivateTransparencyParameter", this);
-    d->alphaTransparencyParameter->setToolTip(tr("Activate transparency."));
+    d->alphaTransparencyParameter->setToolTip(tr("Activate transparency"));
     d->alphaTransparencyParameter->setText(tr("Activate transparency"));
     d->alphaTransparencyParameter->getCheckBox()->setEnabled(true);
     d->parameters << d->alphaTransparencyParameter;
 
     d->minIntensityParameter = new medDoubleParameterL("Min Intensity", this);
-    d->minIntensityParameter->setToolTip(tr("Min Intensity."));
+    d->minIntensityParameter->setToolTip(tr("Min Intensity"));
     d->minIntensityParameter->getLabel()->setText(tr("Min Intensity:"));
     d->minIntensityParameter->setRange(0.0, 1.0);
     d->minIntensityParameter->setValue(0);
     d->parameters << d->minIntensityParameter;
 
     d->maxIntensityParameter = new medDoubleParameterL("Max Intensity", this);
-    d->maxIntensityParameter->setToolTip(tr("Max Intensity."));
+    d->maxIntensityParameter->setToolTip(tr("Max Intensity"));
     d->maxIntensityParameter->getLabel()->setText(tr("Max Intensity:"));
     d->maxIntensityParameter->setRange(0.0, 1.0);
     d->maxIntensityParameter->setValue(1);
@@ -292,17 +292,17 @@ medVtkFibersDataInteractor::medVtkFibersDataInteractor(medAbstractView *parent):
     d->parameters << d->shapesDisplayedGroupParameter;
 
     d->displayPolylinesParameter = new medBoolParameterL("displayPolylinesParameter", this);
-    d->displayPolylinesParameter->setToolTip(tr("Use polylines to draw the fibers."));
+    d->displayPolylinesParameter->setToolTip(tr("Use polylines to draw the fibers"));
     d->displayPolylinesParameter->setText(tr("Display fibers as polylines"));
     d->displayPolylinesParameter->getLabel()->hide();
     d->shapesDisplayedGroupParameter->addParameter(d->displayPolylinesParameter);
     d->displayRibbonsParameter = new medBoolParameterL("displayRibbonsParameter", this);
-    d->displayRibbonsParameter->setToolTip(tr("Use ribbons to draw the fibers."));
+    d->displayRibbonsParameter->setToolTip(tr("Use ribbons to draw the fibers"));
     d->displayRibbonsParameter->setText(tr("Display fibers as ribbons"));
     d->displayRibbonsParameter->getLabel()->hide();
     d->shapesDisplayedGroupParameter->addParameter(d->displayRibbonsParameter);
     d->displayTubesParameter = new medBoolParameterL("displayTubesParameter", this);
-    d->displayTubesParameter->setToolTip(tr("Use tubes to draw the fibers."));
+    d->displayTubesParameter->setToolTip(tr("Use tubes to draw the fibers"));
     d->displayTubesParameter->setText(tr("Display fibers as tubes"));
     d->displayTubesParameter->getLabel()->hide();
     d->shapesDisplayedGroupParameter->addParameter(d->displayTubesParameter);
@@ -310,7 +310,7 @@ medVtkFibersDataInteractor::medVtkFibersDataInteractor(medAbstractView *parent):
     d->displayPolylinesParameter->setValue(true);
 
     d->radiusParameter = new medIntParameterL("fibersRadiusParameter", this);
-    d->radiusParameter->setToolTip(tr("Increase of decrease the radius of the fibers (except if there are being drawn with polylines)."));
+    d->radiusParameter->setToolTip(tr("Increase or decrease the radius of the fibers (except if there are being drawn with polylines)"));
     d->radiusParameter->getLabel()->setText(tr("Fibers radius:"));
     d->radiusParameter->setRange(1, 10);
 
@@ -322,18 +322,18 @@ medVtkFibersDataInteractor::medVtkFibersDataInteractor(medAbstractView *parent):
 
     //--Bundling
     d->andParameter = new medBoolParameterL("andFiberParameter", this);
-    d->andParameter->setToolTip(tr("If \"AND\" is selected fibers will need to overlap with this ROI to be displayed."));
+    d->andParameter->setToolTip(tr("If \"AND\" is selected fibers will need to overlap with this ROI to be displayed"));
     d->andParameter->setText("AND");
     d->andParameter->setValue(true);
     d->andParameter->getLabel()->hide();
 
     d->notParameter = new medBoolParameterL("notFiberParameter", this);
-    d->notParameter->setToolTip(tr("If \"NOT\" is selected fibers overlapping with this ROI will not be displayed."));
+    d->notParameter->setToolTip(tr("If \"NOT\" is selected fibers overlapping with this ROI will not be displayed"));
     d->notParameter->setText("NOT");
     d->notParameter->getLabel()->hide();
 
     d->nullParameter = new medBoolParameterL("nullFiberParameter", this);
-    d->nullParameter->setToolTip(tr("If \"NULL\" is selected this ROI won't be taken into account."));
+    d->nullParameter->setToolTip(tr("If \"NULL\" is selected this ROI won't be taken into account"));
     d->nullParameter->setText("NULL");
     d->nullParameter->getLabel()->hide();
 
@@ -343,11 +343,11 @@ medVtkFibersDataInteractor::medVtkFibersDataInteractor(medAbstractView *parent):
     d->bundleOperationGroupParameter->addParameter(d->nullParameter);
 
     d->tagParameter = new medTriggerParameterL("tagFiberParameter", this);
-    d->tagParameter->setToolTip(tr("Tag the currently shown bundle to let the application memorize it and another, new bundling box, will appear.\nThis new box will also isolate fibers but will also consider the previously \"tagged\" fibers."));
+    d->tagParameter->setToolTip(tr("Tag the currently shown bundle to let the application memorize it and another, new bundling box, will appear.\nThis new box will also isolate fibers but will also consider the previously \"tagged\" fibers"));
     d->tagParameter->setButtonText("Tag");
 
     d->addParameter = new medBoolParameterL("addFiberParameter", this);
-    d->addParameter->setToolTip(tr("Select to either include the fibers that overlap with the bundling box, or to include the ones that do not overlap."));
+    d->addParameter->setToolTip(tr("Select to either include the fibers that overlap with the bundling box, or to include the ones that do not overlap"));
     d->addParameter->setText("Add");
     d->addParameter->setValue(true);
 
@@ -365,12 +365,12 @@ medVtkFibersDataInteractor::medVtkFibersDataInteractor(medAbstractView *parent):
     
     d->showAllBundleParameter = new medBoolParameterL("showAllBundleFiberParameter", this);
     d->showAllBundleParameter->setValue(true);
-    d->showAllBundleParameter->setToolTip(tr("Uncheck if you do not want the previously validated bundles to be displayed."));
+    d->showAllBundleParameter->setToolTip(tr("Uncheck if you do not want the previously validated bundles to be displayed"));
     d->showAllBundleParameter->setText(tr("Show all bundles"));
     d->parameters << d->showAllBundleParameter;
 
     d->showBundleBox = new medBoolParameterL("showBundleFiberBox", this);
-    d->showBundleBox->setToolTip(tr("Select to activate and show the fiber bundling box on the screen."));
+    d->showBundleBox->setToolTip(tr("Select to activate and show the fiber bundling box on the screen"));
     d->showBundleBox->setText("Activate bundling box");
     d->showBundleBox->setValue(false);
 
@@ -1434,12 +1434,12 @@ QWidget* medVtkFibersDataInteractor::buildToolBoxWidget()
     toolBoxLayout->addWidget(d->bundleToolboxWidget);
 
     d->dropOrOpenRoi = new medDropSite(d->toolboxWidget);
-    d->dropOrOpenRoi->setToolTip(tr("Drag-and-drop A ROI from the database."));
+    d->dropOrOpenRoi->setToolTip(tr("Drag-and-drop A ROI from the database"));
     d->dropOrOpenRoi->setText(tr("Drag-and-drop\nfrom the database\nto open a ROI."));
     d->dropOrOpenRoi->setCanAutomaticallyChangeAppereance(false);
 
     QPushButton *clearRoiButton = new QPushButton("Clear ROI", d->toolboxWidget);
-    clearRoiButton->setToolTip(tr("Clear previously loaded ROIs."));
+    clearRoiButton->setToolTip(tr("Clear previously loaded ROIs"));
 
     d->roiComboBox = new QComboBox(d->bundleToolboxWidget);
     if (!d->roiLabels.isEmpty())
@@ -1455,7 +1455,7 @@ QWidget* medVtkFibersDataInteractor::buildToolBoxWidget()
         d->roiComboBox->setCurrentIndex(0);
     }
 
-    d->roiComboBox->setToolTip(tr("Select a ROI to modify how its interaction with the fibers affects whether they are displayed."));
+    d->roiComboBox->setToolTip(tr("Select a ROI to modify how its interaction with the fibers affects whether they are displayed"));
 
     bundleToolboxLayout->addWidget(d->dropOrOpenRoi, 0, Qt::AlignCenter);
     bundleToolboxLayout->addWidget(clearRoiButton, 0, Qt::AlignCenter);

--- a/src/plugins/legacy/meshMapping/meshMappingToolBox.cpp
+++ b/src/plugins/legacy/meshMapping/meshMappingToolBox.cpp
@@ -49,8 +49,7 @@ meshMappingToolBox::meshMappingToolBox(QWidget *parent)
     d->layersForData->addItem("Select the data to map", 0);
 
     QLabel *structureLabel = new QLabel("Mesh", this);
-    structureLabel->setToolTip(tr("Select the mesh whose geometry will be used\n \
-                                  in determining positions to map"));
+    structureLabel->setToolTip(tr("Select the mesh whose geometry will be used\nin determining positions to map"));
     d->layersForStructure = new QComboBox;
     d->layersForStructure->addItem("Select the mesh", 0);
     

--- a/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
@@ -45,7 +45,7 @@ polygonRoiToolBox::polygonRoiToolBox(QWidget *parent ) :
     displayWidget->setLayout(layout);
 
     activateTBButton = new QPushButton(tr("Activate Toolbox"));
-    activateTBButton->setToolTip(tr("Activate closed polygon mode.\nYou should only have one view."));
+    activateTBButton->setToolTip(tr("<p>Activate closed polygon mode. You should only have one view</p>"));
     activateTBButton->setCheckable(true);
     activateTBButton->setObjectName("closedPolygonButton");
     connect(activateTBButton,SIGNAL(toggled(bool)),this,SLOT(clickClosePolygon(bool)));
@@ -97,13 +97,13 @@ polygonRoiToolBox::polygonRoiToolBox(QWidget *parent ) :
     QLabel *saveLabel = new QLabel("Save segmentations as:");
     QHBoxLayout *saveButtonsLayout = new QHBoxLayout();
     saveBinaryMaskButton = new QPushButton(tr("Mask(s)"));
-    saveBinaryMaskButton->setToolTip("Import the current mask to the non persistent database");
+    saveBinaryMaskButton->setToolTip("<p>Import the current mask to the non persistent database</p>");
     saveBinaryMaskButton->setObjectName(generateBinaryImageButtonName);
     connect(saveBinaryMaskButton,SIGNAL(clicked()),this,SLOT(saveBinaryImage()));
     saveButtonsLayout->addWidget(saveBinaryMaskButton);
 
     saveContourButton = new QPushButton("Contour(s)");
-    saveContourButton->setToolTip("Export these contours as an .ctrb file loadable only in this application.");
+    saveContourButton->setToolTip("<p>Export these contours as an .ctrb file loadable only in this application</p>");
     saveContourButton->setMinimumSize(150, 20);
     saveContourButton->setMaximumSize(150, 20);
     saveContourButton->setObjectName("saveContoursButton");

--- a/src/plugins/process/bias_correction/medItkBiasCorrectionProcess.cpp
+++ b/src/plugins/process/bias_correction/medItkBiasCorrectionProcess.cpp
@@ -60,7 +60,7 @@ medItkBiasCorrectionProcess::medItkBiasCorrectionProcess(QObject *parent): medAb
 
     m_poSMaxIterations = new medStringParameter("Iterations", this);
     m_poSMaxIterations->setCaption("Rounds of iterations");
-    m_poSMaxIterations->setDescription("Number of round and number of iteration per round\n like 50x40x30");
+    m_poSMaxIterations->setDescription("Number of round and number of iteration per round\nlike 50x40x30");
     m_poSMaxIterations->setValidator(new QRegExpValidator(QRegExp("^[1-9][0-9]{0,2}(x[1-9][0-9]{0,2})*")));
     m_poSMaxIterations->setValue("50x40x30");
 


### PR DESCRIPTION
Standardize the way tooltips are written:
 * remove "\n" followed by space 
 * remove dot at the end
 * add line break for some long tooltips
 
:m: