### PR TITLE
[Reslice] fix zoom error + code clarity

### DIFF
--- a/src/plugins/legacy/reformat/medResliceViewer.cpp
+++ b/src/plugins/legacy/reformat/medResliceViewer.cpp
@@ -140,7 +140,7 @@ medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medA
     selectedView = 2;
 
     int *imageDims = view3d->GetMedVtkImageInfo()->dimensions;
-    outputSpacing  = view3d->GetMedVtkImageInfo()->spacing;
+    outputSpacingOrSize  = view3d->GetMedVtkImageInfo()->spacing;
 
     viewBody = new QWidget(parent);
 
@@ -382,9 +382,9 @@ void medResliceViewer::saveImage()
     reslicerTop->SetInterpolationModeToLinear();
 
     // Apply resampling in mm
-    if (reformaTlbx->findChild<QComboBox*>("bySpacingOrDimension")->currentText() == "Spacing")
+    if (reformaTlbx->findChild<QComboBox*>("bySpacingOrSize")->currentText() == "Spacing")
     {
-        reslicerTop->SetOutputSpacing(outputSpacing);
+        reslicerTop->SetOutputSpacing(outputSpacingOrSize);
     }
     reslicerTop->Update();
 
@@ -426,44 +426,48 @@ void medResliceViewer::saveImage()
     emit imageReformatedGenerated();
 }
 
-void medResliceViewer::thickSlabChanged(double val)
+void medResliceViewer::askedSpacingOrSizeChange(double val)
 {
     medDoubleParameterL * doubleParam = qobject_cast<medDoubleParameterL*>(QObject::sender());
-
     auto spinBoxSender = doubleParam? doubleParam->getSpinBox() : nullptr;
-
     if (spinBoxSender)
     {
-        double x, y, z;
-        riw[2]->GetResliceCursor()->GetThickness(x,y,z);
+        auto changeFormat = reformaTlbx->findChild<QComboBox*>("bySpacingOrSize")->currentText();
+        auto accessibleName = spinBoxSender->accessibleName();
 
-        if (spinBoxSender->accessibleName()=="SpacingX")
+        if (changeFormat == "Spacing")
         {
-            if (reformaTlbx->findChild<QComboBox*>("bySpacingOrDimension")->currentText() == "Spacing")
+            double x, y, z;
+            riw[2]->GetResliceCursor()->GetThickness(x,y,z);
+
+            // The three windows share the same reslice cursor
+            if (accessibleName == "SpacingOrSizeX")
             {
-                riw[0]->GetResliceCursor()->SetThickness(val,y,z); //the three windows share the same reslice cursor
+                riw[0]->GetResliceCursor()->SetThickness(val,y,z);
             }
-            outputSpacing[0] = val;
+            else if (accessibleName == "SpacingOrSizeY")
+            {
+                riw[0]->GetResliceCursor()->SetThickness(x,val,z);
+            }
+            else if (accessibleName == "SpacingOrSizeZ")
+            {
+                riw[0]->GetResliceCursor()->SetThickness(x,y,val);
+            }
         }
 
-        if (spinBoxSender->accessibleName()=="SpacingY")
+        // For spacing or size changes
+        if (accessibleName == "SpacingOrSizeX")
         {
-            if (reformaTlbx->findChild<QComboBox*>("bySpacingOrDimension")->currentText() == "Spacing")
-            {
-                riw[0]->GetResliceCursor()->SetThickness(x,val,z); //the three windows share the same reslice cursor
-            }
-            outputSpacing[1] = val;
+            outputSpacingOrSize[0] = val;
         }
-
-        if (spinBoxSender->accessibleName()=="SpacingZ")
+        else if (accessibleName == "SpacingOrSizeY")
         {
-            if (reformaTlbx->findChild<QComboBox*>("bySpacingOrDimension")->currentText() == "Spacing")
-            {
-                riw[0]->GetResliceCursor()->SetThickness(x,y,val); //the three windows share the same reslice cursor
-            }
-            outputSpacing[2] = val;
+            outputSpacingOrSize[1] = val;
         }
-        this->render();
+        else if (accessibleName == "SpacingOrSizeZ")
+        {
+            outputSpacingOrSize[2] = val;
+        }
     }
 }
 
@@ -732,7 +736,7 @@ void medResliceViewer::generateOutput(vtkImageReslice* reslicer, QString destTyp
     outputData->setData(filter->GetOutput());
 
     // Apply resampling in pix
-    if (reformaTlbx->findChild<QComboBox*>("bySpacingOrDimension")->currentText() == "Dimension")
+    if (reformaTlbx->findChild<QComboBox*>("bySpacingOrSize")->currentText() == "Dimension")
     {
         applyResamplingPix();
     }
@@ -753,9 +757,9 @@ void medResliceViewer::applyResamplingPix()
 {
     resampleProcess *resamplePr = new resampleProcess();
     resamplePr->setInput(outputData);
-    resamplePr->setParameter(outputSpacing[0], 0);
-    resamplePr->setParameter(outputSpacing[1], 1);
-    resamplePr->setParameter(outputSpacing[2], 2);
+    resamplePr->setParameter(outputSpacingOrSize[0], 0);
+    resamplePr->setParameter(outputSpacingOrSize[1], 1);
+    resamplePr->setParameter(outputSpacingOrSize[2], 2);
     resamplePr->update();
 
     outputData = resamplePr->output();

--- a/src/plugins/legacy/reformat/medResliceViewer.cpp
+++ b/src/plugins/legacy/reformat/medResliceViewer.cpp
@@ -736,7 +736,7 @@ void medResliceViewer::generateOutput(vtkImageReslice* reslicer, QString destTyp
     outputData->setData(filter->GetOutput());
 
     // Apply resampling in pix
-    if (reformaTlbx->findChild<QComboBox*>("bySpacingOrSize")->currentText() == "Dimension")
+    if (reformaTlbx->findChild<QComboBox*>("bySpacingOrSize")->currentText() == "Size")
     {
         applyResamplingPix();
     }

--- a/src/plugins/legacy/reformat/medResliceViewer.h
+++ b/src/plugins/legacy/reformat/medResliceViewer.h
@@ -63,7 +63,7 @@ public slots:
     virtual void render();
 
     void saveImage();
-    void thickSlabChanged(double);
+    void askedSpacingOrSizeChange(double);
     void extentChanged(int);
     bool eventFilter(QObject *object, QEvent *event);
 
@@ -85,7 +85,7 @@ protected:
     QWidget *viewBody;
     QVTKOpenGLWidget *views[4];
     dtkSmartPointer<medAbstractData> inputData;
-    double *outputSpacing;
+    double *outputSpacingOrSize;
     unsigned char selectedView;
     vtkImageView3D *view3d;
     vtkSmartPointer<vtkImageData> vtkViewData;

--- a/src/plugins/legacy/reformat/resliceToolBox.cpp
+++ b/src/plugins/legacy/reformat/resliceToolBox.cpp
@@ -58,7 +58,7 @@ resliceToolBox::resliceToolBox (QWidget *parent) : medAbstractSelectableToolBox 
     d->bySpacingOrSize = new QComboBox(resliceToolBoxBody);
     d->bySpacingOrSize->setObjectName("bySpacingOrSize");
     d->bySpacingOrSize->addItem("Spacing");
-    d->bySpacingOrSize->addItem("Dimension");
+    d->bySpacingOrSize->addItem("Size");
     resampleLayout->addWidget(bySpacingOrSizeLabel);
     resampleLayout->addWidget(d->bySpacingOrSize);
     connect(d->bySpacingOrSize, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(switchSpacingAndDimension(const QString&)));

--- a/src/plugins/legacy/reformat/resliceToolBox.cpp
+++ b/src/plugins/legacy/reformat/resliceToolBox.cpp
@@ -28,9 +28,9 @@ class resliceToolBoxPrivate
 {
 public:
     QPushButton *b_startReslice, *b_stopReslice, *b_saveImage, *b_reset;
-    QComboBox *bySpacingOrDimension;
+    QComboBox *bySpacingOrSize;
     QLabel *helpBegin;
-    medDoubleParameterL *spacingX, *spacingY, *spacingZ;
+    medDoubleParameterL *spacingOrSizeX, *spacingOrSizeY, *spacingOrSizeZ;
     medAbstractLayeredView *currentView;
     medResliceViewer *resliceViewer;
     dtkSmartPointer<medAbstractData> reformatedImage;
@@ -54,14 +54,14 @@ resliceToolBox::resliceToolBox (QWidget *parent) : medAbstractSelectableToolBox 
 
     // User can choose pixel or millimeter resample
     QHBoxLayout * resampleLayout = new QHBoxLayout();
-    QLabel *bySpacingOrDimensionLabel = new QLabel("Select your resample parameter ", resliceToolBoxBody);
-    d->bySpacingOrDimension = new QComboBox(resliceToolBoxBody);
-    d->bySpacingOrDimension->setObjectName("bySpacingOrDimension");
-    d->bySpacingOrDimension->addItem("Spacing");
-    d->bySpacingOrDimension->addItem("Dimension");
-    resampleLayout->addWidget(bySpacingOrDimensionLabel);
-    resampleLayout->addWidget(d->bySpacingOrDimension);
-    connect(d->bySpacingOrDimension, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(switchSpacingAndDimension(const QString&)));
+    QLabel *bySpacingOrSizeLabel = new QLabel("Select your resample parameter ", resliceToolBoxBody);
+    d->bySpacingOrSize = new QComboBox(resliceToolBoxBody);
+    d->bySpacingOrSize->setObjectName("bySpacingOrSize");
+    d->bySpacingOrSize->addItem("Spacing");
+    d->bySpacingOrSize->addItem("Dimension");
+    resampleLayout->addWidget(bySpacingOrSizeLabel);
+    resampleLayout->addWidget(d->bySpacingOrSize);
+    connect(d->bySpacingOrSize, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(switchSpacingAndDimension(const QString&)));
 
     // Spinboxes of resample values
     QWidget *spinBoxes = new QWidget(resliceToolBoxBody);
@@ -69,38 +69,38 @@ resliceToolBox::resliceToolBox (QWidget *parent) : medAbstractSelectableToolBox 
 
     QHBoxLayout *spacingSpinBoxLayoutX = new QHBoxLayout();
     spacingSpinBoxLayoutX->setAlignment(Qt::AlignCenter);
-    d->spacingX = new medDoubleParameterL("X", this);
-    d->spacingX->getSpinBox()->setAccessibleName("SpacingX");
-    d->spacingX->setObjectName("SpacingX");
-    d->spacingX->setRange(0,100);
-    d->spacingX->getSpinBox()->setSuffix(" mm");
-    d->spacingX->setSingleStep(0.1f);
-    spacingSpinBoxLayoutX->addWidget(d->spacingX->getLabel());
-    spacingSpinBoxLayoutX->addWidget(d->spacingX->getSpinBox());
+    d->spacingOrSizeX = new medDoubleParameterL("X", this);
+    d->spacingOrSizeX->getSpinBox()->setAccessibleName("SpacingOrSizeX");
+    d->spacingOrSizeX->setObjectName("SpacingOrSizeX");
+    d->spacingOrSizeX->setRange(0,100);
+    d->spacingOrSizeX->getSpinBox()->setSuffix(" mm");
+    d->spacingOrSizeX->setSingleStep(0.1f);
+    spacingSpinBoxLayoutX->addWidget(d->spacingOrSizeX->getLabel());
+    spacingSpinBoxLayoutX->addWidget(d->spacingOrSizeX->getSpinBox());
     spacingSpinBoxLayout->addLayout(spacingSpinBoxLayoutX);
 
     QHBoxLayout *spacingSpinBoxLayoutY = new QHBoxLayout();
     spacingSpinBoxLayoutY->setAlignment(Qt::AlignCenter);
-    d->spacingY = new medDoubleParameterL("Y", this);
-    d->spacingY->getSpinBox()->setAccessibleName("SpacingY");
-    d->spacingY->setObjectName("SpacingY");
-    d->spacingY->setRange(0,100);
-    d->spacingY->getSpinBox()->setSuffix(" mm");
-    d->spacingY->setSingleStep(0.1f);
-    spacingSpinBoxLayoutY->addWidget(d->spacingY->getLabel());
-    spacingSpinBoxLayoutY->addWidget(d->spacingY->getSpinBox());
+    d->spacingOrSizeY = new medDoubleParameterL("Y", this);
+    d->spacingOrSizeY->getSpinBox()->setAccessibleName("SpacingOrSizeY");
+    d->spacingOrSizeY->setObjectName("SpacingOrSizeY");
+    d->spacingOrSizeY->setRange(0,100);
+    d->spacingOrSizeY->getSpinBox()->setSuffix(" mm");
+    d->spacingOrSizeY->setSingleStep(0.1f);
+    spacingSpinBoxLayoutY->addWidget(d->spacingOrSizeY->getLabel());
+    spacingSpinBoxLayoutY->addWidget(d->spacingOrSizeY->getSpinBox());
     spacingSpinBoxLayout->addLayout(spacingSpinBoxLayoutY);
 
     QHBoxLayout *spacingSpinBoxLayoutZ = new QHBoxLayout();
     spacingSpinBoxLayoutZ->setAlignment(Qt::AlignCenter);
-    d->spacingZ = new medDoubleParameterL("Z", this);
-    d->spacingZ->getSpinBox()->setAccessibleName("SpacingZ");
-    d->spacingZ->setObjectName("SpacingZ");
-    d->spacingZ->setRange(0,100);
-    d->spacingZ->getSpinBox()->setSuffix(" mm");
-    d->spacingZ->setSingleStep(0.1f);
-    spacingSpinBoxLayoutZ->addWidget(d->spacingZ->getLabel());
-    spacingSpinBoxLayoutZ->addWidget(d->spacingZ->getSpinBox());
+    d->spacingOrSizeZ = new medDoubleParameterL("Z", this);
+    d->spacingOrSizeZ->getSpinBox()->setAccessibleName("SpacingOrSizeZ");
+    d->spacingOrSizeZ->setObjectName("SpacingOrSizeZ");
+    d->spacingOrSizeZ->setRange(0,100);
+    d->spacingOrSizeZ->getSpinBox()->setSuffix(" mm");
+    d->spacingOrSizeZ->setSingleStep(0.1f);
+    spacingSpinBoxLayoutZ->addWidget(d->spacingOrSizeZ->getLabel());
+    spacingSpinBoxLayoutZ->addWidget(d->spacingOrSizeZ->getSpinBox());
     spacingSpinBoxLayout->addLayout(spacingSpinBoxLayoutZ);
 
     spinBoxes->setLayout(spacingSpinBoxLayout);
@@ -191,17 +191,22 @@ void resliceToolBox::startReformat()
                                                         getWorkspace()->tabbedViewContainers());
                 d->resliceViewer->setToolBox(this);
                 getWorkspace()->tabbedViewContainers()->setAcceptDrops(false);
-                connect(d->resliceViewer,SIGNAL(imageReformatedGenerated()),this,SLOT(saveReformatedImage()));
                 medViewContainer * container = getWorkspace()->tabbedViewContainers()->insertNewTab(0, "Reslice");
                 getWorkspace()->tabbedViewContainers()->setCurrentIndex(0);
                 container->setDefaultWidget(d->resliceViewer->viewWidget());
-                connect(container, SIGNAL(viewRemoved()),this, SLOT(stopReformat()), Qt::UniqueConnection);
 
-                connect(d->spacingX, SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));
-                connect(d->spacingY, SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));
-                connect(d->spacingZ, SIGNAL(valueChanged(double)), d->resliceViewer, SLOT(thickSlabChanged(double)));
-
-                connect(d->b_saveImage, SIGNAL(clicked()), d->resliceViewer, SLOT(saveImage()));
+                connect(d->resliceViewer,SIGNAL(imageReformatedGenerated()),
+                    this,SLOT(saveReformatedImage()), Qt::UniqueConnection);
+                connect(container, SIGNAL(viewRemoved()),
+                    this, SLOT(stopReformat()), Qt::UniqueConnection);
+                connect(d->spacingOrSizeX, SIGNAL(valueChanged(double)), 
+                    d->resliceViewer, SLOT(askedSpacingOrSizeChange(double)), Qt::UniqueConnection);
+                connect(d->spacingOrSizeY, SIGNAL(valueChanged(double)), 
+                    d->resliceViewer, SLOT(askedSpacingOrSizeChange(double)), Qt::UniqueConnection);
+                connect(d->spacingOrSizeZ, SIGNAL(valueChanged(double)), 
+                    d->resliceViewer, SLOT(askedSpacingOrSizeChange(double)), Qt::UniqueConnection);
+                connect(d->b_saveImage, SIGNAL(clicked()), 
+                    d->resliceViewer, SLOT(saveImage()), Qt::UniqueConnection);
 
                 d->reformatedImage = nullptr;
 
@@ -229,7 +234,7 @@ void resliceToolBox::stopReformat()
 {
     if (getWorkspace())
     {
-        d->bySpacingOrDimension->setCurrentIndex(0); // init resample parameter
+        d->bySpacingOrSize->setCurrentIndex(0); // init resample parameter
         d->helpBegin->show();
         d->reformatOptions->hide();
         d->b_startReslice->show();
@@ -282,19 +287,19 @@ void resliceToolBox::updateView()
 
 void resliceToolBox::displayInfoOnCurrentView()
 {
-    if (d->bySpacingOrDimension->currentIndex() == 0) // Spacing
+    if (d->bySpacingOrSize->currentIndex() == 0) // Spacing
     {
         double *spacing = d->imageInfo->spacing;
-        d->spacingX->setValue(spacing[0]);
-        d->spacingY->setValue(spacing[1]);
-        d->spacingZ->setValue(spacing[2]);
+        d->spacingOrSizeX->setValue(spacing[0]);
+        d->spacingOrSizeY->setValue(spacing[1]);
+        d->spacingOrSizeZ->setValue(spacing[2]);
     }
     else // Dimension
     {
         int *dimension = d->imageInfo->dimensions;
-        d->spacingX->setValue(dimension[0]);
-        d->spacingY->setValue(dimension[1]);
-        d->spacingZ->setValue(dimension[2]);
+        d->spacingOrSizeX->setValue(dimension[0]);
+        d->spacingOrSizeY->setValue(dimension[1]);
+        d->spacingOrSizeZ->setValue(dimension[2]);
     }
 }
 
@@ -319,27 +324,27 @@ void resliceToolBox::switchSpacingAndDimension(const QString & value)
 {
     if (value == "Spacing")
     {
-        d->spacingX->getSpinBox()->setSuffix(" mm");
-        d->spacingX->setRange(0, 100);
-        d->spacingX->setSingleStep(0.1f);
-        d->spacingY->getSpinBox()->setSuffix(" mm");
-        d->spacingY->setRange(0, 100);
-        d->spacingY->setSingleStep(0.1f);
-        d->spacingZ->getSpinBox()->setSuffix(" mm");
-        d->spacingZ->setRange(0, 100);
-        d->spacingZ->setSingleStep(0.1f);
+        d->spacingOrSizeX->getSpinBox()->setSuffix(" mm");
+        d->spacingOrSizeX->setRange(0, 100);
+        d->spacingOrSizeX->setSingleStep(0.1f);
+        d->spacingOrSizeY->getSpinBox()->setSuffix(" mm");
+        d->spacingOrSizeY->setRange(0, 100);
+        d->spacingOrSizeY->setSingleStep(0.1f);
+        d->spacingOrSizeZ->getSpinBox()->setSuffix(" mm");
+        d->spacingOrSizeZ->setRange(0, 100);
+        d->spacingOrSizeZ->setSingleStep(0.1f);
     }
     else // Dimension
     {
-        d->spacingX->getSpinBox()->setSuffix(" px");
-        d->spacingX->setRange(0, 10000);
-        d->spacingX->setSingleStep(10);
-        d->spacingY->getSpinBox()->setSuffix(" px");
-        d->spacingY->setRange(0, 10000);
-        d->spacingY->setSingleStep(10);
-        d->spacingZ->getSpinBox()->setSuffix(" px");
-        d->spacingZ->setRange(0, 10000);
-        d->spacingZ->setSingleStep(10);
+        d->spacingOrSizeX->getSpinBox()->setSuffix(" px");
+        d->spacingOrSizeX->setRange(0, 10000);
+        d->spacingOrSizeX->setSingleStep(10);
+        d->spacingOrSizeY->getSpinBox()->setSuffix(" px");
+        d->spacingOrSizeY->setRange(0, 10000);
+        d->spacingOrSizeY->setSingleStep(10);
+        d->spacingOrSizeZ->getSpinBox()->setSuffix(" px");
+        d->spacingOrSizeZ->setRange(0, 10000);
+        d->spacingOrSizeZ->setSingleStep(10);
     }
     displayInfoOnCurrentView();
 }
@@ -355,16 +360,16 @@ medAbstractData *resliceToolBox::processOutput()
 
 void resliceToolBox::changeButtonValue(QString buttonName, double value)
 {
-    if (buttonName == "SpacingX")
+    if (buttonName == "SpacingOrSizeX")
     {
-        d->spacingX->setValue(value);
+        d->spacingOrSizeX->setValue(value);
     }
-    else if (buttonName == "SpacingY")
+    else if (buttonName == "SpacingOrSizeY")
     {
-        d->spacingY->setValue(value);
+        d->spacingOrSizeY->setValue(value);
     }
-    else if (buttonName == "SpacingZ")
+    else if (buttonName == "SpacingOrSizeZ")
     {
-        d->spacingZ->setValue(value);
+        d->spacingOrSizeZ->setValue(value);
     }
 }


### PR DESCRIPTION
Fix https://github.com/medInria/medInria-public/issues/674

When the user uses the dimension or spacing tool, there is no more a graphic zoom bug on the views.

To find the solution, i needed to clean the code (specially askedSpacingOrSizeChange) to create a clear separation between spacing change and size (previously 'dimension') change, because a lot of the widgets have been wrongly name only with Spacing, instead of both. This is surely due to code history, spacing was coded before.

:m: 