### PR TITLE
allow external resource subdirectories

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -179,17 +179,6 @@ if (WIN32)
 endif()
 
 ## #############################################################################
-## Setup resources directory (for Windows and Linux)
-## #############################################################################
-
-if (NOT APPLE)
-  set(${PROJECT_NAME}_RESOURCES_DIR "${CMAKE_BINARY_DIR}/resources")
-  add_custom_target(make_resource_dir ALL
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${${PROJECT_NAME}_RESOURCES_DIR}"
-    )
-endif()
-
-## #############################################################################
 ## Add subdirectory
 ## #############################################################################
 

--- a/src/app/medInria/CMakeLists.txt
+++ b/src/app/medInria/CMakeLists.txt
@@ -114,7 +114,7 @@ add_executable(${TARGET_NAME} ${DEPLOYMENT_SYSTEM} # Empty for Linux
 
 if (APPLE)
   set_target_properties(${TARGET_NAME} PROPERTIES MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/cmake/MedInriaOSXBundleInfo.plist.in")
-  add_external_resources(${TARGET_NAME} "${CMAKE_CURRENT_SOURCE_DIR}/resources/${TARGET_NAME}.icns")
+  add_external_resources(${TARGET_NAME} FILES "${CMAKE_CURRENT_SOURCE_DIR}/resources/${TARGET_NAME}.icns")
 endif()
 
 ## #############################################################################

--- a/src/layers/legacy/medCoreLegacy/medExternalResources.cpp
+++ b/src/layers/legacy/medCoreLegacy/medExternalResources.cpp
@@ -70,7 +70,7 @@ QString getResourcesDirectoryForMacPackage(QString libraryName)
 }
 
 // (see getResourcesDirectoryForMacPackage for implementation notes)
-QString getResourcePathForMacPackage(QString filename, QString libraryName)
+QString getResourcePathForMacPackage(QString filename, QString subdirectory, QString libraryName)
 {
     QString result;
     CFBundleRef bundle = getBundleOrFramework(libraryName);
@@ -78,8 +78,20 @@ QString getResourcePathForMacPackage(QString filename, QString libraryName)
     if (bundle)
     {
         CFStringRef resourceName = CFStringCreateWithCString(nullptr, qUtf8Printable(filename), kCFStringEncodingUTF8);
-        CFURLRef resourceURL = CFBundleCopyResourceURL(bundle, resourceName, nullptr, nullptr);
+        CFStringRef resourceSubDir = nullptr;
+
+        if (!subdirectory.isEmpty())
+        {
+            resourceSubDir = CFStringCreateWithCString(nullptr, qUtf8Printable(subdirectory), kCFStringEncodingUTF8);
+        }
+
+        CFURLRef resourceURL = CFBundleCopyResourceURL(bundle, resourceName, nullptr, resourceSubDir);
         CFRelease(resourceName);
+
+        if (resourceSubDir)
+        {
+            CFRelease(resourceSubDir);
+        }
 
         if (resourceURL)
         {
@@ -127,18 +139,23 @@ QString getResourcesDirectoryFromApplicationDirectory(QString libraryName)
 
 // Search for the resource in the '../resources/[libraryName/]' directory
 // relative to the application directory.
-QString getResourcePathFromApplicationDirectory(QString filename, QString libraryName)
+QString getResourcePathFromApplicationDirectory(QString filename, QString subdirectory, QString libraryName)
 {
     QString result;
     QString resourcesDirectory = getResourcesDirectoryFromApplicationDirectory(libraryName);
 
     if (!resourcesDirectory.isEmpty())
     {
-        QString resourceFilePath = QDir(resourcesDirectory).filePath(filename);
+        QDir resourcesSubdirectory = resourcesDirectory;
 
-        if (QFileInfo::exists(resourceFilePath))
+        if (subdirectory.isEmpty() || resourcesSubdirectory.cd(subdirectory))
         {
-            result = resourceFilePath;
+            QString resourceFilePath = resourcesSubdirectory.filePath(filename);
+
+            if (QFileInfo::exists(resourceFilePath))
+            {
+                result = resourceFilePath;
+            }
         }
     }
 
@@ -149,27 +166,41 @@ QString getResourcePathFromApplicationDirectory(QString filename, QString librar
 
 } // namespace
 
-QString getExternalResourcesDirectory(QString libraryName)
+QString getExternalResourcesDirectory(QString subdirectory, QString libraryName)
 {
     QString result;
+    QDir resourcesDirectory;
 
 #if defined(Q_OS_MACOS)
-    result = getResourcesDirectoryForMacPackage(libraryName);
+    resourcesDirectory.setPath(getResourcesDirectoryForMacPackage(libraryName));
 #else
-    result = getResourcesDirectoryFromApplicationDirectory(libraryName);
+    resourcesDirectory.setPath(getResourcesDirectoryFromApplicationDirectory(libraryName));
 #endif
+
+    if (subdirectory.isEmpty() || resourcesDirectory.cd(subdirectory))
+    {
+        result = resourcesDirectory.absolutePath();
+    }
 
     return result;
 }
 
-QString getExternalResourcePath(QString filename, QString libraryName)
+QString getExternalResourcePath(QString filepath, QString libraryName)
 {
     QString result;
+    QFileInfo fileInfo = filepath;
+    QString filename = fileInfo.fileName();
+    QString subdirectory = fileInfo.dir().path();
+
+    if (subdirectory == ".")
+    {
+        subdirectory.clear();
+    }
 
 #if defined(Q_OS_MACOS)
-    result = getResourcePathForMacPackage(filename, libraryName);
+    result = getResourcePathForMacPackage(filename, subdirectory, libraryName);
 #else
-    result = getResourcePathFromApplicationDirectory(filename, libraryName);
+    result = getResourcePathFromApplicationDirectory(filename, subdirectory, libraryName);
 #endif
 
     return result;

--- a/src/layers/legacy/medCoreLegacy/medExternalResources.h
+++ b/src/layers/legacy/medCoreLegacy/medExternalResources.h
@@ -31,12 +31,12 @@ namespace med
 // Returns the directory containing the external resources for the project or
 // one of its libraries. A null string is returned if the directory does not
 // exist.
-MEDCORELEGACY_EXPORT QString getExternalResourcesDirectory(QString libraryName = QString());
+MEDCORELEGACY_EXPORT QString getExternalResourcesDirectory(QString subdirectory = QString(), QString libraryName = QString());
 
 // Returns the path of an external resource that was added using
 // add_external_resources in the cmake project. If the resource was added
 // through a library target then the library name must be provided. A null
 // string is returned if the resource is not found.
-MEDCORELEGACY_EXPORT QString getExternalResourcePath(QString filename, QString libraryName = QString());
+MEDCORELEGACY_EXPORT QString getExternalResourcePath(QString filepath, QString libraryName = QString());
 
 } // namespace med


### PR DESCRIPTION
Until now the external resources were restricted to a flat layout. Now it is possible to have a more structured resource layout.

The following changes are made:
- removal of `${PROJECT_NAME}_RESOURCES_DIR`(everything is handled directly in `add_external_resources.cmake`).
- add possibility to specify entire directories as resources.
-  add possibility to place resources in a subdirectory of the resource path.

_This PR introduces changes that break medPython. A second PR (coming soon) will fix it. Also the  `add_external_resources.cmake` macro has changed completely. I don't know yet if this works for the packaging on Linux and Windows. This will be testable with the next PR._ 