### PR TITLE
[medDoubleParameterL] fix wrong 0/0 values if attribute has only 1 value in a mesh

### DIFF
--- a/src/layers/legacy/medCoreLegacy/parameters/medDoubleParameterL.cpp
+++ b/src/layers/legacy/medCoreLegacy/parameters/medDoubleParameterL.cpp
@@ -122,19 +122,16 @@ void medDoubleParameterL::setRange(double min, double max)
     d->min = min;
     d->max = max;
 
-    if(min != max)
+    if(d->spinBox)
     {
-        if(d->spinBox)
-        {
-            d->spinBox->setRange(min, max);
-        }
-        if(d->slider)
-        {
-            d->slider->setRange(0, convertToInt(max));
-        }
-
-        updateInternWigets();
+        d->spinBox->setRange(min, max);
     }
+    if(d->slider)
+    {
+        d->slider->setRange(0, convertToInt(max));
+    }
+
+    updateInternWigets();
 }
 
 void medDoubleParameterL::setSingleStep(double step)


### PR DESCRIPTION
Same as this PR https://github.com/medInria/medInria-public/pull/886

If a mesh has an attribute with only one value (for instance 42), it was show as if the value was 0 (or one of the value already updated from an attribute with multiple values), and was not updated.

:m: