### PR TITLE
Fix mapWorldToDisplayCoordinates function 

### DIFF
--- a/src/plugins/legacy/medVtkView/medVtkView.cpp
+++ b/src/plugins/legacy/medVtkView/medVtkView.cpp
@@ -257,7 +257,9 @@ QPointF medVtkView::mapWorldToDisplayCoordinates(const QVector3D & worldVec)
     // The following code is implemented without calling ren->SetWorldPoint,
     // because that generates an unnecessary modified event.
 
-    vtkRenderer * ren = d->currentView->GetRenderer();
+    vtkRenderer * ren = d->view2d->GetRenderer();
+    if ( !ren )
+        return QPointF();
 
     // Get window for dimensions
     vtkWindow * win = ren->GetVTKWindow();
@@ -291,6 +293,8 @@ QVector3D medVtkView::mapDisplayToWorldCoordinates(const QPointF & scenePoint)
     // because that generates an unnecessary modified event.
 
     vtkRenderer * ren = d->view2d->GetRenderer();
+    if ( !ren )
+        return QVector3D();
 
     /* get physical window dimensions */
     vtkWindow * win = ren->GetVTKWindow();


### PR DESCRIPTION
Calling mapWorldToDisplayCoordinates from medVtkView class leads to a crash. This is due to the fact that currentview is always null. To fix it we use imageView2D as done for mapDisplayToWorldCoordinates function