### PR TITLE
[medViewContainer] allow to reset central view widgets --merge3.2

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.cpp
@@ -111,17 +111,9 @@ medViewContainer::medViewContainer(medViewContainerSplitter *parent): QFrame(par
     d->view = nullptr;
     d->viewToolbar = nullptr;
 
-    d->defaultWidget = new QWidget;
-    d->defaultWidget->setObjectName("defaultWidget");
-    QLabel *defaultLabel = new QLabel(tr("Drag'n drop series/study here from the left panel or:"));
-    QPushButton *openButton  = new QPushButton(tr("Open a file from your system"));
-    QPushButton *sceneButton = new QPushButton(tr("Open a scene from your system"));
-    QVBoxLayout *defaultLayout = new QVBoxLayout(d->defaultWidget);
-    defaultLayout->addWidget(defaultLabel);
-    defaultLayout->addWidget(openButton);
-    defaultLayout->addWidget(sceneButton);
-    connect(openButton,  SIGNAL(clicked()), this, SLOT(openFromSystem()), Qt::UniqueConnection);
-    connect(sceneButton, SIGNAL(clicked()), this, SLOT(loadScene()),      Qt::UniqueConnection);
+    // Themes
+    QVariant themeChosen = medSettingsManager::instance()->value("startup","theme");
+    int themeIndex = themeChosen.toInt();
 
     d->menuButton = new QPushButton(this);
     d->menuButton->setIcon(QIcon(":/pixmaps/tools.png"));
@@ -255,7 +247,7 @@ medViewContainer::medViewContainer(medViewContainerSplitter *parent): QFrame(par
     d->mainLayout->setContentsMargins(0, 0, 0, 0);
     d->mainLayout->setSpacing(0);
     d->mainLayout->addWidget(toolBar, 0, 0, Qt::AlignTop);
-    d->mainLayout->addWidget(d->defaultWidget, 0, 0, 0, 0, Qt::AlignCenter);
+    createdDefaultWidget();
 
     this->setAcceptDrops(true);
     this->setUserSplittable(true);
@@ -302,6 +294,45 @@ QUuid medViewContainer::uuid() const
 medAbstractView* medViewContainer::view() const
 {
     return d->view;
+}
+
+/**
+ * @brief Create the classic inner widget of a container
+ * 
+ */
+void medViewContainer::createdDefaultWidget()
+{
+    // create a default central widget
+    d->defaultWidget = new QWidget;
+    d->defaultWidget->setObjectName("defaultWidget");
+    QLabel *defaultLabel = new QLabel(tr("Drag'n drop series/study here from the left panel or:"));
+    QPushButton *openButton  = new QPushButton(tr("Open a file from your system"));
+    QPushButton *sceneButton = new QPushButton(tr("Open a scene from your system"));
+    QVBoxLayout *defaultLayout = new QVBoxLayout(d->defaultWidget);
+    defaultLayout->addWidget(defaultLabel);
+    defaultLayout->addWidget(openButton);
+    defaultLayout->addWidget(sceneButton);
+    connect(openButton,  SIGNAL(clicked()), this, SLOT(openFromSystem()), Qt::UniqueConnection);
+    connect(sceneButton, SIGNAL(clicked()), this, SLOT(loadScene()),      Qt::UniqueConnection);
+
+    // display the widget
+    d->mainLayout->addWidget(d->defaultWidget, 0, 0, 0, 0, Qt::AlignCenter);
+}
+
+/**
+ * @brief If the inner widget of a view has been removed to put a new 
+ * central widget, this method allows to reset, reinitialize the view 
+ * to the classic inner widget
+ * 
+ */
+void medViewContainer::initializeDefaultWidget()
+{
+    // clear
+    d->mainLayout->removeWidget(d->defaultWidget);
+    delete d->defaultWidget;
+
+    // recreate
+    createdDefaultWidget();
 }
 
 QWidget* medViewContainer::defaultWidget() const

--- a/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.cpp
@@ -111,10 +111,6 @@ medViewContainer::medViewContainer(medViewContainerSplitter *parent): QFrame(par
     d->view = nullptr;
     d->viewToolbar = nullptr;
 
-    // Themes
-    QVariant themeChosen = medSettingsManager::instance()->value("startup","theme");
-    int themeIndex = themeChosen.toInt();
-
     d->menuButton = new QPushButton(this);
     d->menuButton->setIcon(QIcon(":/pixmaps/tools.png"));
     d->menuButton->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);

--- a/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.h
+++ b/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.h
@@ -69,6 +69,8 @@ public:
     medViewContainer* splitHorizontally();
     medViewContainer* split(Qt::AlignmentFlag alignement = Qt::AlignRight);
 
+    void createdDefaultWidget();
+    void initializeDefaultWidget();
     void setDefaultWidget(QWidget *defaultWidget);
     QWidget* defaultWidget() const;
 


### PR DESCRIPTION
From https://github.com/Inria-Asclepios/medInria-public/pull/740

These changes allow to reset the central inner widget of a view when it was changed by a toolbox. Before that, in some toolboxes, we had graphic bugs in the central widget after a reset.

:m: