### PR TITLE
[Package] rm TmpInstall macOS code which does not package

### DIFF
--- a/packaging/apple/mac_packager.sh.in
+++ b/packaging/apple/mac_packager.sh.in
@@ -34,40 +34,6 @@ injectDirs="$injectDirs -inject-dir=$resourceLibsDir"
 
 @dtk_DIR@/bin/dtkDeploy medInria.app $injectDirs &>/dev/null
 
-# A bug in dtkDeploy causes plugins to keep their original installed name so we
-# must manually fix them.
-for lib in @medInria_BINARY_DIR@/bin/TmpInstall/medInria.app/Contents/PlugIns/*.dylib; do
-    libname=${lib##*/}
-    installedName="@executable_path/../PlugIns/$libname"
-    install_name_tool -id $installedName @medInria_BINARY_DIR@/bin/TmpInstall/medInria.app/Contents/PlugIns/$libname
-done
-
-# Resource libraries are sent as plugins to dtkDeploy (above) because they are
-# not dependencies of the executable (dtkDeploy uses otool on the executable to
-# find which libraires should be imported, so it will not find resource
-# libraries). After the execution of dtkDeploy we move these libraries to the
-# frameworks folder and adjust their install name.
-resourceLibs=''
-for lib in $resourceLibsDir/*.dylib; do
-    libname=${lib##*/}
-    copiedLib=@medInria_BINARY_DIR@/bin/TmpInstall/medInria.app/Contents/Frameworks/$libname
-    \mv @medInria_BINARY_DIR@/bin/TmpInstall/medInria.app/Contents/PlugIns/$libname $copiedLib
-    installedName="@executable_path/../Frameworks/$libname"
-    install_name_tool -id $installedName $copiedLib
-    resourceLibs="$resourceLibs $libname"
-done
-
-# Because of the dtkDeploy bug with install names, we have to fix the
-# dependencies of the resource libraries.
-for lib1 in $resourceLibs; do
-    deployedLib1=@medInria_BINARY_DIR@/bin/TmpInstall/medInria.app/Contents/Frameworks/$lib1
-    installedName="@executable_path/../Frameworks/$lib1"
-    for lib2 in $resourceLibs; do
-        deployedLib2=@medInria_BINARY_DIR@/bin/TmpInstall/medInria.app/Contents/Frameworks/$lib2
-        install_name_tool -change $1/$lib1 $installedName $deployedLib2
-    done
-done
-
 #Run fancy packaging apple script
 
 \cp -f @medInria_SOURCE_DIR@/utils/osx_packaging/BaseMedinriaPackage.sparseimage.gz @PROJECT_BINARY_DIR@/MedinriaPackage.sparseimage.gz


### PR DESCRIPTION
We have an error in packaging of medInria/MSC:

```
error: /Library/Developer/CommandLineTools/usr/bin/install_name_tool: can't open file: /System/Volumes/Data/builds/workspace/music-macos-free/build/medInria-build/bin/TmpInstall/medInria.app/Contents/PlugIns/*.dylib (No such file or directory)
mv: rename /System/Volumes/Data/builds/workspace/music-macos-free/build/medInria-build/bin/TmpInstall/medInria.app/Contents/PlugIns/*.dylib to /System/Volumes/Data/builds/workspace/music-macos-free/build/medInria-build/bin/TmpInstall/medInria.app/Contents/Frameworks/*.dylib: No such file or directory
error: /Library/Developer/CommandLineTools/usr/bin/install_name_tool: can't open file: /System/Volumes/Data/builds/workspace/music-macos-free/build/medInria-build/bin/TmpInstall/medInria.app/Contents/Frameworks/*.dylib (No such file or directory)
error: /Library/Developer/CommandLineTools/usr/bin/install_name_tool: more than one input file specified (/System/Volumes/Data/builds/workspace/music-macos-free/build/medInria-build/bin/plugins/libmedItkDWIBasicThresholdingProcessPlugin.dylib and /System/Volumes/Data/builds/workspace/music-macos-free/build/medInria-build/bin/plugins/libmedItkBiasCorrectionProcessPlugin.dylib)
Usage: /Library/Developer/CommandLineTools/usr/bin/install_name_tool [-change old new] ... [-rpath old new] ... [-add_rpath new] ... [-delete_rpath old] ... [-id name] input
```
This is due to code from PR https://github.com/medInria/medInria-public/pull/993 and https://github.com/medInria/medInria-public/pull/994  in `mac_packager.sh.in`. So, @fcollot since it was your code, can you tell us if this part of the code is still needed or can be removed?

:m:
