### PR TITLE
Fixing mirrored DICOM images and their origin

### DIFF
--- a/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
+++ b/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
@@ -690,44 +690,33 @@ double DCMTKImageIO::GetPositionOnStackingAxisForImage (int index)
     }
 
     std::string s_position = this->GetMetaDataValueString("(0020,0032)", index);
-    double pos = 0.0;
     std::istringstream is_stream( s_position.c_str() );
-    if (!(is_stream >> pos) )
+
+    double pos = 0.0;
+    bool foundAxis=false;
+
+    for (int i=0; i<3; i++)
     {
-        itkWarningMacro ( << "Cannot convert string to double: " << s_position.c_str() << std::endl );
-    }
-    else
-    {
-        if (fabs(closestAxis[0]) == 1)
+        if (!(is_stream >> pos) )
         {
-            return pos;
+            itkWarningMacro ( << "Cannot convert string to double: " << s_position.c_str() << std::endl );
         }
-    }
-    if (!(is_stream >> pos) )
-    {
-        itkWarningMacro ( << "Cannot convert string to double: " << s_position.c_str() << std::endl );
-    }
-    else
-    {
-        if (fabs(closestAxis[1]) == 1)
+        else
         {
-            return pos;
-        }
-    }
-    if (!(is_stream >> pos))
-    {
-        itkWarningMacro ( << "Cannot convert string to double: " << s_position.c_str() << std::endl );
-    }
-    else
-    {
-        if (fabs(closestAxis[2]) == 1)
-        {
-            return pos;
+            if (fabs(closestAxis[i]) == 1)
+            {
+                foundAxis = true;
+                break;
+            }
         }
     }
 
-    itkWarningMacro ( <<"Could not identify position on stacking axis, returning zero." << std::endl );
-    return 0.0;
+    if (!foundAxis)
+    {
+        itkWarningMacro ( <<"Could not identify position on stacking axis, returning zero." << std::endl );
+    }
+
+    return pos;
 }
 
 

--- a/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
+++ b/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
@@ -295,23 +295,7 @@ void DCMTKImageIO::ReadImageInformation()
 
     double startLocation = *l;
     double endLocation   = *lle;
-    int locSign = endLocation>startLocation?1.0:-1.0;
-
-    /**
-       The code below is redundant with the code above given that the acquisition order is already taken
-       into account, so inversing the order of the slices in case the direction of acquisition
-       is opposing the order they should be written in the buffer (i.e., cross product of the
-       row direction and column direction) leads to the opposite of what it's seemingly trying to
-       accomplish.
-       Commenting to avoid mirrored images, keeping because I'm confused.
-     */
-    // just check first volume
-//    int startIndex = m_FilenameToIndexMap[ m_LocationToFilenamesMap.lower_bound ( *l )->second ];
-//    int endIndex   = m_FilenameToIndexMap[ m_LocationToFilenamesMap.lower_bound ( *lle )->second ];
-//    double startSlice = this->GetPositionOnStackingAxisForImage ( startIndex );
-//    double endSlice   = this->GetPositionOnStackingAxisForImage ( endIndex );
-//    int sliceDirection = endSlice>=startSlice?locSign:-locSign;
-    int sliceDirection = locSign;
+    int sliceDirection = endLocation>startLocation?1.0:-1.0;
 
     /**
        Now order filenames such that we can read them sequentially and build the 3D/4D volume.
@@ -715,7 +699,9 @@ double DCMTKImageIO::GetPositionOnStackingAxisForImage (int index)
     else
     {
         if (fabs(closestAxis[0]) == 1)
+        {
             return pos;
+        }
     }
     if (!(is_stream >> pos) )
     {
@@ -724,7 +710,9 @@ double DCMTKImageIO::GetPositionOnStackingAxisForImage (int index)
     else
     {
         if (fabs(closestAxis[1]) == 1)
+        {
             return pos;
+        }
     }
     if (!(is_stream >> pos))
     {
@@ -733,7 +721,9 @@ double DCMTKImageIO::GetPositionOnStackingAxisForImage (int index)
     else
     {
         if (fabs(closestAxis[2]) == 1)
+        {
             return pos;
+        }
     }
 
     itkWarningMacro ( <<"Could not identify position on stacking axis, returning zero." << std::endl );

--- a/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
+++ b/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
@@ -590,11 +590,11 @@ void DCMTKImageIO::DetermineOrigin()
     int startIndex = m_FilenameToIndexMap[ m_LocationToFilenamesMap.lower_bound ( *m_LocationSet.begin() )->second ];
     int endIndex   = m_FilenameToIndexMap[ m_LocationToFilenamesMap.lower_bound ( *m_LocationSet.rbegin() )->second ];
 
-    double startZ = this->GetPositionOnStackingAxisForImage (startIndex);
-    double endZ   = this->GetPositionOnStackingAxisForImage (endIndex);
+    double startPosition = this->GetPositionOnStackingAxisForImage (startIndex);
+    double endPosition   = this->GetPositionOnStackingAxisForImage (endIndex);
 
     int index = startIndex;
-    if (endZ<startZ)
+    if (endPosition<startPosition)
     {
         index = endIndex;
     }

--- a/src/layers/legacy/medImageIO/itkDCMTKImageIO.h
+++ b/src/layers/legacy/medImageIO/itkDCMTKImageIO.h
@@ -185,7 +185,7 @@ protected:
     void DetermineOrigin();
     void DetermineOrientation();
 
-    double GetZPositionForImage (int);
+    double GetPositionOnStackingAxisForImage (int);
     double GetSliceLocation(std::string);
 
     void ReadHeader( const std::string& name, const int& fileIndex, const int& fileCount );


### PR DESCRIPTION
The method that gets the position of a slice on the stacking axis was z-specific and only worked on axial acquisition. This method was involved in both the determination of the origin of the image and the ordering of slices in the buffer.

Furthermore, the aforementioned slice ordering code is redundant with the code above it, which led to a double order inversion instead of a simple inversion of the order in which slices are stacked in the buffer, causing the images to be mirrored in case the stacking direction is the opposite of the acquisition direction.

**Before changes:**

![Capture d'écran Deepin_plasmashell_20220505104345](https://user-images.githubusercontent.com/104632751/166930763-23085cdc-965d-44b5-82fa-02f34b6f6058.png)
Here on a coronal acquisition, the patient is facing the wrong way on y

![Capture d'écran Deepin_plasmashell_20220505105049](https://user-images.githubusercontent.com/104632751/166930788-4e6a070a-822d-4783-8842-5607c46fbb39.png)
Here on a sagittal acquisition, the hemispheres are mirrored, which is confirmed by opening the same data on other readers such as 3D Slicer below:
![Capture d'écran Deepin_plasmashell_20220505105014](https://user-images.githubusercontent.com/104632751/166930805-62543755-69f3-42ad-8917-e08038c56df4.png)

**After changes:**

![Capture d'écran Deepin_plasmashell_20220505144700](https://user-images.githubusercontent.com/104632751/166931149-7afd737e-667f-4210-ae94-05a8042bbb97.png)
![Capture d'écran Deepin_plasmashell_20220505144800](https://user-images.githubusercontent.com/104632751/166931164-ce80d674-723c-48ca-960f-535768cb47a7.png)

**Changes:**
- Replaced `double DCMTKImageIO::GetZPositionForImage (int index)` by `double DCMTKImageIO::GetPositionOnStackingAxisForImage (int index)` to support non-axial data
- Commented the redundant change of `locSign` in `void DCMTKImageIO::ReadImageInformation()`
