### PR TITLE
[DCM] do not corrupt exported/imported dcm with odd axis

### DIFF
--- a/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
+++ b/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
@@ -673,7 +673,7 @@ void DCMTKImageIO::DetermineOrientation()
 double DCMTKImageIO::GetPositionOnStackingAxisForImage (int index)
 {
     // Get maximum absolute value, which is the closest to an axis
-    auto result = std::max_element(m_Direction[2].begin(), m_Direction[2].end(), [](int a, int b)
+    auto result = std::max_element(m_Direction[2].begin(), m_Direction[2].end(), [](double a, double b)
     {
         return std::abs(a) < std::abs(b);
     });

--- a/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
+++ b/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
@@ -672,43 +672,15 @@ void DCMTKImageIO::DetermineOrientation()
 
 double DCMTKImageIO::GetPositionOnStackingAxisForImage (int index)
 {
-    // Getting the unit vector of the closest axis
-    // so we know which part of the image position to use
-    vnl_vector<double> closestAxis (3);
-    closestAxis[0] = round(m_Direction[2][0]);
-    closestAxis[1] = round(m_Direction[2][1]);
-    closestAxis[2] = round(m_Direction[2][2]);
-
-    std::string s_position = this->GetMetaDataValueString("(0020,0032)", index);
-    std::istringstream is_stream( s_position.c_str() );
-
-    double pos = 0.0;
-    bool foundAxis=false;
-
-    for (int i=0; i<3; i++)
+    // Get maximum absolute value, which is the closest to an axis
+    auto result = std::max_element(m_Direction[2].begin(), m_Direction[2].end(), [](int a, int b)
     {
-        if (!(is_stream >> pos) )
-        {
-            itkWarningMacro ( << "Cannot convert string to double: " << s_position.c_str() << std::endl );
-        }
-        else
-        {
-            if (fabs(closestAxis[i]) == 1)
-            {
-                foundAxis = true;
-                break;
-            }
-        }
-    }
+        return std::abs(a) < std::abs(b);
+    });
 
-    if (!foundAxis)
-    {
-        itkWarningMacro ( <<"Could not identify position on stacking axis, returning zero." << std::endl );
-    }
-
-    return pos;
+    // Index of the value in the vector
+    return std::distance(m_Direction[2].begin(), result);
 }
-
 
 double DCMTKImageIO::GetSliceLocation(std::string imagePosition)
 {

--- a/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
+++ b/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
@@ -670,7 +670,6 @@ void DCMTKImageIO::DetermineOrientation()
     }
 }
 
-
 double DCMTKImageIO::GetPositionOnStackingAxisForImage (int index)
 {
     // Getting the unit vector of the closest axis
@@ -679,15 +678,6 @@ double DCMTKImageIO::GetPositionOnStackingAxisForImage (int index)
     closestAxis[0] = round(m_Direction[2][0]);
     closestAxis[1] = round(m_Direction[2][1]);
     closestAxis[2] = round(m_Direction[2][2]);
-    if (fabs(closestAxis[0] + closestAxis[1] + closestAxis[2]) != 1)
-    {
-        itkExceptionMacro (
-                    << "Ambiguous slice stack direction: "
-                    <<m_Direction[2][0]<<" "
-                    <<m_Direction[2][1]<<" "
-                    <<m_Direction[2][2]
-                );
-    }
 
     std::string s_position = this->GetMetaDataValueString("(0020,0032)", index);
     std::istringstream is_stream( s_position.c_str() );

--- a/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
+++ b/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
@@ -679,7 +679,20 @@ double DCMTKImageIO::GetPositionOnStackingAxisForImage (int index)
     });
 
     // Index of the value in the vector
-    return std::distance(m_Direction[2].begin(), result);
+    auto principalAxisIndex = std::distance(m_Direction[2].begin(), result);
+
+    return GetPositionFromPrincipalAxisIndex(index, principalAxisIndex);
+}
+
+double DCMTKImageIO::GetPositionFromPrincipalAxisIndex(int index, int principalAxisIndex)
+{
+    std::string s_position = this->GetMetaDataValueString("(0020,0032)", index);
+
+    // Convert string metadata to vector of double
+    std::stringstream lineStream(s_position);
+    std::vector<double> positionVector(std::istream_iterator<double>(lineStream), {});
+
+    return positionVector[principalAxisIndex];
 }
 
 double DCMTKImageIO::GetSliceLocation(std::string imagePosition)

--- a/src/layers/legacy/medImageIO/itkDCMTKImageIO.h
+++ b/src/layers/legacy/medImageIO/itkDCMTKImageIO.h
@@ -21,6 +21,7 @@
 
 #include <medImageIOExport.h>
 
+#include <iterator>
 #include <map>
 #include <vector>
 #include <set>
@@ -188,7 +189,8 @@ protected:
     void DetermineOrigin();
     void DetermineOrientation();
 
-    double GetPositionOnStackingAxisForImage (int);
+    double GetPositionOnStackingAxisForImage(int);
+    double GetPositionFromPrincipalAxisIndex(int, int);
     double GetSliceLocation(std::string);
 
     void ReadHeader( const std::string& name, const int& fileIndex, const int& fileCount );


### PR DESCRIPTION
Exporting and importing DICOM from medInria3.4 i found a bug with some of my files with these kinds of error messages "DEBUG - ven. déc. 16 14:39:11 2022 - "itk::ERROR: DCMTKImageIO(0x7fcd340207f0): Ambiguous slice stack direction: -0.663234 0.582022 0.470501""

After some researches, it is linked to https://github.com/medInria/medInria-public/pull/1003

The solution is to continue the `GetPositionOnStackingAxisForImage` method, even if the axis is not what we may ask.

:m: