### PR TITLE
[Path] switch to utf8 to accept accented paths

### DIFF
--- a/src/app/medInria/medMainWindow.cpp
+++ b/src/app/medInria/medMainWindow.cpp
@@ -460,7 +460,7 @@ void medMainWindow::captureScreenshot()
                                                         "Image files (*.png *.jpeg *.jpg);;All files (*.*)",
                                                         0);
 
-        QByteArray format = fileName.right(fileName.lastIndexOf('.')).toUpper().toLatin1();
+        QByteArray format = fileName.right(fileName.lastIndexOf('.')).toUpper().toUtf8();
         if ( ! QImageWriter::supportedImageFormats().contains(format) )
         {
             format = "PNG";

--- a/src/layers/legacy/medImageIO/itkDataImageReaderBase.cpp
+++ b/src/layers/legacy/medImageIO/itkDataImageReaderBase.cpp
@@ -51,7 +51,7 @@ bool itkDataImageReaderBase::canRead (const QString& path)
     // Avoid to display log of each metadata not read by itk::ImageIOBase
     this->io->SetGlobalWarningDisplay(false);
 
-    if (!this->io->CanReadFile( path.toLatin1().constData() ))
+    if (!this->io->CanReadFile( path.toUtf8().constData() ))
     {
         return false;
     }
@@ -62,7 +62,7 @@ bool itkDataImageReaderBase::canRead (const QString& path)
         // will be handled by more specific image readers
         // (e.g. tensors if 6 or 9 components)
 
-        this->io->SetFileName( path.toLatin1().constData() );
+        this->io->SetFileName( path.toUtf8().constData() );
         try {
            this->io->ReadImageInformation();
         }
@@ -94,7 +94,7 @@ bool itkDataImageReaderBase::readInformation (const QString& path)
     if (this->io.IsNull())
         return false;
 
-    this->io->SetFileName(path.toLatin1().constData());
+    this->io->SetFileName(path.toUtf8().constData());
     try
     {
         this->io->ReadImageInformation();
@@ -276,7 +276,7 @@ bool itkDataImageReaderBase::read_image(const QString& path,const char* type)
     typedef itk::Image<T,DIM> Image;
     typename itk::ImageFileReader<Image>::Pointer TReader = itk::ImageFileReader<Image>::New();
     TReader->SetImageIO(this->io);
-    TReader->SetFileName(path.toLatin1().constData());
+    TReader->SetFileName(path.toUtf8().constData());
     TReader->SetUseStreaming(true);
     TReader->Update();
 

--- a/src/layers/legacy/medImageIO/itkDataImageWriterBase.cpp
+++ b/src/layers/legacy/medImageIO/itkDataImageWriterBase.cpp
@@ -45,7 +45,7 @@ bool itkDataImageWriterBase::canWrite(const QString& path)
     if (this->io.IsNull())
         return false;
 
-    return this->io->CanWriteFile ( path.toLatin1().constData() );
+    return this->io->CanWriteFile ( path.toUtf8().constData() );
 }
 
 template <unsigned DIM,typename T>
@@ -65,7 +65,7 @@ bool itkDataImageWriterBase::write_image(const QString& path,const char* type) {
     typename itk::ImageFileWriter<Image>::Pointer writer = itk::ImageFileWriter <Image>::New();
     writer->SetImageIO (this->io);
     writer->UseCompressionOn();
-    writer->SetFileName(path.toLatin1().constData());
+    writer->SetFileName(path.toUtf8().constData());
     writer->SetInput(image);
     writer->Update();
 

--- a/src/plugins/legacy/itkDataImage/readers/itkGDCMDataImageReader.cpp
+++ b/src/plugins/legacy/itkDataImage/readers/itkGDCMDataImageReader.cpp
@@ -224,12 +224,12 @@ QString itkGDCMDataImageReader::description() const {
 }
 
 bool itkGDCMDataImageReader::canRead(const QString &path) {
-    return d->io->CanReadFile(path.toLatin1().constData());
+    return d->io->CanReadFile(path.toUtf8().constData());
 }
 
 bool itkGDCMDataImageReader::canRead(const QStringList &paths) {
     for (int i=0; i<paths.size(); i++)
-        if (!d->io->CanReadFile(paths[i].toLatin1().constData()))
+        if (!d->io->CanReadFile(paths[i].toUtf8().constData()))
             return false;
     return true;
 }
@@ -247,7 +247,7 @@ bool itkGDCMDataImageReader::readInformation(const QStringList &paths)
 
     FileList filenames;
     for (int i=0; i<paths.size(); i++)
-        filenames.push_back(paths[i].toLatin1().constData());
+        filenames.push_back(paths[i].toUtf8().constData());
 
     FileListMapType map = this->sort(filenames);
 
@@ -408,7 +408,7 @@ bool itkGDCMDataImageReader::read (const QStringList &paths)
 
     FileList filenames;
     for (int i=0;i<paths.size();i++)
-        filenames.push_back(paths[i].toLatin1().constData());
+        filenames.push_back(paths[i].toUtf8().constData());
 
     FileListMapType map = this->sort(filenames);
 
@@ -425,9 +425,9 @@ bool itkGDCMDataImageReader::read (const QStringList &paths)
         QStringList qfilelist = medData->metaDataValues("FilePaths");
         FileList filelist;
         for (int i=0;i<qfilelist.size();i++)
-            filelist.push_back(qfilelist[i].toLatin1().constData());
+            filelist.push_back(qfilelist[i].toUtf8().constData());
 
-        std::cout << "reading : "    << medData->identifier().toLatin1().constData() << std::endl;
+        std::cout << "reading : "    << medData->identifier().toUtf8().constData() << std::endl;
         std::cout << "containing : " << map.size() << " volumes" << std::endl;
 
         try {

--- a/src/plugins/legacy/itkDataSHImage/readers/itkDataSHImageReader.cpp
+++ b/src/plugins/legacy/itkDataSHImage/readers/itkDataSHImageReader.cpp
@@ -70,15 +70,15 @@ bool itkDataSHImageReader::canRead (const QStringList &paths)
 
 bool itkDataSHImageReader::canRead (const QString &path)
 {
-    itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(path.toLatin1().constData(),
+    itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(path.toUtf8().constData(),
                                                                            itk::ImageIOFactory::ReadMode);
 
     if (!imageIO.IsNull())
     {
-        if (!imageIO->CanReadFile ( path.toLatin1().constData() ))
+        if (!imageIO->CanReadFile ( path.toUtf8().constData() ))
             return false;
 
-        imageIO->SetFileName (path.toLatin1().constData());
+        imageIO->SetFileName (path.toUtf8().constData());
         try
         {
             imageIO->ReadImageInformation();
@@ -114,10 +114,10 @@ bool itkDataSHImageReader::readInformation (const QStringList &paths)
 
 bool itkDataSHImageReader::readInformation (const QString &path)
 {
-    itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(path.toLatin1().constData(),
+    itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(path.toUtf8().constData(),
                                                                            itk::ImageIOFactory::ReadMode);
     
-    imageIO->SetFileName ( path.toLatin1().constData() );
+    imageIO->SetFileName ( path.toUtf8().constData() );
     try
     {
         imageIO->ReadImageInformation();
@@ -180,7 +180,7 @@ bool itkDataSHImageReader::read (const QString &path)
             SHImageType::Pointer image = nullptr;
 
             ReaderType::Pointer reader = ReaderType::New();
-            reader->SetFileName ( path.toLatin1().constData() );
+            reader->SetFileName ( path.toUtf8().constData() );
             try
             {
                 reader->Update();
@@ -201,7 +201,7 @@ bool itkDataSHImageReader::read (const QString &path)
             SHImageType::Pointer image = nullptr;
 
             ReaderType::Pointer reader = ReaderType::New();
-            reader->SetFileName ( path.toLatin1().constData() );
+            reader->SetFileName ( path.toUtf8().constData() );
             try
             {
                 reader->Update();

--- a/src/plugins/legacy/itkDataSHImage/writers/itkDataSHImageWriterBase.cpp
+++ b/src/plugins/legacy/itkDataSHImage/writers/itkDataSHImageWriterBase.cpp
@@ -66,7 +66,7 @@ bool itkDataSHImageWriterBase::canWrite(const QString& path)
     if (this->io.IsNull())
         return false;
 
-    return this->io->CanWriteFile ( path.toLatin1().constData() );
+    return this->io->CanWriteFile ( path.toUtf8().constData() );
 }
 
 bool itkDataSHImageWriterBase::write(const QString& path)
@@ -116,7 +116,7 @@ bool itkDataSHImageWriterBase::write(const QString& path, PixelType dummyArgumen
 
     typedef typename itk::ImageFileWriter<SHImageType>::Pointer ImageFileWriterPointer;
     ImageFileWriterPointer myWriter = itk::ImageFileWriter<SHImageType>::New();
-    myWriter->SetFileName(path.toLatin1().constData());
+    myWriter->SetFileName(path.toUtf8().constData());
     myWriter->SetInput(/*mySH*/image);
     try
     {

--- a/src/plugins/legacy/itkDataTensorImage/readers/itkDataTensorImageReaderBase.cpp
+++ b/src/plugins/legacy/itkDataTensorImage/readers/itkDataTensorImageReaderBase.cpp
@@ -57,10 +57,10 @@ bool itkDataTensorImageReaderBase::canRead (const QStringList &paths)
 bool itkDataTensorImageReaderBase::canRead (const QString &path)
 {
     if (!this->io.IsNull()) {
-        if (!this->io->CanReadFile ( path.toLatin1().constData() ))
+        if (!this->io->CanReadFile ( path.toUtf8().constData() ))
             return false;
 
-        this->io->SetFileName (path.toLatin1().constData());
+        this->io->SetFileName (path.toUtf8().constData());
         try
         {
             this->io->ReadImageInformation();
@@ -92,7 +92,7 @@ bool itkDataTensorImageReaderBase::readInformation (const QString &path)
     if (this->io.IsNull())
         return false;
     
-    this->io->SetFileName ( path.toLatin1().constData() );
+    this->io->SetFileName ( path.toUtf8().constData() );
     try
     {
         this->io->ReadImageInformation();
@@ -168,7 +168,7 @@ bool itkDataTensorImageReaderBase::read (const QString &path)
                 {
                     ReaderType::Pointer reader = ReaderType::New();
                     reader->SetImageIO (this->io);
-                    reader->SetFileName ( path.toLatin1().constData() );
+                    reader->SetFileName ( path.toUtf8().constData() );
                     try {
                         reader->Update();
                     }
@@ -231,7 +231,7 @@ bool itkDataTensorImageReaderBase::read (const QString &path)
                 {
                     ReaderType::Pointer reader = ReaderType::New();
                     reader->SetImageIO (this->io);
-                    reader->SetFileName ( path.toLatin1().constData() );
+                    reader->SetFileName ( path.toUtf8().constData() );
                     try {
                         reader->Update();
                     }
@@ -301,7 +301,7 @@ bool itkDataTensorImageReaderBase::read (const QString &path)
                 {
                     ReaderType::Pointer reader = ReaderType::New();
                     reader->SetImageIO (this->io);
-                    reader->SetFileName ( path.toLatin1().constData() );
+                    reader->SetFileName ( path.toUtf8().constData() );
                     try {
                         reader->Update();
                     }
@@ -363,7 +363,7 @@ bool itkDataTensorImageReaderBase::read (const QString &path)
                 {
                     ReaderType::Pointer reader = ReaderType::New();
                     reader->SetImageIO (this->io);
-                    reader->SetFileName ( path.toLatin1().constData() );
+                    reader->SetFileName ( path.toUtf8().constData() );
                     try {
                         reader->Update();
                     }

--- a/src/plugins/legacy/itkDataTensorImage/writers/itkDataTensorImageWriterBase.cpp
+++ b/src/plugins/legacy/itkDataTensorImage/writers/itkDataTensorImageWriterBase.cpp
@@ -65,7 +65,7 @@ bool itkDataTensorImageWriterBase::canWrite(const QString& path)
     if (this->io.IsNull())
         return false;
 
-    return this->io->CanWriteFile ( path.toLatin1().constData() );
+    return this->io->CanWriteFile ( path.toUtf8().constData() );
 }
 
 bool itkDataTensorImageWriterBase::write(const QString& path)
@@ -148,7 +148,7 @@ bool itkDataTensorImageWriterBase::write(const QString& path, PixelType dummyArg
 
     typedef typename itk::ImageFileWriter<VectorImageType>::Pointer ImageFileWriterPointer;
     ImageFileWriterPointer myWriter = itk::ImageFileWriter<VectorImageType>::New();
-    myWriter->SetFileName(path.toLatin1().constData());
+    myWriter->SetFileName(path.toUtf8().constData());
     myWriter->SetInput(myTensorImage);
     try
     {

--- a/src/plugins/legacy/medVtkFibersData/readers/medVtkFibersDataReader.cpp
+++ b/src/plugins/legacy/medVtkFibersData/readers/medVtkFibersDataReader.cpp
@@ -48,7 +48,7 @@ QStringList medVtkFibersDataReader::handled() const
 
 bool medVtkFibersDataReader::canRead (const QString& path)
 {
-    return d->reader->CanReadFile (path.toLatin1().constData());
+    return d->reader->CanReadFile (path.toUtf8().constData());
 }
 
 bool medVtkFibersDataReader::canRead (const QStringList& paths)
@@ -76,7 +76,7 @@ bool medVtkFibersDataReader::readInformation (const QStringList& paths)
 {
     if (!paths.count())
         return false;
-    return this->readInformation ( paths[0].toLatin1().constData() );
+    return this->readInformation ( paths[0].toUtf8().constData() );
 }
 
 bool medVtkFibersDataReader::read (const QString& path)
@@ -89,7 +89,7 @@ bool medVtkFibersDataReader::read (const QString& path)
 
     if (medAbstractData *medData = dynamic_cast<medAbstractData*>(this->data()))
     {
-        d->reader->SetFileName (path.toLatin1().constData());
+        d->reader->SetFileName (path.toUtf8().constData());
         d->reader->Update();
 
         if (vtkFiberDataSet *dataset = d->reader->GetOutput())
@@ -125,7 +125,7 @@ bool medVtkFibersDataReader::read (const QStringList& paths)
 {
     if (!paths.count())
         return false;
-    return this->read ( paths[0].toLatin1().constData() );
+    return this->read ( paths[0].toUtf8().constData() );
 }
 
 void medVtkFibersDataReader::setProgress (int value)

--- a/src/plugins/legacy/medVtkFibersData/writers/medVtkFibersDataWriter.cpp
+++ b/src/plugins/legacy/medVtkFibersData/writers/medVtkFibersDataWriter.cpp
@@ -57,7 +57,7 @@ bool medVtkFibersDataWriter::write(const QString& path)
       return false;
   
   vtkXMLFiberDataSetWriter *writer = vtkXMLFiberDataSetWriter::New();
-  writer->SetFileName ( path.toLatin1().constData() );
+  writer->SetFileName ( path.toUtf8().constData() );
   writer->SetInputData ( dataset );
   writer->SetDataModeToBinary();
   writer->Write();

--- a/src/plugins/legacy/vtkDataMesh/readers/vtkDataMesh4DReader.cpp
+++ b/src/plugins/legacy/vtkDataMesh/readers/vtkDataMesh4DReader.cpp
@@ -46,14 +46,14 @@ QStringList vtkDataMesh4DReader::s_handled()
 
 bool vtkDataMesh4DReader::canRead (const QString& path)
 {
-    return this->reader->CanReadFile (path.toLatin1().constData());
+    return this->reader->CanReadFile (path.toUtf8().constData());
 }
 
 bool vtkDataMesh4DReader::readInformation (const QString& path)
 {
   
     medAbstractData *medData = dynamic_cast<medAbstractData*>(this->data());
-    this->reader->SetFileName (path.toLatin1().constData());
+    this->reader->SetFileName (path.toUtf8().constData());
   
     if (!medData)
     {
@@ -87,7 +87,7 @@ bool vtkDataMesh4DReader::read (const QString& path)
             return false;
         }
 
-        this->reader->SetFileName (path.toLatin1().constData());
+        this->reader->SetFileName (path.toUtf8().constData());
         this->reader->Update();
 
         vtkMetaDataSetSequence* sequence = vtkMetaDataSetSequence::SafeDownCast (this->reader->GetOutput()->GetMetaDataSet ((unsigned int)0));

--- a/src/plugins/legacy/vtkDataMesh/writers/vtkDataMesh4DWriter.cpp
+++ b/src/plugins/legacy/vtkDataMesh/writers/vtkDataMesh4DWriter.cpp
@@ -72,9 +72,8 @@ bool vtkDataMesh4DWriter::write(const QString& path)
     vtkDataManager* manager = vtkDataManager::New();
     manager->AddMetaDataSet (sequence);
 
-    this->writer->SetFileName(path.toLatin1().constData());
+    this->writer->SetFileName(path.toUtf8().constData());
     this->writer->SetInput (manager);
-    // this->writer->SetFileTypeToBinary();
     this->writer->Update();
 
     for(vtkMetaDataSet* dataSet : sequence->GetMetaDataSetList())


### PR DESCRIPTION
Fix https://github.com/medInria/medInria-public/issues/1027

Solve import error when there are accents in a data path to import.

:m: