### PR TITLE
[Browser] ghost toolboxes from PACS/CD tab in DB and FS tabs-master

### DIFF
--- a/src/app/medInria/areas/browser/medBrowserArea.cpp
+++ b/src/app/medInria/areas/browser/medBrowserArea.cpp
@@ -80,20 +80,15 @@ medBrowserArea::medBrowserArea(QWidget *parent) : QWidget(parent), d(new medBrow
     // make toolboxes visible
     onSourceIndexChanged(d->stack->currentIndex());
 
-    //Check if there are already item in the database, otherwise, switch to File system datasource
-    QList<medDataIndex> indexes = medDatabaseNonPersistentController::instance()->availableItems();
-    QList<medDataIndex> patients = medDatabaseController::instance()->patients();
-    if (indexes.isEmpty() && patients.isEmpty())
-    {
-        d->sourceSelectorToolBox->setCurrentTab(1);
-    }
-
     // DataSources
     for(medAbstractDataSource *dataSource : medDataSourceManager::instance()->dataSources())
     {
         addDataSource(dataSource);
     }
- }
+
+    // Switch to default "File system" tab
+    d->sourceSelectorToolBox->setCurrentTab(1);
+}
 
 medBrowserArea::~medBrowserArea()
 {


### PR DESCRIPTION
Same as https://github.com/medInria/medInria-public/pull/987

This Pull Request solves 2 problems:
 * there were ghost toolboxes in tabs in Browser area (fix https://github.com/medInria/medInria-public/issues/949) -> no more ghosts
 * the default tab was defined before adding the data sources, which was not working, and users are often lost with Browser -> File system is the default one

:m: