### PR TITLE
[DCM] no corrupt exported/imported dcm with odd axis --master

### DIFF
--- a/src/layers/legacy/medImageIO/itkDCMTKImageIO.h
+++ b/src/layers/legacy/medImageIO/itkDCMTKImageIO.h
@@ -21,11 +21,11 @@
 
 #include <medImageIOExport.h>
 
+#include <iterator>
 #include <map>
 #include <vector>
 #include <set>
 #include <functional>
-
 
 class DcmElement;
 
@@ -185,7 +185,8 @@ protected:
     void DetermineOrigin();
     void DetermineOrientation();
 
-    double GetPositionOnStackingAxisForImage (int);
+    double GetPositionOnStackingAxisForImage(int);
+    double GetPositionFromPrincipalAxisIndex(int, int);
     double GetSliceLocation(std::string);
 
     void ReadHeader( const std::string& name, const int& fileIndex, const int& fileCount );


### PR DESCRIPTION
Same as https://github.com/medInria/medInria-public/pull/1083 on master branch.

Exporting and importing DICOM from medInria3.4 i found a bug with some of my files with these kinds of error messages "DEBUG - ven. déc. 16 14:39:11 2022 - "itk::ERROR: DCMTKImageIO(0x7fcd340207f0): Ambiguous slice stack direction: -0.663234 0.582022 0.470501""

After some researches, it is linked to https://github.com/medInria/medInria-public/pull/1003

The solution is to continue the `GetPositionOnStackingAxisForImage` method, even if the axis is not what we may ask.

:m: