### PR TITLE
Check datasets by default in save-before-quitting dialog

### DIFF
--- a/src/app/medInria/medSaveModifiedDialog.cpp
+++ b/src/app/medInria/medSaveModifiedDialog.cpp
@@ -51,7 +51,7 @@ class medSaveModifiedDialogCheckListItem : public QTreeWidgetItem
             setText(3, studyName);
             setText(4, seriesName);
             setText(5, file);
-            setCheckState(0, Qt::Unchecked);
+            setCheckState(0, Qt::Checked);
         }
 
         const medDataIndex& getIndex() const


### PR DESCRIPTION
Since this dialog has both a button "Save and quit" and "Quit without saving", the user expects to not quit without saving if they click on "Save and quit". This was reported after cases of data loss.

The suggested fix changes the default values of the checkboxes in the unsaved data list to checked.