### PR TITLE
[iterativeClosestPoint] rewrite ICP code, reorganize toolbox, add fiducial registration error --master

### DIFF
--- a/src/plugins/legacy/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
+++ b/src/plugins/legacy/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
@@ -43,7 +43,6 @@ public:
     QLabel *medianText;
 
     dtkSmartPointer<iterativeClosestPointProcess> process;
-
 };
 
 iterativeClosestPointToolBox::iterativeClosestPointToolBox(QWidget *parent)

--- a/src/plugins/legacy/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
+++ b/src/plugins/legacy/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
@@ -66,10 +66,12 @@ iterativeClosestPointToolBox::iterativeClosestPointToolBox(QWidget *parent)
     // Parameters widgets
     d->layerSource = new QComboBox;
     d->layerSource->addItem("Select the layer", 0);
+    d->layerSource->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
     QLabel *layerSource_Label = new QLabel("Select the source mesh:");
 
     d->layerTarget = new QComboBox;
     d->layerTarget->addItem("Select the layer", 0);
+    d->layerTarget->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
     QLabel *layerTarget_Label = new QLabel("Select the target mesh:");
 
     // Choose scale factor to apply to Source mesh

--- a/src/plugins/legacy/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
+++ b/src/plugins/legacy/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
@@ -43,6 +43,7 @@ public:
     QLabel *medianText;
 
     dtkSmartPointer<iterativeClosestPointProcess> process;
+
 };
 
 iterativeClosestPointToolBox::iterativeClosestPointToolBox(QWidget *parent)

--- a/src/plugins/legacy/iterativeClosestPoint/medICPFilter.cxx
+++ b/src/plugins/legacy/iterativeClosestPoint/medICPFilter.cxx
@@ -230,12 +230,14 @@ vtkMTimeType medICPFilter::GetMTime()
 }
 
 //----------------------------------------------------------------------------
+
 std::vector<vtkIdType> medICPFilter::GetSourceLandmarkIds()
 {
     return this->SourceLandmarkIds;
 }
 
 //----------------------------------------------------------------------------
+
 void medICPFilter::GetFREStats(double &mean, double &stdDev, double &median)
 {
      mean   = this->meanFRE;

--- a/src/plugins/legacy/iterativeClosestPoint/medICPFilter.cxx
+++ b/src/plugins/legacy/iterativeClosestPoint/medICPFilter.cxx
@@ -230,14 +230,12 @@ vtkMTimeType medICPFilter::GetMTime()
 }
 
 //----------------------------------------------------------------------------
-
 std::vector<vtkIdType> medICPFilter::GetSourceLandmarkIds()
 {
     return this->SourceLandmarkIds;
 }
 
 //----------------------------------------------------------------------------
-
 void medICPFilter::GetFREStats(double &mean, double &stdDev, double &median)
 {
      mean   = this->meanFRE;

--- a/src/plugins/legacy/iterativeClosestPoint/medICPFilter.cxx
+++ b/src/plugins/legacy/iterativeClosestPoint/medICPFilter.cxx
@@ -482,7 +482,9 @@ void medICPFilter::InternalUpdate()
         if (this->MeanDistanceMode == VTK_ICP_MODE_RMS)
         {
           totaldist += vtkMath::Distance2BetweenPoints(p1, p2);
-        } else {
+        }
+        else
+        {
           totaldist += sqrt(vtkMath::Distance2BetweenPoints(p1, p2));
         }
       }
@@ -493,7 +495,9 @@ void medICPFilter::InternalUpdate()
       if (this->MeanDistanceMode == VTK_ICP_MODE_RMS)
       {
         this->MeanDistance = sqrt(totaldist / (double)nb_points);
-      } else {
+      }
+      else
+      {
         this->MeanDistance = totaldist / (double)nb_points;
       }
       vtkDebugMacro("Mean distance: " << this->MeanDistance);

--- a/src/plugins/legacy/iterativeClosestPoint/medICPFilter.h
+++ b/src/plugins/legacy/iterativeClosestPoint/medICPFilter.h
@@ -25,7 +25,8 @@ class vtkCellLocator;
 class vtkLandmarkTransform;
 class vtkDataSet;
 
-class ITERATIVECLOSESTPOINTPLUGIN_EXPORT medICPFilter : public vtkLinearTransform {
+class ITERATIVECLOSESTPOINTPLUGIN_EXPORT medICPFilter : public vtkLinearTransform
+{
 public:
   static medICPFilter *New();
   void PrintSelf(ostream &os, vtkIndent indent) override;

--- a/src/plugins/legacy/meshMapping/meshMappingToolBox.cpp
+++ b/src/plugins/legacy/meshMapping/meshMappingToolBox.cpp
@@ -46,12 +46,14 @@ meshMappingToolBox::meshMappingToolBox(QWidget *parent)
     QLabel *dataLabel = new QLabel("Data to map ", this);
     dataLabel->setToolTip(tr("Select the data from which to obtain values"));
     d->layersForData = new QComboBox;
+    d->layersForData->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
     d->layersForData->addItem("Select the data to map", 0);
 
     QLabel *structureLabel = new QLabel("Mesh", this);
     structureLabel->setToolTip(tr("Select the mesh whose geometry will be used\n \
                                   in determining positions to map"));
     d->layersForStructure = new QComboBox;
+    d->layersForStructure->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
     d->layersForStructure->addItem("Select the mesh", 0);
     
     QPushButton *runButton = new QPushButton(tr("Run"), this);


### PR DESCRIPTION
Same as https://github.com/medInria/medInria-public/pull/1030 for medInria4

> To add fiducial registration error to ICP algorithm, it was necessary to recode the method.
> The toolbox was reorganized to have a more relevant disposition for the input parameters.
> The input parameters will be write in the transformation matrix file.
> The fiducial registration error is written in transformation matrix file and in the toolbox after process.

:m: