### PR TITLE
[CentralWidget] merge recreate default widget, and switch after data removal

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.h
+++ b/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.h
@@ -69,15 +69,11 @@ public:
     medViewContainer* splitHorizontally();
     medViewContainer* split(Qt::AlignmentFlag alignement = Qt::AlignRight);
 
+    void createdDefaultWidget();
+    void initializeDefaultWidget();
     void changeDefaultWidget(QWidget *newDefaultWidget);
-
-    /**
-     * @brief In a view, switch between default widget (text and buttons to open data)
-     * with the data widget
-     * @param displayDefault
-     */
-    void displayDefaultWidget(bool displayDefault = true);
     QWidget* defaultWidget() const;
+    void displayDefaultWidget(bool displayDefault = true);
 
     void addColorIndicator(QColor color, QString description="");
     void removeColorIndicator(QColor color);

--- a/src/plugins/legacy/medFilteringWorkspaceL/medFilteringWorkspaceL.cpp
+++ b/src/plugins/legacy/medFilteringWorkspaceL/medFilteringWorkspaceL.cpp
@@ -104,9 +104,10 @@ void medFilteringWorkspaceL::resetDefaultWidgetOutputContainer()
 {
     if(selectorToolBox()) //null when users close the software
     {
-        auto viewLayout = static_cast<QVBoxLayout*>(d->outputContainer->defaultWidget()->layout());
-        auto label = static_cast<QLabel*>(viewLayout->itemAt(0)->widget());
-        label->setText("OUTPUT");
+        // Do not keep open data buttons
+        QLabel *outputLabel = new QLabel("OUTPUT");
+        outputLabel->setAlignment(Qt::AlignCenter);
+        d->outputContainer->changeDefaultWidget(outputLabel);
         d->outputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
         d->outputContainer->setUserSplittable(false);
         d->outputContainer->setMultiLayered(false);

--- a/src/plugins/legacy/medRegistrationWorkspace/medRegistrationWorkspace.cpp
+++ b/src/plugins/legacy/medRegistrationWorkspace/medRegistrationWorkspace.cpp
@@ -118,13 +118,10 @@ void medRegistrationWorkspace::resetDefaultWidgetFuseContainer()
 {
     if(selectorToolBox()) //null when users close the software
     {
-        auto viewLayout = static_cast<QVBoxLayout*>(d->containers[Fuse]->defaultWidget()->layout());
-        auto label = static_cast<QLabel*>(viewLayout->itemAt(0)->widget());
-        if (!label->text().contains("FUSE"))
-        {
-            label->setText("FUSE\n\n"+label->text());
-            label->setAlignment(Qt::AlignCenter);
-        }
+        // Do not keep open data buttons
+        QLabel *outputLabel = new QLabel("FUSE");
+        outputLabel->setAlignment(Qt::AlignCenter);
+        d->containers[Fuse]->changeDefaultWidget(outputLabel);
         d->containers[Fuse]->setUserSplittable(false);
         d->containers[Fuse]->setAcceptDrops(false); // only addition from the app
         d->containers[Fuse]->setClosingMode(medViewContainer::CLOSE_BUTTON_HIDDEN);


### PR DESCRIPTION
Apply https://github.com/medInria/medInria-public/pull/1012 which allow to recreate the central widget of a view (text + data open buttons). For instance in a toolbox if the inner widget of a toolbox has been changed, and we switch to an other toolbox.

On previous work https://github.com/medInria/medInria-public/pull/917 on master branch to solve some reinitialisation bugs of views with changed central widget (Filtering/Registration workspaces for instance).

OUTPUT view in Filtering, and FUSE view in Registration do not allow data drop, so i removed the opening buttons. OUTPUT view in Filtering in centered.

:m: