### PR TITLE
[Tabs] handling of tabs: removal, switch --master

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/medTabbedViewContainers.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/medTabbedViewContainers.cpp
@@ -264,21 +264,23 @@ void medTabbedViewContainers::closeTab(int index)
     {
         this->addContainerInTabUnNamed();
     }
-
-    // Update the remaining tab indexes
-    d->containerSelectedForTabIndex.remove(index);
-    QHash <int, QList<QUuid> > copyHash;
-    for(auto currentTabIndex : d->containerSelectedForTabIndex.keys())
+    else
     {
-        auto previousTab = d->containerSelectedForTabIndex.take(currentTabIndex);
-        copyHash.insert(copyHash.count(), previousTab);
-    }
-    d->containerSelectedForTabIndex.clear();
-    d->containerSelectedForTabIndex = copyHash;
+        // Update the remaining tab indexes
+        d->containerSelectedForTabIndex.remove(index);
+        QHash <int, QList<QUuid> > copyHash;
+        for(auto currentTabIndex : d->containerSelectedForTabIndex.keys())
+        {
+            auto previousTab = d->containerSelectedForTabIndex.take(currentTabIndex);
+            copyHash.insert(copyHash.count(), previousTab);
+        }
+        d->containerSelectedForTabIndex.clear();
+        d->containerSelectedForTabIndex = copyHash;
     
-    // Update the current tab to the last one
-    setCurrentIndex(this->count()-1);
-    emit containersSelectedChanged();
+        // Update the current tab to the last one
+        setCurrentIndex(this->count()-1);
+        emit containersSelectedChanged();
+    }
 }
 
 void medTabbedViewContainers::tabBarDoubleClickedHandler(int index)

--- a/src/layers/legacy/medCoreLegacy/gui/medTabbedViewContainers.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/medTabbedViewContainers.cpp
@@ -60,13 +60,12 @@ medTabbedViewContainers::medTabbedViewContainers(medAbstractWorkspaceLegacy* own
     d->closeShortcut = new QShortcut(this);
     d->closeShortcut->setKey(Qt::ControlModifier + Qt::Key_W);
     
-    // ///////////////////////////////////////////////////////////////////////
-    // Connect for creation and remove tab
+    // Connect for creation, removal and move of tabs
     connect(d->addTabButton, SIGNAL(clicked()),    this, SLOT(addContainerInTabUnNamed()));
     connect(this, SIGNAL(tabCloseRequested(int)),  this, SLOT(closeTab(int)));
     connect(d->closeShortcut, SIGNAL(activated()), this, SLOT(closeCurrentTab()));
+    connect(tabBar(), SIGNAL(tabMoved(int,int)), this, SLOT(movedTabs(int,int)));
 
-    // ///////////////////////////////////////////////////////////////////////
     // Connect group of view handling
     connect(medViewContainerManager::instance(), SIGNAL(containerAboutToBeDestroyed(QUuid)), this, SLOT(removeContainerFromSelection(QUuid)));
     connect(this, SIGNAL(containersSelectedChanged()), this, SLOT(buildTemporaryPool()));
@@ -250,15 +249,36 @@ void medTabbedViewContainers::closeTab(int index)
         poMainSpliter->disconnect(this);
     }
     poTmp->deleteLater();
-
+    
     //Reset tab name if it follows the rule '<Workspace Name>###' is follows 
     for (int i = 0; i < this->count(); ++i)
+    {
         if (this->tabText(i).isEmpty() || this->tabText(i).startsWith(d->owningWorkspace->name(), Qt::CaseSensitive))
+        {
             this->setTabText(i, d->owningWorkspace->name() + " " + QString::number(i + 1));
+        }
+    }
 
     // If medTabbedViewContainers is empty and empty is not allowed, we recreate one tab
     if (d->bKeepLeastOne && (this->count() < 1))
+    {
         this->addContainerInTabUnNamed();
+    }
+
+    // Update the remaining tab indexes
+    d->containerSelectedForTabIndex.remove(index);
+    QHash <int, QList<QUuid> > copyHash;
+    for(auto currentTabIndex : d->containerSelectedForTabIndex.keys())
+    {
+        auto previousTab = d->containerSelectedForTabIndex.take(currentTabIndex);
+        copyHash.insert(copyHash.count(), previousTab);
+    }
+    d->containerSelectedForTabIndex.clear();
+    d->containerSelectedForTabIndex = copyHash;
+    
+    // Update the current tab to the last one
+    setCurrentIndex(this->count()-1);
+    emit containersSelectedChanged();
 }
 
 void medTabbedViewContainers::tabBarDoubleClickedHandler(int index)
@@ -448,4 +468,20 @@ void medTabbedViewContainers::minimizeSplitterContainers(QUuid containerMaximize
     {
         splitter->show();
     }
+}
+
+/**
+ * @brief Launched when a tab from the tabs bar is moved to a new position
+ * 
+ * @param from index tab before
+ * @param to index tab after
+ */
+void medTabbedViewContainers::movedTabs(int from, int to)
+{
+    auto previousFrom = d->containerSelectedForTabIndex.take(from);
+    auto previousTo   = d->containerSelectedForTabIndex.take(to);
+    d->containerSelectedForTabIndex.insert(from, previousTo);
+    d->containerSelectedForTabIndex.insert(to,   previousFrom);
+
+    emit containersSelectedChanged();
 }

--- a/src/layers/legacy/medCoreLegacy/gui/medTabbedViewContainers.h
+++ b/src/layers/legacy/medCoreLegacy/gui/medTabbedViewContainers.h
@@ -58,6 +58,7 @@ public slots:
     medViewContainer* insertNewTab(int index, const QString &name);
     void closeCurrentTab();
     void closeTab(int index);
+    void movedTabs(int from, int to);
 
 private slots :
     void tabBarDoubleClickedHandler(int  index);


### PR DESCRIPTION
Same as https://github.com/medInria/medInria-public/pull/1067 on master branch

Fix https://github.com/medInria/medInria-public/issues/517
Fix https://github.com/medInria/medInria-public/issues/1066

There were problems with the tabs in medInria, leading to users not using them (and they have been locked in most of the workspaces). If you want to test, check the Visualization workspace.

This PR adds handling of tabs when they are switched, or removed.

:m: