### PR TITLE
Add PYNCPP external project

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,11 @@ option(USE_FFmpeg
   )
 endif()
 
+option(USE_Python
+  "Build with Python support"
+  ON
+  )
+
 ## #############################################################################
 ## Find package
 ## #############################################################################
@@ -79,6 +84,10 @@ find_package(Qt5 REQUIRED COMPONENTS
 
 find_package(dtk REQUIRED)
 include_directories(${dtk_INCLUDE_DIRS})
+
+if(USE_Python)
+    find_package(PYNCPP REQUIRED COMPONENTS Qt5)
+endif()
 
 ## #############################################################################
 ## enable c++ 17
@@ -156,6 +165,8 @@ if(NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
   message(STATUS "Add -DQT_NO_DEBUG")
   add_definitions(-DQT_NO_DEBUG)
 endif()
+
+add_compile_definitions("USE_PYTHON=$<BOOL:USE_PYTHON>")
 
 ## #############################################################################
 ## Windows specificity

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -47,6 +47,8 @@ option(USE_DTKIMAGING "Use DTK imaging layer" OFF )
   
 option(USE_OSPRay "Use OSPRay for CPU VR" OFF )
 
+option(USE_Python "Build with Python support" ON)
+
 if (NOT WIN32)
   option(USE_FFmpeg "Build with FFmpeg video export support" OFF)
   if (${USE_FFmpeg})
@@ -68,6 +70,12 @@ list(APPEND external_projects
 if (USE_DTKIMAGING)
     list(APPEND external_projects
         dtkImaging
+        )
+endif()
+
+if (USE_Python)
+    list(APPEND external_projects
+        PYNCPP
         )
 endif()
 

--- a/superbuild/projects_modules/PYNCPP.cmake
+++ b/superbuild/projects_modules/PYNCPP.cmake
@@ -1,0 +1,66 @@
+################################################################################
+#
+# medInria
+#
+# Copyright (c) INRIA 2022. All rights reserved.
+# See LICENSE.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.
+#
+################################################################################
+
+function(PYNCPP_project)
+
+    set(ep PYNCPP)
+
+    EP_Initialisation(${ep}
+        USE_SYSTEM OFF
+        BUILD_SHARED_LIBS ON
+        REQUIRED_FOR_PLUGINS OFF
+        )
+
+    if(USE_SYSTEM_${ep})
+        find_package(PYNCPP ${version_major}.${version_minor}.${version_patch}
+            REQUIRED COMPONENTS Qt5
+            )
+    else()
+        epComputPath(${ep})
+
+        set(source_dir ${EP_PATH_SOURCE}/${ep})
+        set(binary_dir ${build_path})
+
+        set(project_args
+            GIT_REPOSITORY ${GITHUB_PREFIX}LIRYC-IHU/pyncpp.git
+            GIT_TAG origin/working
+            GIT_SHALLOW True
+            GIT_PROGRESS True
+            )
+
+        ## #####################################################################
+        ## Add external project
+        ## #####################################################################
+
+        ExternalProject_Add(${ep}
+            PREFIX ${EP_PATH_SOURCE}
+            SOURCE_DIR ${source_dir}
+            BINARY_DIR ${binary_dir}
+            TMP_DIR ${tmp_path}
+            STAMP_DIR ${stamp_path}
+            DEPENDS ${${ep}_dependencies}
+            INSTALL_COMMAND ""
+            "${project_args}"
+            )
+
+        ExternalProject_Get_Property(${ep} binary_dir)
+
+        ## #####################################################################
+        ## Export variables
+        ## #####################################################################
+
+        set(${ep}_DIR ${binary_dir} PARENT_SCOPE)
+
+    endif()
+
+endfunction()

--- a/superbuild/projects_modules/PYNCPP.cmake
+++ b/superbuild/projects_modules/PYNCPP.cmake
@@ -22,7 +22,7 @@ function(PYNCPP_project)
         )
 
     if(USE_SYSTEM_${ep})
-        find_package(PYNCPP ${version_major}.${version_minor}.${version_patch}
+        find_package(PYNCPP
             REQUIRED COMPONENTS Qt5
             )
     else()

--- a/superbuild/projects_modules/medInria.cmake
+++ b/superbuild/projects_modules/medInria.cmake
@@ -78,6 +78,7 @@ set(cmake_args
   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS_${ep}}
   -DUSE_DTKIMAGING:BOOL=${USE_DTKIMAGING}
   -DUSE_OSPRay:BOOL=${USE_OSPRay}
+  -DUSE_Python:BOOL=${USE_Python}
   -DmedInria_VERSION:STRING=${${PROJECT_NAME}_VERSION}
   -DBUILD_ALL_PLUGINS=OFF
   -DBUILD_COMPOSITEDATASET_PLUGIN=OFF
@@ -93,7 +94,6 @@ set(cmake_cache_args
   -DTTK_DIR:PATH=${TTK_DIR}
   -DVTK_DIR:PATH=${VTK_DIR}
   -DQt5_DIR:PATH=${Qt5_DIR}
-  -DPYNCPP_DIR:PATH=${PYNCPP_DIR}
   -DLogDemons_DIR:PATH=${LogDemons_DIR}
   -DBoost_INCLUDE_DIR:PATH=${Boost_INCLUDE_DIR}
   )
@@ -108,6 +108,12 @@ if (USE_DTKIMAGING)
     ${cmake_args}
     -DdtkImaging_DIR:PATH=${dtkImaging_DIR}
     )
+endif()
+
+if (USE_Python)
+  list(APPEND cmake_cache_args
+      -DPYNCPP_DIR:PATH=${PYNCPP_DIR}
+      )
 endif()
   
 ## #############################################################################

--- a/superbuild/projects_modules/medInria.cmake
+++ b/superbuild/projects_modules/medInria.cmake
@@ -93,6 +93,7 @@ set(cmake_cache_args
   -DTTK_DIR:PATH=${TTK_DIR}
   -DVTK_DIR:PATH=${VTK_DIR}
   -DQt5_DIR:PATH=${Qt5_DIR}
+  -DPYNCPP_DIR:PATH=${PYNCPP_DIR}
   -DLogDemons_DIR:PATH=${LogDemons_DIR}
   -DBoost_INCLUDE_DIR:PATH=${Boost_INCLUDE_DIR}
   )


### PR DESCRIPTION
The PYNCPP project compiles it's own version of Python (or installs one on Windows), with ._pth configuration file support on all platforms, and provides an API to embed Python in a CPP application.
(This only adds the external project. The runtime initialisation of Python and the packaging aspects are not handled here)