### PR TITLE
[macOS] enable shortcuts

### DIFF
--- a/src/app/medInria/main.cpp
+++ b/src/app/medInria/main.cpp
@@ -29,6 +29,10 @@
 #include <medSettingsManager.h>
 #include <medStorage.h>
 
+#ifdef Q_WS_MAC
+extern void qt_set_sequence_auto_mnemonic(bool b);
+#endif
+
 void forceShow(medMainWindow& mainwindow )
 {
     //Idea and code taken from the OpenCOR project, Thanks Allan for the code!
@@ -68,6 +72,13 @@ void forceShow(medMainWindow& mainwindow )
 
 int main(int argc,char* argv[])
 {
+    // As described in QShortcut documentation, on macOS, shortcuts are disabled by default. 
+    // To enable them we need to set qt_set_sequence_auto_mnemonic.
+    // On Linux & Windows the classic shortcut key is ALT. 
+#ifdef Q_WS_MAC
+    qt_set_sequence_auto_mnemonic(true);
+#endif
+
     // Setup openGL surface compatible with QVTKOpenGLNativeWidget required by medVtkView.
     // We could have used "SurfaceFormat::setDefaultFormat(QVTKOpenGLNativeWidget::defaultFormat())"
     // directly, but in order to avoid a link to VTK here, here is a copy of


### PR DESCRIPTION
From an issue on https://github.com/Inria-Asclepios/medInria-public/issues/169

On macOS the shortcuts in Qt applications are disabled by default: https://doc.qt.io/qt-6/qshortcut.html#details

This PR adds the methods which enable shortcuts.

I put the PR in draft since it needs to be tested. It can be tested with the Exit pop-up.

:m: