### PR TITLE
Set cmake minimum version to 19 for medInria project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.19)
 
 if(POLICY CMP0020)
   cmake_policy(SET CMP0020 NEW)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.19)
 
 if(NOT DEFINED ${medInria_VERSION})
     set(medInria_VERSION 3.3.0)


### PR DESCRIPTION
The minimum required cmake version is still set at 3.3 on medInria 3. This means that for any cmake policy introduced after 3.3 the default behaviour of the policy will be chosen unless it is manually set. This is causing issues with the python embedding code.