### PR TITLE
Resource libraries

### DIFF
--- a/packaging/apple/ApplePackaging.cmake
+++ b/packaging/apple/ApplePackaging.cmake
@@ -40,6 +40,7 @@ configure_file(
   
 configure_file(${CMAKE_SOURCE_DIR}/packaging/apple/mac_packager.sh.in 
   ${PROJECT_BINARY_DIR}/packaging/apple/mac_packager.sh
+  @ONLY
   )
 
 set(CPACK_INSTALL_SCRIPT 

--- a/packaging/apple/mac_packager.sh.in
+++ b/packaging/apple/mac_packager.sh.in
@@ -33,7 +33,8 @@ done
 
 @dtk_DIR@/bin/dtkDeploy medInria.app $injectDirs &>/dev/null
 
-# A bug in dtkDeploy causes plugins to keep their original installed name. We must must manually fix them.
+# A bug in dtkDeploy causes plugins to keep their original installed name so we
+# must manually fix them.
 for lib in @medInria_BINARY_DIR@/bin/TmpInstall/medInria.app/Contents/PlugIns/*.dylib; do
     libname=${lib##*/}
     installedName="@executable_path/../PlugIns/$libname"

--- a/packaging/apple/mac_packager.sh.in
+++ b/packaging/apple/mac_packager.sh.in
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-# Usage: 
-# - mac_packager.sh plugin1 plugin2 ... pluginN
-# or
-# - mac_packager.sh path_to_plugins/*
+# Usage:
+# - mac_packager.sh path_to_plugins1 path_to_plugins2...
 
 # To build a stand-alone mac version of the application, do the following:
 
@@ -27,9 +25,12 @@ cd TmpInstall
 #Run sub-packagers
 injectDirs=''
 for i in $*; do
-	echo $i
-	injectDirs="$injectDirs -inject-dir=$i"
+        echo $i
+        injectDirs="$injectDirs -inject-dir=$i"
 done
+
+resourceLibsDir=@medInria_BINARY_DIR@/lib/resources
+injectDirs="$injectDirs -inject-dir=$resourceLibsDir"
 
 @dtk_DIR@/bin/dtkDeploy medInria.app $injectDirs &>/dev/null
 
@@ -39,6 +40,32 @@ for lib in @medInria_BINARY_DIR@/bin/TmpInstall/medInria.app/Contents/PlugIns/*.
     libname=${lib##*/}
     installedName="@executable_path/../PlugIns/$libname"
     install_name_tool -id $installedName @medInria_BINARY_DIR@/bin/TmpInstall/medInria.app/Contents/PlugIns/$libname
+done
+
+# Resource libraries are sent as plugins to dtkDeploy (above) because they are
+# not dependencies of the executable (dtkDeploy uses otool on the executable to
+# find which libraires should be imported, so it will not find resource
+# libraries). After the execution of dtkDeploy we move these libraries to the
+# frameworks folder and adjust their install name.
+resourceLibs=''
+for lib in $resourceLibsDir/*.dylib; do
+    libname=${lib##*/}
+    copiedLib=@medInria_BINARY_DIR@/bin/TmpInstall/medInria.app/Contents/Frameworks/$libname
+    \mv @medInria_BINARY_DIR@/bin/TmpInstall/medInria.app/Contents/PlugIns/$libname $copiedLib
+    installedName="@executable_path/../Frameworks/$libname"
+    install_name_tool -id $installedName $copiedLib
+    resourceLibs="$resourceLibs $libname"
+done
+
+# Because of the dtkDeploy bug with install names, we have to fix the
+# dependencies of the resource libraries.
+for lib1 in $resourceLibs; do
+    deployedLib1=@medInria_BINARY_DIR@/bin/TmpInstall/medInria.app/Contents/Frameworks/$lib1
+    installedName="@executable_path/../Frameworks/$lib1"
+    for lib2 in $resourceLibs; do
+        deployedLib2=@medInria_BINARY_DIR@/bin/TmpInstall/medInria.app/Contents/Frameworks/$lib2
+        install_name_tool -change $1/$lib1 $installedName $deployedLib2
+    done
 done
 
 #Run fancy packaging apple script

--- a/packaging/apple/mac_packager.sh.in
+++ b/packaging/apple/mac_packager.sh.in
@@ -33,6 +33,13 @@ done
 
 @dtk_DIR@/bin/dtkDeploy medInria.app $injectDirs &>/dev/null
 
+# A bug in dtkDeploy causes plugins to keep their original installed name. We must must manually fix them.
+for lib in @medInria_BINARY_DIR@/bin/TmpInstall/medInria.app/Contents/PlugIns/*.dylib; do
+    libname=${lib##*/}
+    installedName="@executable_path/../PlugIns/$libname"
+    install_name_tool -id $installedName @medInria_BINARY_DIR@/bin/TmpInstall/medInria.app/Contents/PlugIns/$libname
+done
+
 #Run fancy packaging apple script
 
 \cp -f @medInria_SOURCE_DIR@/utils/osx_packaging/BaseMedinriaPackage.sparseimage.gz @PROJECT_BINARY_DIR@/MedinriaPackage.sparseimage.gz

--- a/src/cmake/module/set_lib_install_rules.cmake
+++ b/src/cmake/module/set_lib_install_rules.cmake
@@ -11,64 +11,76 @@
 #
 ################################################################################
 
-macro(set_lib_install_rules_generic target dest)
+function(set_lib_install_rules target)
 
 ################################################################################
 #
-# Usage: set_lib_install_rules(target, header1, header2, header3 ...)
-# set rules for the library designed by the target, and add all the additional
-# header to {CMAKE_PREFIX_INSTALL}/include during install step.
+# Usage: set_lib_install_rules(target [RESOURCE] [HEADERS [headers...]])
+#
+# Set rules for a library target.
+#
+# The options are:
+#
+# RESOURCE
+#     Indicate that this is a resource library. Resource libraries are shared
+#     librairies that are not dependencies (direct or indirect) of the
+#     executable. An example of this are Python extension modules, which are not
+#     linked into the executable but loaded by the embedded Python's import
+#     mechanism.
+#
+# HEADERS
+#     Add headers to '{CMAKE_PREFIX_INSTALL}/include' during the install step.
 #
 ################################################################################
 
-get_property(GENERATOR_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    cmake_parse_arguments(PARSE_ARGV 1 "ARG" "RESOURCE" "" "HEADERS")
+    get_property(GENERATOR_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 
-if(${GENERATOR_MULTI_CONFIG})
-  set_target_properties( ${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG          ${dest}/${platformType}Debug/bin)
-  set_target_properties( ${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE        ${dest}/${platformType}Release/bin)
-  set_target_properties( ${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL     ${dest}/${platformType}MinSizeRel/bin)
-  set_target_properties( ${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${dest}/${platformType}RelWithDebInfo/bin)
-                                                                                        
-  set_target_properties( ${target} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_DEBUG          ${dest}/${platformType}Debug/lib)
-  set_target_properties( ${target} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_RELEASE        ${dest}/${platformType}Release/lib)
-  set_target_properties( ${target} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_MINSIZEREL     ${dest}/${platformType}MinSizeRel/lib)
-  set_target_properties( ${target} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_RELWITHDEBINFO ${dest}/${platformType}RelWithDebInfo/lib)
-                                                                                        
-  set_target_properties( ${target} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_DEBUG          ${dest}/${platformType}Debug/lib)
-  set_target_properties( ${target} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELEASE        ${dest}/${platformType}Release/lib)
-  set_target_properties( ${target} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL     ${dest}/${platformType}MinSizeRel/lib)
-  set_target_properties( ${target} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO ${dest}/${platformType}RelWithDebInfo/lib)
-else()                                                                                  
-  set_target_properties( ${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY                ${dest}/bin)
-  set_target_properties( ${target} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY                ${dest}/lib)
-  set_target_properties( ${target} PROPERTIES LIBRARY_OUTPUT_DIRECTORY                ${dest}/lib)
-endif()
+    if (medInria_DIR)
+        set(dest ${medInria_DIR})
+    else()
+        set(dest ${CMAKE_BINARY_DIR})
+    endif()
 
-install(TARGETS ${target}
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  FRAMEWORK DESTINATION lib
-  RESOURCE DESTINATION resources/${target}
-  )
+    set(shared_lib_dir lib$<$<AND:$<BOOL:${ARG_RESOURCE}>,$<PLATFORM_ID:Darwin>>:/resource_libs>)
+
+    if(${GENERATOR_MULTI_CONFIG})
+        set_target_properties( ${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG          ${dest}/${platformType}Debug/bin)
+        set_target_properties( ${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE        ${dest}/${platformType}Release/bin)
+        set_target_properties( ${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL     ${dest}/${platformType}MinSizeRel/bin)
+        set_target_properties( ${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${dest}/${platformType}RelWithDebInfo/bin)
+
+        set_target_properties( ${target} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_DEBUG          ${dest}/${platformType}Debug/lib)
+        set_target_properties( ${target} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_RELEASE        ${dest}/${platformType}Release/lib)
+        set_target_properties( ${target} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_MINSIZEREL     ${dest}/${platformType}MinSizeRel/lib)
+        set_target_properties( ${target} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_RELWITHDEBINFO ${dest}/${platformType}RelWithDebInfo/lib)
+
+        set_target_properties( ${target} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_DEBUG          ${dest}/${platformType}Debug/${shared_lib_dir})
+        set_target_properties( ${target} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELEASE        ${dest}/${platformType}Release/${shared_lib_dir})
+        set_target_properties( ${target} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL     ${dest}/${platformType}MinSizeRel/${shared_lib_dir})
+        set_target_properties( ${target} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO ${dest}/${platformType}RelWithDebInfo/${shared_lib_dir})
+    else()
+        set_target_properties( ${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY                ${dest}/bin)
+        set_target_properties( ${target} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY                ${dest}/lib)
+        set_target_properties( ${target} PROPERTIES LIBRARY_OUTPUT_DIRECTORY                ${dest}/${shared_lib_dir})
+    endif()
+
+    install(TARGETS ${target}
+        RUNTIME DESTINATION lib
+        LIBRARY DESTINATION ${shared_lib_dir}
+        ARCHIVE DESTINATION lib
+        FRAMEWORK DESTINATION ${shared_lib_dir}
+        RESOURCE DESTINATION resources/${target}
+        )
 
 ## #############################################################################
-## Add header wich have to be exposed in the include dir of the install tree
+## Add headers wich have to be exposed in the include dir of the install tree
 ## #############################################################################
 
-if(${ARGC} GREATER 2)
-  install(FILES ${ARGN}
-    DESTINATION include/${target}
-    )
-endif()
+    if(ARG_HEADERS)
+        install(FILES ${ARG_HEADERS}
+            DESTINATION include/${target}
+            )
+    endif()
 
-endmacro()
-
-
-macro(set_lib_install_rules target)
-  set_lib_install_rules_generic(${target} ${CMAKE_BINARY_DIR} ${ARGN})
-endmacro()
-
-macro(set_lib_install_rules_external target)
-  set_lib_install_rules_generic(${target} ${medInria_DIR} ${ARGN})
-endmacro()
+endfunction()

--- a/src/layers/legacy/medCoreLegacy/CMakeLists.txt
+++ b/src/layers/legacy/medCoreLegacy/CMakeLists.txt
@@ -91,7 +91,7 @@ endif()
 ## install
 ## #############################################################################
 
-set_lib_install_rules(${TARGET_NAME}
+set_lib_install_rules(${TARGET_NAME} HEADERS
   ${${TARGET_NAME}_HEADERS}
   )
 

--- a/src/layers/legacy/medImageIO/CMakeLists.txt
+++ b/src/layers/legacy/medImageIO/CMakeLists.txt
@@ -102,6 +102,6 @@ target_link_libraries(${TARGET_NAME}
 ## install
 ## #############################################################################
 
-set_lib_install_rules(${TARGET_NAME}
+set_lib_install_rules(${TARGET_NAME} HEADERS
   ${${TARGET_NAME}_HEADERS}
   )

--- a/src/layers/legacy/medLog/CMakeLists.txt
+++ b/src/layers/legacy/medLog/CMakeLists.txt
@@ -80,6 +80,6 @@ target_link_libraries(${TARGET_NAME}
 ## install
 ## #############################################################################
 
-set_lib_install_rules(${TARGET_NAME}
+set_lib_install_rules(${TARGET_NAME} HEADERS
   ${${TARGET_NAME}_HEADERS}
   )

--- a/src/layers/legacy/medPacs/CMakeLists.txt
+++ b/src/layers/legacy/medPacs/CMakeLists.txt
@@ -71,6 +71,6 @@ target_include_directories(${TARGET_NAME}
 ## install
 ## #############################################################################
 
-set_lib_install_rules(${TARGET_NAME}
+set_lib_install_rules(${TARGET_NAME} HEADERS
   ${${TARGET_NAME}_HEADERS}
   )

--- a/src/layers/legacy/medRegistration/CMakeLists.txt
+++ b/src/layers/legacy/medRegistration/CMakeLists.txt
@@ -106,6 +106,6 @@ target_link_libraries(${TARGET_NAME}
 ## install
 ## #############################################################################
 
-set_lib_install_rules(${TARGET_NAME}
+set_lib_install_rules(${TARGET_NAME} HEADERS
   ${${TARGET_NAME}_HEADERS}
   )

--- a/src/layers/legacy/medUtilities/CMakeLists.txt
+++ b/src/layers/legacy/medUtilities/CMakeLists.txt
@@ -78,6 +78,6 @@ target_link_libraries(${TARGET_NAME}
 ## install
 ## #############################################################################
 
-set_lib_install_rules(${TARGET_NAME}
+set_lib_install_rules(${TARGET_NAME} HEADERS
   ${${TARGET_NAME}_HEADERS}
   )

--- a/src/layers/legacy/medVtkDataMeshBase/CMakeLists.txt
+++ b/src/layers/legacy/medVtkDataMeshBase/CMakeLists.txt
@@ -74,7 +74,7 @@ target_link_libraries(${TARGET_NAME}
 ## install
 ## #############################################################################
 
-set_lib_install_rules(${TARGET_NAME}
+set_lib_install_rules(${TARGET_NAME} HEADERS
   ${${TARGET_NAME}_HEADERS}
   )
 

--- a/src/layers/legacy/medVtkInria/CMakeLists.txt
+++ b/src/layers/legacy/medVtkInria/CMakeLists.txt
@@ -106,7 +106,7 @@ target_link_libraries(${TARGET_NAME}
 ## install
 ## #############################################################################
 
-set_lib_install_rules(${TARGET_NAME}
+set_lib_install_rules(${TARGET_NAME} HEADERS
   ${${TARGET_NAME}_HEADERS}
   )
 

--- a/src/layers/medComposer/CMakeLists.txt
+++ b/src/layers/medComposer/CMakeLists.txt
@@ -84,6 +84,6 @@ target_link_libraries(${TARGET_NAME}
 ## install
 ## #############################################################################
 
-set_lib_install_rules(${TARGET_NAME}
+set_lib_install_rules(${TARGET_NAME} HEADERS
   ${${TARGET_NAME}_HEADERS}
   )

--- a/src/layers/medCore/CMakeLists.txt
+++ b/src/layers/medCore/CMakeLists.txt
@@ -72,6 +72,6 @@ target_link_libraries(${TARGET_NAME}
 ## install
 ## #############################################################################
 
-set_lib_install_rules(${TARGET_NAME}
+set_lib_install_rules(${TARGET_NAME} HEADERS
   ${${TARGET_NAME}_HEADERS}
   )

--- a/src/layers/medPython/base/CMakeLists.txt
+++ b/src/layers/medPython/base/CMakeLists.txt
@@ -62,6 +62,8 @@ target_compile_definitions(${TARGET_NAME} PRIVATE
     TARGET_NAME="${TARGET_NAME}"
     PYTHON_PLUGIN_PREFIX="${PYTHON_PLUGIN_PREFIX}"
     PROJECT_NAME="${PROJECT_NAME}"
+    PYTHON_VERSION_MINOR=${PYTHON_VERSION_MINOR}
+    PYTHON_VERSION_STRING="${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}"
     )
 
 ## #############################################################################
@@ -94,6 +96,6 @@ target_link_libraries(${TARGET_NAME}
 ## Install
 ## #############################################################################
 
-set_lib_install_rules(${TARGET_NAME}
+set_lib_install_rules(${TARGET_NAME} HEADERS
     ${${TARGET_NAME}_HEADERS}
     )

--- a/src/layers/medPython/tools/CMakeLists.txt
+++ b/src/layers/medPython/tools/CMakeLists.txt
@@ -132,6 +132,6 @@ target_link_libraries(medInria_bindings
 ## Install
 ## #############################################################################
 
-set_lib_install_rules(${TARGET_NAME}
+set_lib_install_rules(${TARGET_NAME} HEADERS
     ${${TARGET_NAME}_HEADERS}
     )

--- a/src/layers/medWidgets/CMakeLists.txt
+++ b/src/layers/medWidgets/CMakeLists.txt
@@ -74,6 +74,6 @@ target_link_libraries(${TARGET_NAME}
 ## install
 ## #############################################################################
 
-set_lib_install_rules(${TARGET_NAME}
+set_lib_install_rules(${TARGET_NAME} HEADERS
   ${${TARGET_NAME}_HEADERS}
   )


### PR DESCRIPTION
(based on https://github.com/medInria/medInria-public/pull/993)
(commit (https://github.com/medInria/medInria-public/commit/51a7f1d918396abb65a8708d54c697d14d566583)]

Adds the concept of resource libraries which are libraries that must be packaged with the application but are not dependencies of the executable. The Python binding system creates shared libraries that are loaded by Python when the corresponding module is loaded. These libraries are not linked into the executable and therefore do not appear as dependencies. This causes a problem on macOS with dtkDeploy because it uses otool to find which libraries should be copied to the bundle. Plugins are handled differently: dtkDeploy imports all the plugins found in the designated directories. We can therefore use this to allow dtkDeploy to import resource libraries (and their dependencies) and then manually move them to the correct place in the bundle.

Notes:
  - changed the doc at the beginning of mac_packager.sh which was already outdated (the script works on directories only, not file paths)
  - the `set_lib_install_rules` macro is now a function and is properly indented.