### PR TITLE
[Mesh Visu] improvements, use vtkIdFilter and vtkGeometryFilter

### DIFF
--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.cxx
@@ -20,7 +20,6 @@
 #include <vtksys/SystemTools.hxx>
 
 #include <vtkProperty.h>
-#include <vtkDataSetSurfaceFilter.h>
 #include <vtkPolyDataMapper.h>
 #include <vtkPolyDataNormals.h>
 

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -21,7 +21,8 @@
 #include <vtkAnnotatedCubeActor.h>
 #include <vtkColorTransferFunction.h>
 #include <vtkDataSetCollection.h>
-#include <vtkDataSetSurfaceFilter.h>
+#include <vtkGeometryFilter.h>
+#include <vtkIdFilter.h>
 #include <vtkImageActor.h>
 #include <vtkImageAppendComponents.h>
 #include <vtkImageCast.h>
@@ -918,57 +919,41 @@ void vtkImageView3D::UpdateDisplayExtent()
 }
 
 //----------------------------------------------------------------------------
-vtkActor* vtkImageView3D::AddDataSet (vtkPointSet* arg, vtkProperty* prop)
+vtkActor* vtkImageView3D::AddDataSet(vtkPointSet* arg, vtkProperty* prop)
 {
-  auto geometryextractor = vtkDataSetSurfaceFilter::New();
-  auto normalextractor = vtkPolyDataNormals::New();
-  auto mapper = vtkPolyDataMapper::New();
-  auto actor = vtkActor::New();
+    vtkSmartPointer<vtkActor> actor = DataSetToActor(arg, prop);
+    Renderer->AddViewProp(actor);
 
-  normalextractor->SetFeatureAngle (90);
-  ///\todo try to skip the normal extraction filter in order to
-  // enhance the visualization speed when the data is time sequence.
-  geometryextractor->SetInputData (arg);
-  normalextractor->SetInputConnection (geometryextractor->GetOutputPort());
-  mapper->SetInputConnection (normalextractor->GetOutputPort());
-  actor->SetMapper (mapper);
-  if (prop)
-    actor->SetProperty (prop);
+    // If this is the first widget to be added, reset camera
+    if (!GetMedVtkImageInfo() || !GetMedVtkImageInfo()->initialized)
+    {
+        this->ResetCamera(arg);
+    }
 
-  Renderer->AddViewProp(actor);
+    this->DataSetCollection->AddItem(arg);
+    this->DataSetActorCollection->AddItem(actor);
 
-  mapper->Delete();
-  normalextractor->Delete();
-  geometryextractor->Delete();
-  actor->Delete();
-
-  // If this is the first widget to be added, reset camera
-  if ( ! GetMedVtkImageInfo() || !GetMedVtkImageInfo()->initialized)
-  {
-      this->ResetCamera(arg);
-  }
-
-  this->DataSetCollection->AddItem (arg);
-  this->DataSetActorCollection->AddItem ( actor);
-
-  // the actor is actually not deleted as it has
-  // been referenced in the renderer, so we can
-  // safely return it. well hopefully.
-  return actor;
+    return actor;
 }
 
 //----------------------------------------------------------------------------
-vtkActor* vtkImageView3D::DataSetToActor(vtkPointSet* arg, vtkProperty* prop)
+vtkSmartPointer<vtkActor> vtkImageView3D::DataSetToActor(vtkPointSet* arg, vtkProperty* prop)
 {
-    auto geometryextractor = vtkDataSetSurfaceFilter::New();
-    auto normalextractor = vtkPolyDataNormals::New();
-    auto mapper = vtkPolyDataMapper::New();
-    auto actor = vtkActor::New();
+    auto idFilter = vtkSmartPointer<vtkIdFilter>::New();
+    auto geometryextractor = vtkSmartPointer<vtkGeometryFilter>::New();
+    auto normalextractor = vtkSmartPointer<vtkPolyDataNormals>::New();
+    auto mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+    auto actor = vtkSmartPointer<vtkActor>::New();
 
+    idFilter->PointIdsOn();
+    idFilter->CellIdsOn();
+    idFilter->FieldDataOn();
+    idFilter->SetIdsArrayName("vtkOriginalIds");
+    idFilter->SetInputData(arg);
+    idFilter->Update();
+
+    geometryextractor->SetInputConnection(idFilter->GetOutputPort());
     normalextractor->SetFeatureAngle(90);
-    ///\todo try to skip the normal extraction filter in order to
-    // enhance the visualization speed when the data is time sequence.
-    geometryextractor->SetInputData(arg);
     normalextractor->SetInputConnection(geometryextractor->GetOutputPort());
     mapper->SetInputConnection(normalextractor->GetOutputPort());
     actor->SetMapper(mapper);
@@ -976,10 +961,6 @@ vtkActor* vtkImageView3D::DataSetToActor(vtkPointSet* arg, vtkProperty* prop)
     {
         actor->SetProperty(prop);
     }
-
-    mapper->Delete();
-    normalextractor->Delete();
-    geometryextractor->Delete();
 
     return actor;
 }

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
@@ -142,7 +142,7 @@ public:
 
     void SetInput      (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = nullptr, int layer = 0) override;
     virtual bool data2DTreatment();
-    static vtkActor* DataSetToActor(vtkPointSet* arg, vtkProperty* prop = nullptr);
+    static vtkSmartPointer<vtkActor> DataSetToActor(vtkPointSet* arg, vtkProperty* prop = nullptr);
     virtual void SetInputLayer (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = nullptr, int layer = 0);
     void SetFirstLayer(vtkAlgorithmOutput *pi_poInputAlgoImg, vtkMatrix4x4 *matrix= nullptr, int layer = 0);
 

--- a/src/plugins/legacy/medVtkFibersData/manager/vtkFibersManager.cxx
+++ b/src/plugins/legacy/medVtkFibersData/manager/vtkFibersManager.cxx
@@ -52,9 +52,6 @@
 #include "vtkFibersManagerCallback.h"
 #include "vtkFiberPickerCallback.h"
 
-#include <vtkDataSetSurfaceFilter.h>
-#include <vtkPolyDataNormals.h>
-
 vtkStandardNewMacro(vtkFibersManager);
 
 

--- a/src/plugins/legacy/vtkDataMesh/datas/vtkDataMesh4D.cpp
+++ b/src/plugins/legacy/vtkDataMesh/datas/vtkDataMesh4D.cpp
@@ -21,7 +21,6 @@
 #include <vtkMetaDataSetSequence.h>
 
 #include <vtkPNGWriter.h>
-#include <vtkDataSetSurfaceFilter.h>
 #include <vtkPolyDataMapper.h>
 #include <vtkActor.h>
 #include <vtkProperty.h>

--- a/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
+++ b/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
@@ -17,7 +17,6 @@
 
 #include <vtkCamera.h>
 #include <vtkActor.h>
-#include <vtkDataSetSurfaceFilter.h>
 #include <vtkImageView.h>
 #include <vtkImageView2D.h>
 #include <vtkImageView3D.h>


### PR DESCRIPTION
Fusion of https://github.com/medInria/medInria-public/pull/902 and https://github.com/medInria/medInria-public/pull/1006 to enhance the way mesh are displayed/handled in 3D views. 
Use vtkGeometryFilter instead of vtkDataSetSurfaceFilter when adding a mesh in a view, and add vtkIdFilter for retrieval of original ids.

:m:
