### PR TITLE
[Variational] GUI, applied data saved, data name, spacing error

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -6,7 +6,8 @@ medInria 3.3:
 - Check the version of the vtk file to avoid crash due to the new format introduced in vtk 9
 - ManualRegistration, avoid duplication in outputs
 - Reslice, solve crashs after removing a data in view
-- PolygonROI, solve graphical/ergonomy pb and crashes (split, clear) 
+- PolygonROI, solve graphical/ergonomy pb and crashes (split, clear)
+- Variational Segmentation: enhance GUI, solve a spacing error on output masks
 
 medInria 3.2:
 - Add some tooltips in view navigator

--- a/src/plugins/legacy/variationalSegmentation/vtkLandmarkSegmentationController.cpp
+++ b/src/plugins/legacy/variationalSegmentation/vtkLandmarkSegmentationController.cpp
@@ -602,9 +602,9 @@ vtkLandmarkSegmentationController::binaryType::Pointer vtkLandmarkSegmentationCo
     ImageType::SpacingType outputSpacing;
 
     ImageType::SizeType filterInputSize = implicitFunction->GetLargestPossibleRegion().GetSize();
-    outputSpacing[0] = implicitFunction->GetSpacing()[0] * (static_cast<double>(filterInputSize[0]) / static_cast<double>(outputSize[0]));
-    outputSpacing[1] = implicitFunction->GetSpacing()[1] * (static_cast<double>(filterInputSize[1]) / static_cast<double>(outputSize[1]));
-    outputSpacing[2] = implicitFunction->GetSpacing()[2] * (static_cast<double>(filterInputSize[2]) / static_cast<double>(outputSize[2]));
+    outputSpacing[0] = implicitFunction->GetSpacing()[0] * (static_cast<double>(filterInputSize[0]-1) / static_cast<double>(outputSize[0]));
+    outputSpacing[1] = implicitFunction->GetSpacing()[1] * (static_cast<double>(filterInputSize[1]-1) / static_cast<double>(outputSize[1]));
+    outputSpacing[2] = implicitFunction->GetSpacing()[2] * (static_cast<double>(filterInputSize[2]-1) / static_cast<double>(outputSize[2]));
 
     filter->SetInput(implicitFunction);
     filter->SetSize(size);


### PR DESCRIPTION
This PR:
 * fix https://github.com/medInria/medInria-public/issues/793 removing the white plans on output mask
 * enhance the GUI, the first button is the saving of the mask, before the application of the mask on the view, and exported data name shorten
 * the application of the mask save the applied data, not the mask, which is done with the mask button

:m: