### PR TITLE
[Launcher] unix - not needed path

### DIFF
--- a/packaging/unix/Launchers.cmake
+++ b/packaging/unix/Launchers.cmake
@@ -54,7 +54,7 @@ else()
 endif()
 
 set(MEDINRIA_PLUGINS_DIRS "\${MEDINRIA_DIR}/plugins:\${MEDINRIA_DIR}/bin/plugins:\${MEDINRIA_USER_PLUGINS_DIRS}")
-set(MEDINRIA_PLUGINS_LEGACY_DIRS "\${MEDINRIA_DIR}/plugins_legacy:\${MEDINRIA_DIR}/bin/plugins_legacy:\${MEDINRIA_USER_PLUGINS_DIRS_LEGACY}")
+set(MEDINRIA_PLUGINS_LEGACY_DIRS "\${MEDINRIA_DIR}/bin/plugins_legacy:\${MEDINRIA_USER_PLUGINS_DIRS_LEGACY}")
 
 configure_file(${CURRENT_SRC_DIR}/medInria.sh.in ${CURRENT_BIN_DIR}/medInria_launcher.sh @ONLY)
 install(PROGRAMS ${CURRENT_BIN_DIR}/medInria_launcher.sh


### PR DESCRIPTION
On Unix (Fedora - Ubuntu - macOS), a path in the launcher was not needed and created log error on Fedora and Ubuntu.

:m: