### PR TITLE
[Ubuntu22.04] switch to ITK5.2.1

### DIFF
--- a/src/layers/legacy/medImageIO/itkMultiThreadedImageIOBase.cpp
+++ b/src/layers/legacy/medImageIO/itkMultiThreadedImageIOBase.cpp
@@ -18,6 +18,7 @@
 
 namespace itk
 {
+  itkEventMacroDefinition(SliceReadEvent, itk::AnyEvent);
 
   MultiThreadedImageIOBase::MultiThreadedImageIOBase() :
     m_NumberOfThreads(0)

--- a/src/layers/legacy/medImageIO/itkMultiThreadedImageIOBase.h
+++ b/src/layers/legacy/medImageIO/itkMultiThreadedImageIOBase.h
@@ -78,5 +78,5 @@ namespace itk
     
   };
   
-  itkEventMacro (SliceReadEvent, AnyEvent)
+  itkEventMacroDeclaration(SliceReadEvent, itk::AnyEvent);
 } // end of namespace

--- a/src/plugins/legacy/itkDataDiffusionGradientList/CMakeLists.txt
+++ b/src/plugins/legacy/itkDataDiffusionGradientList/CMakeLists.txt
@@ -35,9 +35,7 @@ include_directories(${dtk_INCLUDE_DIRS})
 find_package(ITK REQUIRED COMPONENTS ITKCommon)
 include(${ITK_USE_FILE})
 
-find_package(TTK REQUIRED)
-include(${TTK_USE_FILE})
-
+find_package(TTK REQUIRED COMPONENTS ITKTensor)
 
 ## #############################################################################
 ## List Sources
@@ -91,7 +89,7 @@ target_link_libraries(${TARGET_NAME}
   ${QT_LIBRARIES}
   dtkLog
   dtkCore
-  ITKTensor
+  TTK::ITKTensor
   medCore
   medLog
   )

--- a/src/plugins/legacy/itkDataTensorImage/CMakeLists.txt
+++ b/src/plugins/legacy/itkDataTensorImage/CMakeLists.txt
@@ -38,9 +38,7 @@ include(${ITK_USE_FILE})
 find_package(VTK REQUIRED  COMPONENTS vtkCommonCore vtkCommonExecutionModel vtkRenderingCore vtkImagingCore vtkInteractionStyle vtkInteractionWidgets)
 include(${VTK_USE_FILE})
 
-find_package(TTK REQUIRED)
-include(${TTK_USE_FILE})
-
+find_package(TTK REQUIRED COMPONENTS ITKTensor ttkAlgorithms)
 
 ## #############################################################################
 ## List Sources
@@ -118,7 +116,8 @@ target_link_libraries(${TARGET_NAME}
   ITKIOPNG
   ITKIOStimulate
   ITKIOVTK
-  ITKTensor
+  TTK::ITKTensor
+  TTK::ttkAlgorithms
   medCore
   medLog
   medVtkInria

--- a/src/plugins/legacy/itkFilters/CMakeLists.txt
+++ b/src/plugins/legacy/itkFilters/CMakeLists.txt
@@ -34,7 +34,7 @@ find_package(dtk REQUIRED)
 include_directories(${dtk_INCLUDE_DIRS})
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon ITKThresholding ITKConnectedComponents
-                                     ITKSmoothing ITKBinaryMathematicalMorphology)
+                                     ITKSmoothing ITKBinaryMathematicalMorphology ITKMathematicalMorphology)
 include(${ITK_USE_FILE})
 
 ## #############################################################################
@@ -73,8 +73,10 @@ add_library(${TARGET_NAME} SHARED
 target_link_libraries(${TARGET_NAME}
   ${QT_LIBRARIES}
   dtkCore
-  dtkLog  
-  ${ITK_LIBRARIES}
+  dtkLog
+  ITKCommon
+  ITKSmoothing
+  ITKMathematicalMorphology
   medCore
   medUtilities
   )

--- a/src/plugins/legacy/medCompositeDataSets/CMakeLists.txt
+++ b/src/plugins/legacy/medCompositeDataSets/CMakeLists.txt
@@ -35,8 +35,7 @@ find_package(dtk REQUIRED)
 include(${dtk_USE_FILE})
 include(dtkPlugin)
 
-find_package(TTK REQUIRED)
-include(${TTK_USE_FILE})
+find_package(TTK REQUIRED COMPONENTS ITKTensor)
 
 ## #################################################################
 ## Input
@@ -71,7 +70,7 @@ target_link_libraries(${PROJECT_NAME}
   dtkCore 
   dtkLog
   dtkZip
-  ITKTensor
+  TTK::ITKTensor
   ITKCommon  
   medCore
   medGui

--- a/src/plugins/legacy/medVtkFibersData/CMakeLists.txt
+++ b/src/plugins/legacy/medVtkFibersData/CMakeLists.txt
@@ -38,8 +38,7 @@ include(${VTK_USE_FILE})
 find_package(ITK REQUIRED COMPONENTS ITKCommon ITKVtkGlue)
 include(${ITK_USE_FILE})
 
-find_package(TTK REQUIRED)
-include(${TTK_USE_FILE})
+find_package(TTK REQUIRED COMPONENTS ttkAlgorithms ITKTensor)
 
 ## #############################################################################
 ## List Sources
@@ -106,7 +105,8 @@ target_link_libraries(${TARGET_NAME}
   medCore
   medLog
   medVtkInria
-  ttkAlgorithms
+  TTK::ttkAlgorithms
+  TTK::ITKTensor
   ITKCommon
   ITKVtkGlue
   )

--- a/src/plugins/process/itkDWIBrainMaskCalculatorProcess/CMakeLists.txt
+++ b/src/plugins/process/itkDWIBrainMaskCalculatorProcess/CMakeLists.txt
@@ -19,8 +19,7 @@ set(TARGET_NAME itkDWIBrainMaskCalculatorProcessPlugin)
 ## Resolve dependencies
 ## #############################################################################
 
-find_package(TTK REQUIRED)
-include(${TTK_USE_FILE})
+find_package(TTK REQUIRED COMPONENTS Registration ttkAlgorithms)
 
 find_package(ITK REQUIRED COMPONENTS ITKCommon ITKImageStatistics ITKImageIntensity ITKSmoothing ITKThresholding ITKMathematicalMorphology ITKBinaryMathematicalMorphology ITKLabelVoting)
 include(${ITK_USE_FILE})
@@ -63,6 +62,8 @@ target_link_libraries(${TARGET_NAME}
   ITKCommon
   ITKStatistics
   ITKSmoothing
+  TTK::Registration
+  TTK::ttkAlgorithms
   Qt5::Core
   dtkCore
   dtkCoreSupport

--- a/src/plugins/process/morphomath_operation/CMakeLists.txt
+++ b/src/plugins/process/morphomath_operation/CMakeLists.txt
@@ -61,6 +61,7 @@ target_include_directories(${TARGET_NAME}
 
 target_link_libraries(${TARGET_NAME}
   ITKCommon
+  ITKMathematicalMorphology
   Qt5::Core
   dtkCore
   dtkLog

--- a/src/plugins/process/ttkTensorEstimationProcess/CMakeLists.txt
+++ b/src/plugins/process/ttkTensorEstimationProcess/CMakeLists.txt
@@ -7,8 +7,7 @@ set(TARGET_NAME ttkTensorEstimationProcessPlugin)
 find_package(ITK REQUIRED COMPONENTS ITKCommon ITKFiniteDifference)
 include(${ITK_USE_FILE})
 
-find_package(TTK REQUIRED)
-include(${TTK_USE_FILE})
+find_package(TTK REQUIRED COMPONENTS ITKTensor ttkAlgorithms)
 
 ## #############################################################################
 ## List Sources
@@ -50,7 +49,8 @@ target_link_libraries(${TARGET_NAME}
   dtkCore
   dtkCoreSupport
   dtkLog
-  ITKTensor
+  TTK::ITKTensor
+  TTK::ttkAlgorithms
   medCoreLegacy
   medCore
   medWidgets

--- a/src/plugins/process/ttkTensorScalarMapsProcess/CMakeLists.txt
+++ b/src/plugins/process/ttkTensorScalarMapsProcess/CMakeLists.txt
@@ -4,8 +4,7 @@ set(TARGET_NAME ttkTensorScalarMapsProcessPlugin)
 ## Resolve dependencies
 ## #############################################################################
 
-find_package(TTK REQUIRED)
-include(${TTK_USE_FILE})
+find_package(TTK REQUIRED COMPONENTS ITKTensor ttkAlgorithms)
 
 find_package(VTK REQUIRED COMPONENTS vtkRenderingCore)
 include(${VTK_USE_FILE})
@@ -53,7 +52,8 @@ target_link_libraries(${TARGET_NAME}
   dtkCore
   dtkCoreSupport
   dtkLog
-  ITKTensor
+  TTK::ITKTensor
+  TTK::ttkAlgorithms
   medCore
   medCoreLegacy
   medVtkInria

--- a/src/plugins/process/ttkTensorTractographyProcess/CMakeLists.txt
+++ b/src/plugins/process/ttkTensorTractographyProcess/CMakeLists.txt
@@ -32,8 +32,8 @@ include(${VTK_USE_FILE})
 find_package(ITK REQUIRED ITKCommon ITKTransform ITKImageFunction)
 include(${ITK_USE_FILE})
 
-find_package(TTK REQUIRED)
-include(${TTK_USE_FILE})
+find_package(TTK REQUIRED COMPONENTS ITKTensor ttkAlgorithms)
+
 ## #############################################################################
 ## List Sources
 ## #############################################################################
@@ -74,7 +74,8 @@ target_link_libraries(${TARGET_NAME}
   dtkCore
   dtkCoreSupport
   dtkLog
-  ITKTensor
+  TTK::ITKTensor
+  TTK::ttkAlgorithms
   ITKIOTransformBase
   medCore
   medCoreLegacy

--- a/superbuild/patches/VTK.patch
+++ b/superbuild/patches/VTK.patch
@@ -1,15 +1,34 @@
-From 1b7b962d0efbb009384f0ed7c6f6669250a0542a Mon Sep 17 00:00:00 2001
-From: "mathilde.merle" <mathilde.merle@ihu-liryc.fr>
-Date: Wed, 7 Oct 2020 09:43:48 +0200
+From b71eca16d3996ae2304497c2f4a167f96d204b00 Mon Sep 17 00:00:00 2001
+From: Mathilde Merle <mathilde.merle@ihu-liryc.fr>
+Date: Fri, 19 Apr 2024 13:29:27 +0200
 Subject: [PATCH] VTK
 
 ---
+ CMake/VTKGenerateExportHeader.cmake       | 6 +++++-
  IO/Movie/module.cmake                     | 1 +
  IO/Movie/vtkOggTheoraWriter.cxx           | 4 +++-
  Rendering/Qt/vtkQtLabelRenderStrategy.cxx | 1 +
  Rendering/Qt/vtkQtStringToImage.cxx       | 1 +
- 4 files changed, 6 insertions(+), 1 deletion(-)
+ 5 files changed, 11 insertions(+), 2 deletions(-)
 
+diff --git a/CMake/VTKGenerateExportHeader.cmake b/CMake/VTKGenerateExportHeader.cmake
+index 9a7a76386e..f71969ae54 100644
+--- a/CMake/VTKGenerateExportHeader.cmake
++++ b/CMake/VTKGenerateExportHeader.cmake
+@@ -174,8 +174,12 @@ macro(_vtk_test_compiler_hidden_visibility)
+     execute_process(COMMAND ${CMAKE_C_COMPILER} --version
+       OUTPUT_VARIABLE _gcc_version_info
+       ERROR_VARIABLE _gcc_version_info)
+-    string(REGEX MATCH "[3-9]\\.[0-9]\\.[0-9]*"
++    string(REGEX MATCH "[1-9][0-9]\\.[0-9]\\.[0-9]*"
+       _gcc_version "${_gcc_version_info}")
++    if(NOT _gcc_version)
++      string(REGEX MATCH "[3-9]\\.[0-9]\\.[0-9]*"
++        _gcc_version "${_gcc_version_info}")
++    endif()
+     # gcc on mac just reports: "gcc (GCC) 3.3 20030304 ..." without the
+     # patch level, handle this here:
+     if(NOT _gcc_version)
 diff --git a/IO/Movie/module.cmake b/IO/Movie/module.cmake
 index fd6d096384..071b4a20a2 100644
 --- a/IO/Movie/module.cmake
@@ -68,5 +87,5 @@ index 549ffbe874..a7c726e4f9 100644
  #include <QTextDocument>
  #include <QTextStream>
 -- 
-2.14.3 (Apple Git-98)
+2.34.1
 

--- a/superbuild/projects_modules/DCMTK.cmake
+++ b/superbuild/projects_modules/DCMTK.cmake
@@ -39,7 +39,7 @@ if (NOT USE_SYSTEM_${ep})
 ## Set up versioning control
 ## #############################################################################
 
-set(git_url git://git.dcmtk.org/dcmtk.git)
+set(git_url ${GITHUB_PREFIX}DCMTK/dcmtk.git)
 set(git_tag DCMTK-3.6.2)
 
 

--- a/superbuild/projects_modules/ITK.cmake
+++ b/superbuild/projects_modules/ITK.cmake
@@ -39,7 +39,7 @@ if (NOT USE_SYSTEM_${ep})
 ## #############################################################################
 
 set(git_url ${GITHUB_PREFIX}InsightSoftwareConsortium/ITK.git)
-set(git_tag v5.1.1)
+set(git_tag v5.2.1)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project

--- a/superbuild/projects_modules/TTK.cmake
+++ b/superbuild/projects_modules/TTK.cmake
@@ -103,7 +103,8 @@ ExternalProject_Add(${ep}
 ## #############################################################################
 
 ExternalProject_Get_Property(${ep} binary_dir)
-set(${ep}_DIR ${binary_dir} PARENT_SCOPE)
+set(${ep}_ROOT ${binary_dir}  PARENT_SCOPE)
+set(${ep}_DIR  ${binary_dir}/lib/cmake/TTK PARENT_SCOPE)
   
 endif() #NOT USE_SYSTEM_ep
 

--- a/superbuild/projects_modules/TTK.cmake
+++ b/superbuild/projects_modules/TTK.cmake
@@ -41,7 +41,7 @@ if (NOT USE_SYSTEM_${ep})
 ## #############################################################################
 
 set(git_url ${GITHUB_PREFIX}medInria/TTK.git)
-set(git_tag ITK5.1.1)
+set(git_tag ITK5.2.1)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project


### PR DESCRIPTION
Compilation of medInria 4 done on a fresh install of Ubuntu 22.04.

I needed to switch to ITK5.2.1 instead of ITK5.1.1. ITK5.1.1 was not compatible with gcc11.3 (native on Ubuntu22 whereas it's gcc9.4 on Ubuntu 20).

I created also this PR: https://github.com/medInria/TTK/pull/4 on TTK. In addition to the merge of this PR on TTK, a `ITK5.2.1` branch or tag should be created to be used in medInria.

The prerequisites for medInria 4 are:
```bash
sudo apt install git g++ cmake cmake-curses-gui libboost-all-dev libxt-dev
sudo apt install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools  qttools5-dev qtdeclarative5-dev libqt5x11extras5-dev libqt5svg5-dev
```

This PR should be tested on Windows, Fedora, macOS, so i let this PR in draft for now (especially since the TTK tag should be created before using this PR).

:m: