### PR TITLE
[Four-views] solve crash closing the views --master

### DIFF
--- a/src/layers/legacy/medCoreLegacy/parameters/medViewParameterGroupL.cpp
+++ b/src/layers/legacy/medCoreLegacy/parameters/medViewParameterGroupL.cpp
@@ -47,11 +47,6 @@ medViewParameterGroupL::~medViewParameterGroupL()
 {
     medParameterGroupManagerL::instance()->unregisterGroup(this);
 
-    for(medAbstractView *view : d->impactedViews)
-    {
-        removeImpactedView(view);
-    }
-
     d->pool->clear();
 
     delete d;


### PR DESCRIPTION
Same as https://github.com/medInria/medInria-public/pull/1060

Fix https://github.com/medInria/medInria-public/issues/995

The views are already cleaned at closing through a signal set in `medViewParameterGroupL::addImpactedView`. 
Removing them manually in `~medViewParameterGroupL` leads to trying to remove already removed views, generating a crash.

:m: