### PR TITLE
[Combobox] right size with long data array name

### DIFF
--- a/src/plugins/legacy/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
+++ b/src/plugins/legacy/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
@@ -66,10 +66,12 @@ iterativeClosestPointToolBox::iterativeClosestPointToolBox(QWidget *parent)
     // Parameters widgets
     d->layerSource = new QComboBox;
     d->layerSource->addItem("Select the layer", 0);
+    d->layerSource->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
     QLabel *layerSource_Label = new QLabel("Select the source mesh:");
 
     d->layerTarget = new QComboBox;
     d->layerTarget->addItem("Select the layer", 0);
+    d->layerTarget->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
     QLabel *layerTarget_Label = new QLabel("Select the target mesh:");
 
     // Choose scale factor to apply to Source mesh

--- a/src/plugins/legacy/meshMapping/meshMappingToolBox.cpp
+++ b/src/plugins/legacy/meshMapping/meshMappingToolBox.cpp
@@ -46,12 +46,14 @@ meshMappingToolBox::meshMappingToolBox(QWidget *parent)
     QLabel *dataLabel = new QLabel("Select the data to map ", this);
     dataLabel->setToolTip(tr("Select the dataset from which to obtain\n probe values (image or mesh)."));
     d->layersForData = new QComboBox;
+    d->layersForData->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
     d->layersForData->addItem("Select the layer", 0);
 
     QLabel *structureLabel = new QLabel("Select the structure", this);
     structureLabel->setToolTip(tr("Select the dataset whose geometry will be used\n \
                                   in determining positions to probe (typically a mesh)."));
     d->layersForStructure = new QComboBox;
+    d->layersForStructure->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
     d->layersForStructure->addItem("Select the layer", 0);
     
     QPushButton *runButton = new QPushButton(tr("Run"), this);


### PR DESCRIPTION
Solve toolbox width error in case of opening data with long data array name, before opening the toolbox.

:m: