### PR TITLE
[medUtilitiesITK] binarize mask to 0/1

### DIFF
--- a/src/layers/legacy/medUtilities/CMakeLists.txt
+++ b/src/layers/legacy/medUtilities/CMakeLists.txt
@@ -25,7 +25,7 @@ include_directories(${dtk_INCLUDE_DIRS})
 find_package(VTK REQUIRED COMPONENTS vtkInteractionWidgets )
 include(${VTK_USE_FILE})
 
-find_package(ITK REQUIRED COMPONENTS ITKCommon ITKIOGDCM)
+find_package(ITK REQUIRED COMPONENTS ITKCommon ITKIOGDCM ITKThresholding)
 include(${ITK_USE_FILE})
 
 if (ITK_USE_SYSTEM_GDCM)

--- a/src/layers/legacy/medUtilities/medUtilitiesITK.cpp
+++ b/src/layers/legacy/medUtilities/medUtilitiesITK.cpp
@@ -14,6 +14,20 @@
 
 #include <statsROI.h>
 
+/**
+ * @brief For masks with values non-0/1, as -1024/10000, set the intensity to 0/1
+ *
+ * @param data
+ */
+dtkSmartPointer<medAbstractData> medUtilitiesITK::binarizeMask(dtkSmartPointer<medAbstractData> data)
+{
+    statsROI statsProcess;
+    statsProcess.setInput(data, 0);
+    statsProcess.setParameter(statsROI::BINARIZE);
+    statsProcess.update();
+    return statsProcess.dataOutput();
+}
+
 double medUtilitiesITK::minimumValue(dtkSmartPointer<medAbstractData> data)
 {
     statsROI statsProcess;

--- a/src/layers/legacy/medUtilities/medUtilitiesITK.h
+++ b/src/layers/legacy/medUtilities/medUtilitiesITK.h
@@ -27,6 +27,8 @@ class MEDUTILITIES_EXPORT medUtilitiesITK
 {
 public:
 
+    static dtkSmartPointer<medAbstractData> binarizeMask(dtkSmartPointer<medAbstractData> data);
+    
     /**
      * @brief minimumValue computes the minimum pixel intensity in a volume
      * @param the input volume

--- a/src/layers/legacy/medUtilities/statsROI.h
+++ b/src/layers/legacy/medUtilities/statsROI.h
@@ -24,7 +24,8 @@ public:
     dtkSmartPointer <medAbstractData> input0; //data
     dtkSmartPointer <medAbstractData> input1; //mask
     std::vector<double> computedOutput;
-    enum statsParameter {MEAN_STDDEVIATION, VOLUMEML, MINMAX};
+    dtkSmartPointer<medAbstractData> computedDataOutput;
+    enum statsParameter {MEAN_STDDEVIATION, VOLUMEML, MINMAX, BINARIZE};
     statsParameter chooseFct;
     double outsideValue;
 
@@ -45,4 +46,6 @@ public:
     
     //! The output will be available through here
     std::vector<double> output();
+
+    dtkSmartPointer<medAbstractData> dataOutput();
 };


### PR DESCRIPTION
A lot of filters/toolbox can crash if the masks used are not 0/1 masks, as -1024/10000 or 0/255.

This PR adds a medUtilitiesITK fct to switch these masks to 0/1 if needed.

It will be needed on MUSICardio side in incomping PRs, and also in medInria.

:m: