### PR TITLE
[MemoryLeak] medVtkView::buildThumbnail

### DIFF
--- a/src/layers/legacy/medCoreLegacy/data/medAbstractData.cpp
+++ b/src/layers/legacy/medCoreLegacy/data/medAbstractData.cpp
@@ -31,8 +31,6 @@ class medAbstractDataPrivate
 public:
     medDataIndex index;
     QList< dtkSmartPointer<medAttachedData> > attachedData;
-
-    QImage thumbnail;
 };
 
 medAbstractData::medAbstractData( medAbstractData *parent )
@@ -212,62 +210,7 @@ QImage medAbstractData::generateThumbnail(QSize size)
 
 QImage medAbstractData::generateThumbnailInGuiThread(QSize size)
 {
-    // Hack: some drivers crash on offscreen rendering, so we detect which one
-    // we're currently using, and if it is one of the crashy ones, render to a
-    // proper window instead, that we try to hide behind the main one.
-
-    bool offscreenCapable = false;
-    med::GPUInfo gpu = med::gpuModel();
-
-#if defined(Q_OS_MAC)
-    // all drivers work so far
-    offscreenCapable = true;
-#elif defined(Q_OS_WIN32)
-    // doesn't work on Intel drivers
-    if ( ! gpu.vendor.toLower().contains("intel"))
-        offscreenCapable = true;
-#elif defined(Q_OS_LINUX)
-    if (gpu.vendor.toLower().contains("nvidia")
-            || gpu.vendor.toLower().contains("intel")
-            || gpu.vendor.toLower().contains("mesa/x.org"))
-    {
-        offscreenCapable = true;
-    }
-#endif
-
     dtkSmartPointer<medAbstractImageView> view = medViewFactory::instance()->createView<medAbstractImageView>("medVtkView");
-
-    if(offscreenCapable)
-    {
-        view->setOffscreenRendering(true);
-    }
-    else
-    {
-        // We need to get a handle to the main window, so we can A) find its position, and B) ensure it is drawn over the temporary window
-        const QVariant property = QApplication::instance()->property("MainWindow");
-        QObject* qObject = property.value<QObject*>();
-
-        if (qObject)
-        {
-            QMainWindow* aMainWindow = dynamic_cast<QMainWindow*>(qObject);
-            QWidget * viewWidget = view->viewWidget();
-
-            // Show our view in a separate, temporary window
-            viewWidget->show();
-            // position the temporary window behind the main application
-            viewWidget->move(aMainWindow->geometry().x(), aMainWindow->geometry().y());
-            // and raise the main window above the temporary
-            aMainWindow->raise();
-
-            // We need to wait for the window manager to finish animating before we can continue.
-#ifdef Q_OS_LINUX
-            Q_UNUSED(QTest::qWaitForWindowExposed(viewWidget));
-#endif
-        }
-    }
-
     view->addLayer(this);
-
-    // We're rendering here, to the temporary window, and will then use the resulting image
     return view->generateThumbnail(size);
 }

--- a/src/layers/legacy/medCoreLegacy/parameters/medParameterPoolManagerL.cpp
+++ b/src/layers/legacy/medCoreLegacy/parameters/medParameterPoolManagerL.cpp
@@ -37,6 +37,18 @@ medParameterPoolManagerL::medParameterPoolManagerL(void) : d(new medParameterPoo
 {
 }
 
+medParameterPoolManagerL::~medParameterPoolManagerL()
+{
+    for (auto it = d->pools.begin(); it != d->pools.end(); ++it)
+    {
+        delete it.value();
+    }
+    d->pools.clear();
+
+    delete d;
+    d = nullptr;
+}
+
 void medParameterPoolManagerL::removePool(QString poolId)
 {
     medParameterPoolL *poolToRemove = d->pools.value(poolId);

--- a/src/layers/legacy/medCoreLegacy/parameters/medParameterPoolManagerL.h
+++ b/src/layers/legacy/medCoreLegacy/parameters/medParameterPoolManagerL.h
@@ -42,6 +42,7 @@ public slots:
 
 protected:
     medParameterPoolManagerL();
+    ~medParameterPoolManagerL();
 
     static medParameterPoolManagerL *s_instance;
 

--- a/src/layers/legacy/medCoreLegacy/parameters/medTimeLineParameterL.cpp
+++ b/src/layers/legacy/medCoreLegacy/parameters/medTimeLineParameterL.cpp
@@ -66,6 +66,11 @@ public:
 
         if(numberOfFramesLabel)
             delete numberOfFramesLabel;
+
+        if (extensionShiftParameter)
+        {
+            delete extensionShiftParameter;
+        }
     }
 };
 
@@ -148,6 +153,7 @@ medTimeLineParameterL::medTimeLineParameterL(QString name, QObject *parent):
 medTimeLineParameterL::~medTimeLineParameterL()
 {
     delete d;
+    d = nullptr;
 }
 
 void medTimeLineParameterL::clear()

--- a/src/layers/legacy/medCoreLegacy/parameters/medTimeLineParameterL.cpp
+++ b/src/layers/legacy/medCoreLegacy/parameters/medTimeLineParameterL.cpp
@@ -66,11 +66,6 @@ public:
 
         if(numberOfFramesLabel)
             delete numberOfFramesLabel;
-
-        if (extensionShiftParameter)
-        {
-            delete extensionShiftParameter;
-        }
     }
 };
 
@@ -153,7 +148,6 @@ medTimeLineParameterL::medTimeLineParameterL(QString name, QObject *parent):
 medTimeLineParameterL::~medTimeLineParameterL()
 {
     delete d;
-    d = nullptr;
 }
 
 void medTimeLineParameterL::clear()

--- a/src/plugins/legacy/medVtkView/medVtkView.cpp
+++ b/src/plugins/legacy/medVtkView/medVtkView.cpp
@@ -465,29 +465,11 @@ QImage medVtkView::buildThumbnail(const QSize &size)
     this->blockSignals(true);
     int w(size.width()), h(size.height());
 
-    // will cause crashes if any calls to renWin->Render() happened before this line
-    d->mainWindow->resize(w,h);
-    d->mainWindow->show();
-    d->renWin->SetSize(w,h);
-    render();
-
-#ifdef Q_OS_LINUX
-    // X11 likes to animate window creation, which means by the time we grab the
-    // widget, it might not be fully ready yet, in which case we get artefacts.
-    // Only necessary if rendering to an actual screen window.
-    if(d->renWin->GetOffScreenRendering() == 0)
-    {
-        Q_UNUSED(QTest::qWaitForWindowExposed(d->viewWidget));
-    }
-#endif
-
     QImage thumbnail = d->viewWidget->grabFramebuffer();
+    thumbnail = thumbnail.scaledToHeight(h, Qt::SmoothTransformation);
+    thumbnail = thumbnail.copy((thumbnail.width()-w)/2, 0, w, h);
 
-    d->mainWindow->hide();
     this->blockSignals(false);
-
-    thumbnail = thumbnail.copy(0, thumbnail.height() - h, w, h);
-
     return thumbnail;
 }
 

--- a/src/plugins/legacy/medVtkView/medVtkView.cpp
+++ b/src/plugins/legacy/medVtkView/medVtkView.cpp
@@ -194,6 +194,7 @@ medVtkView::~medVtkView()
         d->renWin->SetOffScreenRendering(0);
     d->renWin->Delete();
     delete d->viewWidget;
+    delete d->mainWindow;
 
     delete d;
 }


### PR DESCRIPTION
Fix a memory leak building the thumbnail importing a data. This PR removes the need to resize a pop-up to get a thumbnail with the right size. Instead, we resize a QImage.

Tested on Ubuntu and macOS.
 
-> memory leak fixed, no more po-up importing a data, and a quicker import.

:m:

