### PR TITLE
Insert some useful metadatas into the database

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
@@ -663,6 +663,19 @@ void medAbstractDatabaseImporter::populateMissingMetadata(medAbstractData *medDa
 
     if (!medData->hasMetaData(medMetaDataKeys::AcquisitionTime.key()))
         medData->setMetaData(medMetaDataKeys::AcquisitionTime.key(), QStringList() << "");
+
+    if (!medData->hasMetaData(medMetaDataKeys::StudyTime.key()))
+        medData->setMetaData(medMetaDataKeys::StudyTime.key(), QStringList() << "");
+
+    if (!medData->hasMetaData(medMetaDataKeys::StudyDate.key()))
+        medData->setMetaData(medMetaDataKeys::StudyDate.key(), QStringList() << "");
+
+    if (!medData->hasMetaData(medMetaDataKeys::SeriesTime.key()))
+        medData->setMetaData(medMetaDataKeys::SeriesTime.key(), QStringList() << "");
+
+    if (!medData->hasMetaData(medMetaDataKeys::SeriesDate.key()))
+        medData->setMetaData(medMetaDataKeys::SeriesDate.key(), QStringList() << "");
+
 }
 
 //-----------------------------------------------------------------------------------------------------------

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseImporter.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseImporter.cpp
@@ -161,7 +161,9 @@ int medDatabaseImporter::getOrCreateStudy ( const medAbstractData* medData, QSql
     QString studyName   = medMetaDataKeys::StudyDescription.getFirstValue(medData).simplified();
     QString studyUid    = medMetaDataKeys::StudyInstanceUID.getFirstValue(medData);
     QString studyId     = medMetaDataKeys::StudyID.getFirstValue(medData);
-    QString seriesName   = medMetaDataKeys::SeriesDescription.getFirstValue(medData).simplified();
+    QString seriesName  = medMetaDataKeys::SeriesDescription.getFirstValue(medData).simplified();
+    QString studyTime   = medMetaDataKeys::StudyTime.getFirstValue(medData);
+    QString studyDate   = medMetaDataKeys::StudyDate.getFirstValue(medData);
 
     if( studyName=="EmptyStudy" && seriesName=="EmptySeries" )
         return studyDbId;
@@ -183,13 +185,15 @@ int medDatabaseImporter::getOrCreateStudy ( const medAbstractData* medData, QSql
     {
         QString refThumbPath = medMetaDataKeys::ThumbnailPath.getFirstValue(medData);
 
-        query.prepare ( "INSERT INTO study (patient, name, uid, thumbnail, studyId) "
-                        "VALUES (:patient, :studyName, :studyUid, :thumbnail, :studyId)" );
+        query.prepare ( "INSERT INTO study (patient, name, uid, thumbnail, studyId, time, date) "
+                        "VALUES (:patient, :studyName, :studyUid, :thumbnail, :studyId, :studyTime, :studyDate)" );
         query.bindValue ( ":patient", patientDbId );
         query.bindValue ( ":studyName", studyName );
         query.bindValue ( ":studyUid", studyUid );
         query.bindValue ( ":thumbnail", refThumbPath );
-        query.bindValue ( ":studyId", studyId);
+        query.bindValue ( ":studyId", studyId );
+        query.bindValue ( ":studyTime", studyTime );
+        query.bindValue ( ":studyDate", studyDate );
 
         query.exec();
 
@@ -259,36 +263,41 @@ int medDatabaseImporter::getOrCreateSeries ( const medAbstractData* medData, QSq
             seriesPath = fileNames.count()>0 ? fileNames[0] : "" ;
         }
 
-        int size               = medMetaDataKeys::Size.getFirstValue(medData).toInt();
-        QString refThumbPath   = medMetaDataKeys::ThumbnailPath.getFirstValue(medData);
-        QString age            = medMetaDataKeys::Age.getFirstValue(medData);
-        QString description    = medMetaDataKeys::Description.getFirstValue(medData);
-        QString modality       = medMetaDataKeys::Modality.getFirstValue(medData);
-        QString protocol       = medMetaDataKeys::Protocol.getFirstValue(medData);
-        QString comments       = medMetaDataKeys::Comments.getFirstValue(medData);
-        QString status         = medMetaDataKeys::Status.getFirstValue(medData);
-        QString acqdate        = medMetaDataKeys::AcquisitionDate.getFirstValue(medData);
-        QString importdate     = medMetaDataKeys::ImportationDate.getFirstValue(medData);
-        QString referee        = medMetaDataKeys::Referee.getFirstValue(medData);
-        QString performer      = medMetaDataKeys::Performer.getFirstValue(medData);
-        QString institution    = medMetaDataKeys::Institution.getFirstValue(medData);
-        QString report         = medMetaDataKeys::Report.getFirstValue(medData);
+        int size                = medMetaDataKeys::Size.getFirstValue(medData).toInt();
+        QString refThumbPath    = medMetaDataKeys::ThumbnailPath.getFirstValue(medData);
+        QString age             = medMetaDataKeys::Age.getFirstValue(medData);
+        QString description     = medMetaDataKeys::Description.getFirstValue(medData);
+        QString modality        = medMetaDataKeys::Modality.getFirstValue(medData);
+        QString protocol        = medMetaDataKeys::Protocol.getFirstValue(medData);
+        QString comments        = medMetaDataKeys::Comments.getFirstValue(medData);
+        QString status          = medMetaDataKeys::Status.getFirstValue(medData);
+        QString acqdate         = medMetaDataKeys::AcquisitionDate.getFirstValue(medData);
+        QString importdate      = medMetaDataKeys::ImportationDate.getFirstValue(medData);
+        QString referee         = medMetaDataKeys::Referee.getFirstValue(medData);
+        QString performer       = medMetaDataKeys::Performer.getFirstValue(medData);
+        QString institution     = medMetaDataKeys::Institution.getFirstValue(medData);
+        QString report          = medMetaDataKeys::Report.getFirstValue(medData);
         QString origin          = medMetaDataKeys::Origin.getFirstValue(medData);
         QString flipAngle       = medMetaDataKeys::FlipAngle.getFirstValue(medData);
         QString echoTime        = medMetaDataKeys::EchoTime.getFirstValue(medData);
         QString repetitionTime  = medMetaDataKeys::RepetitionTime.getFirstValue(medData);
         QString acquisitionTime = medMetaDataKeys::AcquisitionTime.getFirstValue(medData);
+        QString seriesTime      = medMetaDataKeys::SeriesTime.getFirstValue(medData);
+        QString seriesDate      = medMetaDataKeys::SeriesDate.getFirstValue(medData);
+        QString kvp             = medMetaDataKeys::KVP.getFirstValue(medData);
 
         query.prepare ( "INSERT INTO series (study, seriesId, size, name, path, uid, "
                         "orientation, seriesNumber, sequenceName, sliceThickness, rows, columns, "
                         "thumbnail, age, description, modality, protocol, comments, "
                         "status, acquisitiondate, importationdate, referee, performer, institution, report, "
-                        "origin, flipAngle, echoTime, repetitionTime, acquisitionTime) "
+                        "origin, flipAngle, echoTime, repetitionTime, acquisitionTime, "
+                        "time, date, kvp) "
                         "VALUES (:study, :seriesId, :size, :seriesName, :seriesPath, :seriesUid, "
                         ":orientation, :seriesNumber, :sequenceName, :sliceThickness, :rows, :columns, "
                         ":thumbnail, :age, :description, :modality, :protocol, :comments, "
                         ":status, :acquisitiondate, :importationdate, :referee, :performer, :institution, :report, "
-                        ":origin, :flipAngle, :echoTime, :repetitionTime, :acquisitionTime)" );
+                        ":origin, :flipAngle, :echoTime, :repetitionTime, :acquisitionTime, "
+                        ":seriesTime, :seriesDate, :kvp)" );
 
         query.bindValue ( ":study",          studyDbId );
         query.bindValue ( ":seriesId",       seriesId );
@@ -320,6 +329,9 @@ int medDatabaseImporter::getOrCreateSeries ( const medAbstractData* medData, QSq
         query.bindValue ( ":echoTime",         echoTime );
         query.bindValue ( ":repetitionTime",   repetitionTime );
         query.bindValue ( ":acquisitionTime",  acquisitionTime );
+        query.bindValue ( ":seriesTime",     seriesTime );
+        query.bindValue ( ":seriesDate",     seriesDate );
+        query.bindValue ( ":kvp",            kvp );
 
         if ( !query.exec() )
         {

--- a/src/layers/legacy/medCoreLegacy/database/medDatabasePersistentController.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabasePersistentController.cpp
@@ -76,6 +76,10 @@ void medDatabasePersistentControllerPrivate::buildMetaDataLookup()
                           TableEntryList() << TableEntry(T_study, "uid"));
     metaDataLookup.insert(medMetaDataKeys::StudyID.key(),
                           TableEntryList() << TableEntry(T_study, "studyId"));
+    metaDataLookup.insert(medMetaDataKeys::StudyTime.key(),
+                          TableEntryList() << TableEntry(T_study, "time"));
+    metaDataLookup.insert(medMetaDataKeys::StudyDate.key(),
+                          TableEntryList() << TableEntry(T_study, "date"));
     // Series Data
     metaDataLookup.insert(medMetaDataKeys::Size.key(),
                           TableEntryList() << TableEntry(T_series, "size"));
@@ -141,6 +145,12 @@ void medDatabasePersistentControllerPrivate::buildMetaDataLookup()
     metaDataLookup.insert(medMetaDataKeys::AcquisitionTime.key(),
                           TableEntryList()
                               << TableEntry(T_series, "acquisitionTime"));
+    metaDataLookup.insert(medMetaDataKeys::SeriesTime.key(),
+                          TableEntryList() << TableEntry(T_series, "time"));
+    metaDataLookup.insert(medMetaDataKeys::SeriesDate.key(),
+                          TableEntryList() << TableEntry(T_series, "date"));
+    metaDataLookup.insert(medMetaDataKeys::KVP.key(),
+                          TableEntryList() << TableEntry(T_series, "kvp"));
 }
 
 /**

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
@@ -66,11 +66,11 @@ medAbstractData* medDatabaseReader::run()
     QSqlQuery query(medDataManager::instance()->controller()->database());
 
     QString patientName, birthdate, gender, patientId;
-    QString studyName, studyUid, studyId;
+    QString studyName, studyUid, studyId, studyTime, studyDate;
     QString seriesName, seriesPath, seriesUid, orientation, seriesNumber, sequenceName,
-            sliceThickness, rows, columns, thumbnailPath, description, protocol,
+            sliceThickness, rows, columns, thumbnailPath, age, description, protocol,
             comments, status, acquisitiondate, importationdate, referee,
-            institution, report, modality, seriesId;
+            institution, report, modality, seriesId, seriesTime, seriesDate, kvp;
     QString origin, flipAngle, echoTime, repetitionTime, acquisitionTime;
     bool indexed;
 
@@ -91,7 +91,7 @@ medAbstractData* medDatabaseReader::run()
     gender = query.value ( 2 ).toString();
     patientId = query.value ( 3 ).toString();
 
-    query.prepare ( "SELECT name, uid, studyId FROM study WHERE id = :id" );
+    query.prepare ( "SELECT name, uid, studyId, time, date FROM study WHERE id = :id" );
     query.bindValue ( ":id", studyDbId );
     if ( !query.exec() )
     {
@@ -106,12 +106,14 @@ medAbstractData* medDatabaseReader::run()
     studyName = query.value ( 0 ).toString();
     studyUid = query.value ( 1 ).toString();
     studyId = query.value ( 2 ).toString();
+    studyTime = query.value ( 3 ).toString();
+    studyDate = query.value ( 4 ).toString();
 
     query.prepare ( "SELECT name, uid, orientation, seriesNumber, sequenceName, sliceThickness, rows, columns, "
-                    "description, protocol, comments, status, acquisitiondate, importationdate, referee, "
+                    "age, description, protocol, comments, status, acquisitiondate, importationdate, referee, "
                     "institution, report, modality, seriesId, "
                     "origin, flipAngle, echoTime, repetitionTime, acquisitionTime, "
-                    "path, thumbnail, isIndexed "
+                    "path, thumbnail, isIndexed, time, date, kvp "
                     "FROM series WHERE id = :id" );
     query.bindValue ( ":id", seriesDbId );
 
@@ -133,28 +135,32 @@ medAbstractData* medDatabaseReader::run()
     sliceThickness = query.value ( 5 ).toString();
     rows = query.value ( 6 ).toString();
     columns = query.value ( 7 ).toString();
-    description = query.value ( 8 ).toString();
-    protocol = query.value ( 9 ).toString();
-    comments = query.value ( 10 ).toString();
-    status = query.value ( 11 ).toString();
-    acquisitiondate = query.value ( 12 ).toString();
-    importationdate = query.value ( 13 ).toString();
-    referee = query.value ( 14 ).toString();
-    institution = query.value ( 15 ).toString();
-    report = query.value ( 16 ).toString();
-    modality = query.value ( 17 ).toString();
-    seriesId = query.value ( 18 ).toString();
+    age = query.value ( 8 ).toString();
+    description = query.value ( 9 ).toString();
+    protocol = query.value ( 10 ).toString();
+    comments = query.value ( 11 ).toString();
+    status = query.value ( 12 ).toString();
+    acquisitiondate = query.value ( 13 ).toString();
+    importationdate = query.value ( 14 ).toString();
+    referee = query.value ( 15 ).toString();
+    institution = query.value ( 16 ).toString();
+    report = query.value ( 17 ).toString();
+    modality = query.value ( 18 ).toString();
+    seriesId = query.value ( 19 ).toString();
 
     // MR
-    origin          = query.value ( 19 ).toString();
-    flipAngle       = query.value ( 20 ).toString();
-    echoTime        = query.value ( 21 ).toString();
-    repetitionTime  = query.value ( 22 ).toString();
-    acquisitionTime = query.value ( 23 ).toString();
+    origin          = query.value ( 20 ).toString();
+    flipAngle       = query.value ( 21 ).toString();
+    echoTime        = query.value ( 22 ).toString();
+    repetitionTime  = query.value ( 23 ).toString();
+    acquisitionTime = query.value ( 24 ).toString();
 
-    seriesPath = query.value ( 24 ).toString();
-    thumbnailPath = query.value ( 25 ).toString();
-    indexed = query.value ( 26 ).toBool();
+    seriesPath = query.value ( 25 ).toString();
+    thumbnailPath = query.value ( 26 ).toString();
+    indexed = query.value ( 27 ).toBool();
+    seriesTime = query.value ( 28 ).toString();
+    seriesDate = query.value ( 29 ).toString();
+    kvp = query.value ( 30 ).toString();
 
     QStringList filePaths = seriesPath.split(';', QString::SkipEmptyParts);
     for(int i = 0 ; i < filePaths.size(); i++)
@@ -191,6 +197,8 @@ medAbstractData* medDatabaseReader::run()
     medMetaDataKeys::StudyDescription.set ( medData, studyName );
     medMetaDataKeys::StudyID.set ( medData, studyId );
     medMetaDataKeys::StudyInstanceUID.set ( medData, studyUid );
+    medMetaDataKeys::StudyTime.set ( medData, studyTime );
+    medMetaDataKeys::StudyDate.set ( medData, studyDate );
     medMetaDataKeys::SeriesDescription.set ( medData, seriesName );
     medMetaDataKeys::SeriesID.set ( medData, seriesId );
     medMetaDataKeys::SeriesInstanceUID.set ( medData, seriesUid );
@@ -199,6 +207,7 @@ medAbstractData* medDatabaseReader::run()
     medMetaDataKeys::Rows.set ( medData, rows );
     medMetaDataKeys::AcquisitionDate.set ( medData, acquisitiondate );
     medMetaDataKeys::Comments.set ( medData, comments );
+    medMetaDataKeys::Age.set( medData, age);
     medMetaDataKeys::Description.set ( medData, description );
     medMetaDataKeys::ImportationDate.set ( medData, importationdate );
     medMetaDataKeys::Modality.set ( medData, modality );
@@ -210,6 +219,9 @@ medAbstractData* medDatabaseReader::run()
     medMetaDataKeys::SequenceName.set ( medData, sequenceName );
     medMetaDataKeys::SliceThickness.set ( medData, sliceThickness );
     medMetaDataKeys::SeriesNumber.set(medData, seriesNumber);
+    medMetaDataKeys::SeriesTime.set(medData, seriesTime);
+    medMetaDataKeys::SeriesDate.set(medData, seriesDate);
+    medMetaDataKeys::KVP.set(medData, kvp);
 
     // MR
     medMetaDataKeys::Origin.set(medData, origin);

--- a/src/layers/legacy/medCoreLegacy/database/medLocalDbController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medLocalDbController.h
@@ -28,14 +28,15 @@ class MEDCORELEGACY_EXPORT medLocalDbController : public medDatabasePersistentCo
 public:
     static medLocalDbController *instance();
 
-    bool createConnection();
+    bool createConnection() override;
     bool closeConnection() override;
 
     QList<medDataIndex> patients() const override;
     void requestDatabaseForModel(QHash<int, QHash<QString, QVariant> > &patientData,
                                  QHash<int, QHash<QString, QVariant> > &studyData,
-                                 QHash<int, QHash<QString, QVariant> > &seriesData) const;
+                                 QHash<int, QHash<QString, QVariant> > &seriesData) const override;
 
+    void addTextColumnToStudyTableIfNeeded(QSqlQuery query, QString columnName);
     void addTextColumnToSeriesTableIfNeeded(QSqlQuery query, QString columnName);
 
 protected:

--- a/src/layers/legacy/medCoreLegacy/gui/database/medDatabaseMetadataItemDialog.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/database/medDatabaseMetadataItemDialog.cpp
@@ -65,7 +65,7 @@ medDatabaseMetadataItemDialog::medDatabaseMetadataItemDialog(QList<QString> keyL
 
     // Populate the tree
     int cpt = 0;
-    for (QString key : keyList)
+    for (QString &key : keyList)
     {
         // Only keep non empty metadata values
         if (!metadataList.at(cpt).toString().isEmpty())

--- a/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
+++ b/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
@@ -955,6 +955,24 @@ std::string DCMTKImageIO::GetStudyDate() const
     return name;
 }
 
+std::string DCMTKImageIO::GetStudyTime() const
+{
+    std::string name = this->GetMetaDataValueString ( "(0008,0030)", 0 );
+    return name;
+}
+
+std::string DCMTKImageIO::GetSeriesDate() const
+{
+    std::string name = this->GetMetaDataValueString ( "(0008,0021)", 0 );
+    return name;
+}
+
+std::string DCMTKImageIO::GetSeriesTime() const
+{
+    std::string name = this->GetMetaDataValueString ( "(0008,0031)", 0 );
+    return name;
+}
+
 std::string DCMTKImageIO::GetModality() const
 {
     std::string name = this->GetMetaDataValueString ( "(0008,0060)", 0 );

--- a/src/layers/legacy/medImageIO/itkDCMTKImageIO.h
+++ b/src/layers/legacy/medImageIO/itkDCMTKImageIO.h
@@ -94,6 +94,9 @@ public:
     std::string GetNumberOfSeriesInStudy() const;
     std::string GetNumberOfStudyRelatedSeries() const;
     std::string GetStudyDate() const;
+    std::string GetStudyTime() const;
+    std::string GetSeriesDate() const;
+    std::string GetSeriesTime() const;
     std::string GetModality() const;
     std::string GetManufacturer() const;
     std::string GetInstitution() const;

--- a/src/layers/legacy/medUtilities/medUtilities.cpp
+++ b/src/layers/legacy/medUtilities/medUtilities.cpp
@@ -95,6 +95,8 @@ QStringList medUtilities::metaDataKeysToCopyForDerivedData(medAbstractData* deri
          << medMetaDataKeys::Referee.key()
          << medMetaDataKeys::StudyDate.key()
          << medMetaDataKeys::StudyTime.key()
+         << medMetaDataKeys::SeriesDate.key()
+         << medMetaDataKeys::SeriesTime.key()
          << medMetaDataKeys::Modality.key()
          << medMetaDataKeys::Performer.key()
          << medMetaDataKeys::Report.key()

--- a/src/plugins/legacy/itkDataImage/readers/itkDCMTKDataImageReader.cpp
+++ b/src/plugins/legacy/itkDataImage/readers/itkDCMTKDataImageReader.cpp
@@ -388,7 +388,9 @@ bool itkDCMTKDataImageReader::readInformation(const QStringList& paths)
         medData->setMetaData(medMetaDataKeys::Institution.key(),      QString::fromLatin1(d->io->GetInstitution().c_str()));
         medData->setMetaData(medMetaDataKeys::Referee.key(),          QString::fromLatin1(d->io->GetReferringPhysicianName().c_str()));
         //StudyDate
+        medData->setMetaData(medMetaDataKeys::StudyDate.key(),        QString::fromLatin1(d->io->GetStudyDate().c_str()));
         //StudyTime
+        medData->setMetaData(medMetaDataKeys::StudyTime.key(),        QString::fromLatin1(d->io->GetStudyTime().c_str()));
 
         // SERIES
         //SeriesID
@@ -400,7 +402,9 @@ bool itkDCMTKDataImageReader::readInformation(const QStringList& paths)
         medData->setMetaData(medMetaDataKeys::Protocol.key(),          QString::fromLatin1(d->io->GetProtocolName().c_str()));
         medData->setMetaData(medMetaDataKeys::SeriesDescription.key(), QString::fromLatin1(d->io->GetSeriesDescription().c_str()));
         //SeriesDate
+        medData->setMetaData(medMetaDataKeys::SeriesDate.key(),        QString::fromLatin1(d->io->GetSeriesDate().c_str()));
         //SeriesTime
+        medData->setMetaData(medMetaDataKeys::SeriesTime.key(),       QString::fromLatin1(d->io->GetSeriesTime().c_str()));
         //SeriesThumbnail
 
         // IMAGE

--- a/src/plugins/legacy/itkDataImage/writers/itkDicomDataImageWriter.cpp
+++ b/src/plugins/legacy/itkDataImage/writers/itkDicomDataImageWriter.cpp
@@ -107,72 +107,77 @@ QString itkDicomDataImageWriter::sopClassUID(QString modality)
 
 void itkDicomDataImageWriter::fillDictionaryFromMetaDataKey(itk::MetaDataDictionary &dictionary, bool &studyUIDExistance)
 {
+    bool studyTimeExistance = false;
+    bool studyDateExistance = false;
+    bool seriesTimeExistance = false;
+    bool seriesDateExistance = false;
+
     //Get metaDataKey from data
-    foreach (QString metaDataKey, data()->metaDataList())
+    for (QString metaDataKey: data()->metaDataList())
     {
-        if (metaDataKey == QString("Modality"))
+        if (metaDataKey == medMetaDataKeys::Modality.key())
         {
             // SOP class UID
             itk::EncapsulateMetaData<std::string>(dictionary, "0008|0016", sopClassUID(data()->metadata(metaDataKey)).toStdString());
             // Modality
             itk::EncapsulateMetaData<std::string>(dictionary, "0008|0060", data()->metadata(metaDataKey).toStdString());
         }
-        if (metaDataKey == QString("BirthDate"))
+        if (metaDataKey == medMetaDataKeys::BirthDate.key())
         {
             // Patient's Birthdate
             itk::EncapsulateMetaData<std::string>(dictionary, "0010|0030", data()->metadata(metaDataKey).toStdString());
         }
-        if (metaDataKey == QString("Gender"))
+        if (metaDataKey == medMetaDataKeys::Gender.key())
         {
             // Patient's Sex
             itk::EncapsulateMetaData<std::string>(dictionary, "0010|0040", data()->metadata(metaDataKey).toStdString());
         }
-        if(metaDataKey == QString("PatientName"))
+        if(metaDataKey == medMetaDataKeys::PatientName.key())
         {
             // Patient's Name
             itk::EncapsulateMetaData<std::string>(dictionary, "0010|0010",  data()->metadata(metaDataKey).toStdString());
         }
-        if(metaDataKey == QString("PatientID"))
+        if(metaDataKey == medMetaDataKeys::PatientID.key())
         {
             // Patient's Id
             itk::EncapsulateMetaData<std::string>(dictionary, "0010|0020", data()->metadata(metaDataKey).toStdString());
         }
-        if(metaDataKey == QString("Age"))
+        if(metaDataKey == medMetaDataKeys::Age.key())
         {
             // Patient's Age
-            itk::EncapsulateMetaData<std::string>(dictionary, "0010|0010", data()->metadata(metaDataKey).toStdString());
+            itk::EncapsulateMetaData<std::string>(dictionary, "0010|1010", data()->metadata(metaDataKey).toStdString());
         }
-        if(metaDataKey == QString("SeriesDescription"))
+        if(metaDataKey == medMetaDataKeys::SeriesDescription.key())
         {
             // Series Description
             itk::EncapsulateMetaData<std::string>(dictionary, "0008|103e", data()->metadata(metaDataKey).toStdString());
         }
-        if(metaDataKey == QString("SeriesNumber"))
+        if(metaDataKey == medMetaDataKeys::SeriesNumber.key())
         {
             // Series Number
             itk::EncapsulateMetaData<std::string>(dictionary, "0020|0011",  data()->metadata(metaDataKey).toStdString());
         }
-        if(metaDataKey == QString("Referee"))
+        if(metaDataKey == medMetaDataKeys::Referee.key())
         {
             //Referee physician name
             itk::EncapsulateMetaData<std::string>(dictionary, "0008|0090", data()->metadata(metaDataKey).toStdString());
         }
-        if(metaDataKey == QString("Performer"))
+        if(metaDataKey == medMetaDataKeys::Performer.key())
         {
             //Performer physician name
             itk::EncapsulateMetaData<std::string>(dictionary, "0008|1050", data()->metadata(metaDataKey).toStdString());
         }
-        if(metaDataKey == QString("Protocol"))
+        if(metaDataKey == medMetaDataKeys::Protocol.key())
         {
             //Protocol
             itk::EncapsulateMetaData<std::string>(dictionary, "0018|1030", data()->metadata(metaDataKey).toStdString());
         }
-        if(metaDataKey == QString("Descriptions"))
+        if(metaDataKey == medMetaDataKeys::Description.key())
         {
             //Scan options
             itk::EncapsulateMetaData<std::string>(dictionary, "0018|0022", data()->metadata(metaDataKey).toStdString());
         }
-        if(metaDataKey == QString("StudyInstanceUID"))
+        if(metaDataKey == medMetaDataKeys::StudyInstanceUID.key())
         {
             // Study Instance UID
             if(!data()->metadata(metaDataKey).trimmed().isEmpty())
@@ -181,17 +186,17 @@ void itkDicomDataImageWriter::fillDictionaryFromMetaDataKey(itk::MetaDataDiction
                 itk::EncapsulateMetaData<std::string>(dictionary, "0020|000d",  data()->metadata(metaDataKey).toStdString());
             }
         }
-        if(metaDataKey == QString("StudyID"))
+        if(metaDataKey == medMetaDataKeys::StudyID.key())
         {
             // Study ID
             itk::EncapsulateMetaData<std::string>(dictionary, "0020|0010",  data()->metadata(metaDataKey).toStdString());
         }
-        if(metaDataKey == QString("StudyDescription"))
+        if(metaDataKey == medMetaDataKeys::StudyDescription.key())
         {
             // Study Description
             itk::EncapsulateMetaData<std::string>(dictionary, "0008|1030", data()->metadata(metaDataKey).toStdString());
         }
-        if(metaDataKey == QString("Institution"))
+        if(metaDataKey == medMetaDataKeys::Institution.key())
         {
             // Institution Name
             itk::EncapsulateMetaData<std::string>(dictionary, "0008|0080", data()->metadata(metaDataKey).toStdString());
@@ -200,17 +205,17 @@ void itkDicomDataImageWriter::fillDictionaryFromMetaDataKey(itk::MetaDataDiction
         {
             itk::EncapsulateMetaData<std::string>(dictionary, "0020|0012", data()->metadata(metaDataKey).toStdString());
         }
-        if(metaDataKey == QString("AcquisitionDate"))
+        if(metaDataKey == medMetaDataKeys::AcquisitionDate.key())
         {
             // Acquisition Date
             itk::EncapsulateMetaData<std::string>(dictionary, "0008|0022", data()->metadata(metaDataKey).toStdString());
         }
-        if(metaDataKey == QString("AcquisitionTime"))
+        if(metaDataKey == medMetaDataKeys::AcquisitionTime.key())
         {
             // Acquisition Date
             itk::EncapsulateMetaData<std::string>(dictionary, "0008|0032", data()->metadata(metaDataKey).toStdString());
         }
-        if(metaDataKey == QString("SequenceName"))
+        if(metaDataKey == medMetaDataKeys::SequenceName.key())
         {
             // Sequence Name
             itk::EncapsulateMetaData<std::string>(dictionary, "0018|0024", data()->metadata(metaDataKey).toStdString());
@@ -237,7 +242,67 @@ void itkDicomDataImageWriter::fillDictionaryFromMetaDataKey(itk::MetaDataDiction
         if (metaDataKey == medMetaDataKeys::Manufacturer.key())
         {
             itk::EncapsulateMetaData<std::string>(dictionary, "0008|0070", data()->metadata(metaDataKey).toStdString());
+        }       
+        if(metaDataKey == medMetaDataKeys::StudyTime.key())
+        {
+            // Study Time
+            if(!data()->metadata(metaDataKey).trimmed().isEmpty())
+            {
+                studyTimeExistance = true;
+                itk::EncapsulateMetaData<std::string>(dictionary, "0008|0030", data()->metadata(metaDataKey).toStdString());
+            }
         }
+        if(metaDataKey == medMetaDataKeys::StudyDate.key())
+        {
+            // Study Date
+            if(!data()->metadata(metaDataKey).trimmed().isEmpty())
+            {
+                studyDateExistance = true;
+                itk::EncapsulateMetaData<std::string>(dictionary, "0008|0020", data()->metadata(metaDataKey).toStdString());
+            }
+        }
+        if(metaDataKey == medMetaDataKeys::SeriesTime.key())
+        {
+            // Series Time
+            if(!data()->metadata(metaDataKey).trimmed().isEmpty())
+            {
+                seriesTimeExistance = true;
+                itk::EncapsulateMetaData<std::string>(dictionary, "0008|0031", data()->metadata(metaDataKey).toStdString());
+            }
+        }
+        if(metaDataKey == medMetaDataKeys::SeriesDate.key())
+        {
+            // Series Date
+            if(!data()->metadata(metaDataKey).trimmed().isEmpty())
+            {
+                seriesDateExistance = true;
+                itk::EncapsulateMetaData<std::string>(dictionary, "0008|0021", data()->metadata(metaDataKey).toStdString());
+            }
+        }
+    }
+
+    // Add inside input data current Time and date if they do not exist
+    // by default if not present the writer use the current time but the fractional part of a second
+    // change between slices which can be problematic for some software
+    if (!studyTimeExistance)
+    {
+        QString currentTime = QDateTime::currentDateTime().toString("hhmmss.zzzzzz");
+        itk::EncapsulateMetaData<std::string>(dictionary, "0008|0030", currentTime.toStdString());
+    }
+    if (!studyDateExistance)
+    {
+        QString currentDate = QDateTime::currentDateTime().toString("yyyyMMdd");
+        itk::EncapsulateMetaData<std::string>(dictionary, "0008|0020", currentDate.toStdString());
+    }
+    if (!seriesTimeExistance)
+    {
+        QString currentTime = QDateTime::currentDateTime().toString("hhmmss.zzzzzz");
+        itk::EncapsulateMetaData<std::string>(dictionary, "0008|0031", currentTime.toStdString());
+    }
+    if (!seriesDateExistance)
+    {
+        QString currentDate = QDateTime::currentDateTime().toString("yyyyMMdd");
+        itk::EncapsulateMetaData<std::string>(dictionary, "0008|0021", currentDate.toStdString());
     }
 }
 
@@ -246,13 +311,13 @@ void itkDicomDataImageWriter::fillDictionaryWithModalityDependentData(itk::MetaD
     QString modality = data()->metadata(medMetaDataKeys::Modality.key());
     if (modality.contains("MR"))
     {
-        itk::EncapsulateMetaData<std::string>(dictionary, "0018|0081", data()->metadata("EchoTime").toStdString());
-        itk::EncapsulateMetaData<std::string>(dictionary, "0018|1314", data()->metadata("FlipAngle").toStdString());
-        itk::EncapsulateMetaData<std::string>(dictionary, "0018|0080", data()->metadata("RepetitionTime").toStdString());
+        itk::EncapsulateMetaData<std::string>(dictionary, "0018|0081", data()->metadata(medMetaDataKeys::EchoTime.key()).toStdString());
+        itk::EncapsulateMetaData<std::string>(dictionary, "0018|1314", data()->metadata(medMetaDataKeys::FlipAngle.key()).toStdString());
+        itk::EncapsulateMetaData<std::string>(dictionary, "0018|0080", data()->metadata(medMetaDataKeys::RepetitionTime.key()).toStdString());
     }
     else if (modality.contains("CT"))
     {
-        itk::EncapsulateMetaData<std::string>(dictionary, "0018|0060", data()->metadata("KVP").toStdString());
+        itk::EncapsulateMetaData<std::string>(dictionary, "0018|0060", data()->metadata(medMetaDataKeys::KVP.key()).toStdString());
     }
 
 }


### PR DESCRIPTION
-When writing a dicom file study date, study time, series times and series dates are needed if they are not provided by the data the writer uses the current time but the fractional part of a second could change between slices which can be problematic for some software like lead-DBS used by RebrAIn. Indeed for lead-DBS slices are not stacked if these values change.

-the kvp metadata information was not kept inside the database so the dicom writer was adding 1 by default to all ct dicom 

-Morever we now read patient age from the database so this information is accessible from the medinria metadata list interface 