### PR TITLE
[Writer] list in ascended order + priorities

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medDataManager.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDataManager.cpp
@@ -483,6 +483,8 @@ void medDataManager::setWriterPriorities()
     QList<QString> writers = medAbstractDataFactory::instance()->writers();
     QMap<int, QString> writerPriorites;
 
+    writers.sort();
+
     // set vtkDataMeshWriter as a top priority writer
     if(writers.contains("vtkDataMeshWriter"))
     {


### PR DESCRIPTION
When a user wants to export a data (right click -> Export, in database), the itk and vtk data are set as high priority, but the remaining of the list is random. This is a GUI problem for user, because it takes time to find the correct writer in the list if it's random.

This PR adds a `sort` method to the list of writers, before the high priority set to ITK and VTK writers.

:m: