### PR TITLE
[medAbstractData]: add drivers capable of on offscreen rendering in generateThumbnailInGuiThread - master

### DIFF
--- a/src/layers/legacy/medCoreLegacy/data/medAbstractData.cpp
+++ b/src/layers/legacy/medCoreLegacy/data/medAbstractData.cpp
@@ -228,7 +228,8 @@ QImage medAbstractData::generateThumbnailInGuiThread(QSize size)
         offscreenCapable = true;
 #elif defined(Q_OS_LINUX)
     if (gpu.vendor.toLower().contains("nvidia")
-            || gpu.vendor.toLower().contains("intel"))
+            || gpu.vendor.toLower().contains("intel")
+            || gpu.vendor.toLower().contains("mesa/x.org"))
     {
         offscreenCapable = true;
     }


### PR DESCRIPTION
Same as https://github.com/medInria/medInria-public/pull/1051 on master branch.

> On virtual machine using mesa/x.org drivers each time a thumbnail was generated an orphaned widget was seen on the screen.
> To fix this issue the driver is added to the list of drivers capable of on offscreen rendering in generateThumbnailInGuiThread method.
