### PR TITLE
[Paint] create mask before trying to paint + hide a button

### DIFF
--- a/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
+++ b/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
@@ -564,6 +564,41 @@ void AlgorithmPaintToolBox::activateStroke()
     addBrushSize_shortcut->setEnabled(true);
     reduceBrushSize_shortcut->setEnabled(true);
 
+    setCurrentView(currentView);
+
+    if (!m_imageData)
+    {
+        this->setData(currentView->layerData(0));
+    }
+    if (!m_imageData)
+    {
+        qWarning() << "Could not set data";
+        return;
+    }
+
+    if(!currentView->contains(m_maskAnnotationData))
+    {
+        m_maskAnnotationData->setMetaData("SeriesDescription", "mask");
+        currentView->addLayer(m_maskAnnotationData);
+        for(medAbstractInteractor* interactor : currentView->layerInteractors(getWorkspace()->getSelectedLayerIndices()[0]))
+        {
+            if (interactor->identifier() == "medAnnotationInteractor")
+            {
+                for(medAbstractParameterL* parameter : interactor->linkableParameters())
+                {
+                    if (parameter->name() == "Opacity")
+                    {
+                        qobject_cast<medDoubleParameterL*>(parameter)->setValue(0.4);
+                    }
+                }
+            }
+        }
+
+        // Update Mouse Interaction ToolBox
+        currentView->setCurrentLayer(0);
+        getWorkspace()->updateMouseInteractionToolBox();
+    }
+
     activateCustomedCursor(); // Add circular cursor for painting
 }
 
@@ -1250,23 +1285,12 @@ AlgorithmPaintToolBox::GenerateMinMaxValuesFromImage ()
 
 void AlgorithmPaintToolBox::updateStroke(ClickAndMoveEventFilter * filter, medAbstractImageView * view)
 {
-    setCurrentView(view);
     if ( !isMask2dOnSlice() )
     {
         return;
     }
 
     const double radius = m_brushSizeSlider->value(); // in image units.
-
-    if ( !m_imageData )
-    {
-        this->setData(view->layerData(0));
-    }
-    if (!m_imageData)
-    {
-        qWarning() << "Could not set data";
-        return;
-    }
 
     QVector3D newPoint = filter->points().back();
 
@@ -1372,29 +1396,6 @@ void AlgorithmPaintToolBox::updateStroke(ClickAndMoveEventFilter * filter, medAb
     m_itkMask->GetPixelContainer()->Modified();
     m_itkMask->SetPipelineMTime(m_itkMask->GetMTime());
 
-    if(!view->contains(m_maskAnnotationData))
-    {
-        m_maskAnnotationData->setMetaData("SeriesDescription", "mask");
-        view->addLayer(m_maskAnnotationData);
-        for(medAbstractInteractor* interactor : view->layerInteractors(getWorkspace()->getSelectedLayerIndices()[0]))
-        {
-            if (interactor->identifier() == "medAnnotationInteractor")
-            {
-                for(medAbstractParameterL* parameter : interactor->linkableParameters())
-                {
-                    if (parameter->name() == "Opacity")
-                    {
-                        qobject_cast<medDoubleParameterL*>(parameter)->setValue(0.4);
-                    }
-                }
-            }
-        }
-
-        // Update Mouse Interaction ToolBox
-        view->setCurrentLayer(0);
-        getWorkspace()->updateMouseInteractionToolBox();
-    }
-
     if ( slicingParameter )
     {
         slicingParameter->getSlider()->addTick(currentIdSlice);
@@ -1482,6 +1483,7 @@ void AlgorithmPaintToolBox::updateButtons()
         m_labelColorWidget->hide();
         m_strokeLabelSpinBox->hide();
         m_colorLabel->hide();
+        m_removeSeedButton->hide();
         return;
     }
     else
@@ -1498,6 +1500,7 @@ void AlgorithmPaintToolBox::updateButtons()
             m_wand3DRealTime->show();
             m_wandInfo->show();
             m_brushSizeSlider->hide();
+            m_removeSeedButton->show();
         }
         else if ( m_paintState == PaintState::Stroke )
         {
@@ -1506,6 +1509,7 @@ void AlgorithmPaintToolBox::updateButtons()
             m_wandUpperThresholdSlider->hide();
             m_wand3DCheckbox->hide();
             m_wand3DRealTime->hide();
+            m_removeSeedButton->hide();
         }
     }
 }


### PR DESCRIPTION
Same as https://github.com/medInria/medInria-public/pull/1073

Fix https://github.com/medInria/medInria-public/issues/726

Create the mask data in Paint when the user clicks on "Paint/Erase", not at the first click on the image. The creation of the mask is too slow, and the drawing not smooth at the beginning.

Also, switching from Magic Wand to Paint/Erase was not hiding the removeSeed button.

:m: