### PR TITLE
[CMake] minimum version at 3.19

### DIFF
--- a/src/app/medPluginGenerator/template/cmake
+++ b/src/app/medPluginGenerator/template/cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
 
 project(%1Plugin)
 

--- a/src/app/medPluginGenerator/template/cmake
+++ b/src/app/medPluginGenerator/template/cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
-
 project(%1Plugin)
 
 ## #############################################################################

--- a/src/app/medPluginGenerator/template/cmake
+++ b/src/app/medPluginGenerator/template/cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.19)
 
 project(%1Plugin)
 

--- a/src/app/medPluginGenerator/template/filtering/cmake
+++ b/src/app/medPluginGenerator/template/filtering/cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
 
 project(%1Plugin)
 

--- a/src/app/medPluginGenerator/template/filtering/cmake
+++ b/src/app/medPluginGenerator/template/filtering/cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
-
 project(%1Plugin)
 
 ## #############################################################################

--- a/src/app/medPluginGenerator/template/filtering/cmake
+++ b/src/app/medPluginGenerator/template/filtering/cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.19)
 
 project(%1Plugin)
 

--- a/src/app/medPluginGenerator/template/registration/cmake
+++ b/src/app/medPluginGenerator/template/registration/cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
 
 project(%1Plugin)
 

--- a/src/app/medPluginGenerator/template/registration/cmake
+++ b/src/app/medPluginGenerator/template/registration/cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
-
 project(%1Plugin)
 
 ## #################################################################

--- a/src/app/medPluginGenerator/template/registration/cmake
+++ b/src/app/medPluginGenerator/template/registration/cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.19)
 
 project(%1Plugin)
 

--- a/src/plugins/legacy/itkINRDataImageReader/CMakeLists.txt
+++ b/src/plugins/legacy/itkINRDataImageReader/CMakeLists.txt
@@ -13,8 +13,6 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
-
 set(TARGET_NAME itkINRDataImageReaderPlugin)
 
 ## #################################################################

--- a/src/plugins/legacy/itkINRDataImageReader/CMakeLists.txt
+++ b/src/plugins/legacy/itkINRDataImageReader/CMakeLists.txt
@@ -13,7 +13,7 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.19)
 
 set(TARGET_NAME itkINRDataImageReaderPlugin)
 

--- a/src/plugins/legacy/itkINRDataImageReader/CMakeLists.txt
+++ b/src/plugins/legacy/itkINRDataImageReader/CMakeLists.txt
@@ -13,7 +13,7 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
 
 set(TARGET_NAME itkINRDataImageReaderPlugin)
 

--- a/src/plugins/legacy/itkINRDataImageWriter/CMakeLists.txt
+++ b/src/plugins/legacy/itkINRDataImageWriter/CMakeLists.txt
@@ -13,7 +13,7 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
 
 set(TARGET_NAME itkINRDataImageWriterPlugin)
 

--- a/src/plugins/legacy/itkINRDataImageWriter/CMakeLists.txt
+++ b/src/plugins/legacy/itkINRDataImageWriter/CMakeLists.txt
@@ -13,7 +13,7 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.19)
 
 set(TARGET_NAME itkINRDataImageWriterPlugin)
 

--- a/src/plugins/legacy/itkINRDataImageWriter/CMakeLists.txt
+++ b/src/plugins/legacy/itkINRDataImageWriter/CMakeLists.txt
@@ -13,8 +13,6 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
-
 set(TARGET_NAME itkINRDataImageWriterPlugin)
 
 ## #################################################################

--- a/src/plugins/legacy/medCompositeDataSets/CMakeLists.txt
+++ b/src/plugins/legacy/medCompositeDataSets/CMakeLists.txt
@@ -11,7 +11,7 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.19)
 
 project(medCompositeDataSetsPlugin)
 

--- a/src/plugins/legacy/medCompositeDataSets/CMakeLists.txt
+++ b/src/plugins/legacy/medCompositeDataSets/CMakeLists.txt
@@ -11,7 +11,7 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
 
 project(medCompositeDataSetsPlugin)
 

--- a/src/plugins/legacy/medCompositeDataSets/CMakeLists.txt
+++ b/src/plugins/legacy/medCompositeDataSets/CMakeLists.txt
@@ -11,8 +11,6 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
-
 project(medCompositeDataSetsPlugin)
 
 ## #################################################################

--- a/src/plugins/legacy/undoRedoRegistration/CMakeLists.txt
+++ b/src/plugins/legacy/undoRedoRegistration/CMakeLists.txt
@@ -13,7 +13,7 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
 
 set(TARGET_NAME undoRedoRegistrationPlugin)
 

--- a/src/plugins/legacy/undoRedoRegistration/CMakeLists.txt
+++ b/src/plugins/legacy/undoRedoRegistration/CMakeLists.txt
@@ -13,7 +13,7 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.19)
 
 set(TARGET_NAME undoRedoRegistrationPlugin)
 

--- a/src/plugins/legacy/undoRedoRegistration/CMakeLists.txt
+++ b/src/plugins/legacy/undoRedoRegistration/CMakeLists.txt
@@ -13,8 +13,6 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
-
 set(TARGET_NAME undoRedoRegistrationPlugin)
 
 ## #############################################################################


### PR DESCRIPTION
In order to easily maintain the cmake minimal versions, only the superbuild CMake and the src one set the minimal version (3.19 for now).

:m: