### PR TITLE
[Zoom] proper zoom displaying data on xy and not xyz

### DIFF
--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.h
@@ -505,6 +505,8 @@ protected:
 
     virtual void GetWithinBoundsPosition (double* pos1, double* dos2);
 
+    double getImageHalfMaximumSize();
+
 protected:
     /**
      Takes a vtkScalarsToColors pointer


### PR DESCRIPTION
Fix https://github.com/medInria/medInria-public/issues/491

It was a very old bug in medInria from 3.0. The zoom was incorrectly set at opening of data, specially some data as the medInria data test "CT_mouse.mha". 

In this PR, the zoom value is calculated through only x and y values, not z. 

Let me know if you think this new behavior could create any problem elsewhere.

:m: