### PR TITLE
[Attributes] some mesh fields not displayed in color in 3D

### DIFF
--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -950,7 +950,6 @@ vtkSmartPointer<vtkActor> vtkImageView3D::DataSetToActor(vtkPointSet* arg, vtkPr
     idFilter->FieldDataOn();
     idFilter->SetIdsArrayName("vtkOriginalIds");
     idFilter->SetInputData(arg);
-    idFilter->Update();
 
     geometryextractor->SetInputConnection(idFilter->GetOutputPort());
     normalextractor->SetFeatureAngle(90);

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -945,14 +945,15 @@ vtkSmartPointer<vtkActor> vtkImageView3D::DataSetToActor(vtkPointSet* arg, vtkPr
     auto mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
     auto actor = vtkSmartPointer<vtkActor>::New();
 
-    idFilter->SetCellIds(1);
-    idFilter->SetPointIds(1);
+    idFilter->PointIdsOn();
+    idFilter->CellIdsOn();
+    idFilter->FieldDataOn();
     idFilter->SetIdsArrayName("vtkOriginalIds");
     idFilter->SetInputData(arg);
-    normalextractor->SetFeatureAngle(90);
-    ///\todo try to skip the normal extraction filter in order to
-    // enhance the visualization speed when the data is time sequence.
+    idFilter->Update();
+
     geometryextractor->SetInputConnection(idFilter->GetOutputPort());
+    normalextractor->SetFeatureAngle(90);
     normalextractor->SetInputConnection(geometryextractor->GetOutputPort());
     mapper->SetInputConnection(normalextractor->GetOutputPort());
     actor->SetMapper(mapper);


### PR DESCRIPTION
Same as https://github.com/Inria-Asclepios/medInria-public/pull/736

Since this PR https://github.com/medInria/medInria-public/pull/902 some attributes of meshes were not displayed in color in 3D orientation. It was because vtkIdFilter vas not properly initialized. This PR solves this problem.

:m: