### PR TITLE
mac_packager: fix plugin install names

### DIFF
--- a/packaging/apple/ApplePackaging.cmake
+++ b/packaging/apple/ApplePackaging.cmake
@@ -40,6 +40,7 @@ configure_file(
   
 configure_file(${CMAKE_SOURCE_DIR}/packaging/apple/mac_packager.sh.in 
   ${PROJECT_BINARY_DIR}/packaging/apple/mac_packager.sh
+  @ONLY
   )
 
 set(CPACK_INSTALL_SCRIPT 

--- a/packaging/apple/mac_packager.sh.in
+++ b/packaging/apple/mac_packager.sh.in
@@ -33,7 +33,8 @@ done
 
 @dtk_DIR@/bin/dtkDeploy medInria.app $injectDirs &>/dev/null
 
-# A bug in dtkDeploy causes plugins to keep their original installed name. We must must manually fix them.
+# A bug in dtkDeploy causes plugins to keep their original installed name so we
+# must manually fix them.
 for lib in @medInria_BINARY_DIR@/bin/TmpInstall/medInria.app/Contents/PlugIns/*.dylib; do
     libname=${lib##*/}
     installedName="@executable_path/../PlugIns/$libname"

--- a/packaging/apple/mac_packager.sh.in
+++ b/packaging/apple/mac_packager.sh.in
@@ -33,6 +33,13 @@ done
 
 @dtk_DIR@/bin/dtkDeploy medInria.app $injectDirs &>/dev/null
 
+# A bug in dtkDeploy causes plugins to keep their original installed name. We must must manually fix them.
+for lib in @medInria_BINARY_DIR@/bin/TmpInstall/medInria.app/Contents/PlugIns/*.dylib; do
+    libname=${lib##*/}
+    installedName="@executable_path/../PlugIns/$libname"
+    install_name_tool -id $installedName @medInria_BINARY_DIR@/bin/TmpInstall/medInria.app/Contents/PlugIns/$libname
+done
+
 #Run fancy packaging apple script
 
 \cp -f @medInria_SOURCE_DIR@/utils/osx_packaging/BaseMedinriaPackage.sparseimage.gz @PROJECT_BINARY_DIR@/MedinriaPackage.sparseimage.gz


### PR DESCRIPTION
The dtkDeploy tool does not update the install names of the plugin dylibs:

<img width="1004" alt="Screen Shot 2022-04-08 at 10 30 20" src="https://user-images.githubusercontent.com/7769799/162401606-47475650-da34-44af-9575-4287ea6d53b7.png">

These should be set to `@executable_path/../PlugIns/[library name]`.
(this bug has no impact on the execution of the current application but causes a crash in an upcoming PR for Python)