### PR TITLE
[Browser] ghost toolboxes from PACS/CD tab in DB and FS tabs

### DIFF
--- a/src/app/medInria/areas/browser/medBrowserArea.cpp
+++ b/src/app/medInria/areas/browser/medBrowserArea.cpp
@@ -79,20 +79,15 @@ medBrowserArea::medBrowserArea(QWidget *parent) : QWidget(parent), d(new medBrow
     // make toolboxes visible
     onSourceIndexChanged(d->stack->currentIndex());
 
-    //Check if there are already item in the database, otherwise, switch to File system datasource
-    QList<medDataIndex> indexes = medDatabaseNonPersistentController::instance()->availableItems();
-    QList<medDataIndex> patients = medDataManager::instance()->controller()->patients(); 
-    if (indexes.isEmpty() && patients.isEmpty())
-    {
-        d->sourceSelectorToolBox->setCurrentTab(1);
-    }
-
     // DataSources
     for(medAbstractDataSource *dataSource : medDataSourceManager::instance()->dataSources())
     {
         addDataSource(dataSource);
     }
- }
+
+    // Switch to default "File system" tab
+    d->sourceSelectorToolBox->setCurrentTab(1);
+}
 
 medBrowserArea::~medBrowserArea()
 {

--- a/src/layers/legacy/medCoreLegacy/gui/medToolBoxContainer.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/medToolBoxContainer.cpp
@@ -57,10 +57,10 @@ void medToolBoxContainer::insertToolBox(int index, medToolBox* toolBox)
     if (toolBox)
     {
         d->toolboxes.insert(index, toolBox);
+        toolBox->setParent(d->container);
         d->layout->setStretch(d->layout->count()-1, 0);
         d->layout->insertWidget(index, toolBox, 0, Qt::AlignTop);
         d->layout->addStretch(1);
-        toolBox->show();
     }
 }
 


### PR DESCRIPTION
This Pull Request solves 2 problems:
 * there were ghost toolboxes in tabs in Browser area (fix https://github.com/medInria/medInria-public/issues/949) -> no more ghosts
 * the default tab was defined before adding the data sources, which was not working, and users are often lost with Browser -> File system is the default one

:m: