### PR TITLE
[ITK] switch to v5.3rc04

### DIFF
--- a/src/layers/legacy/medImageIO/itkMultiThreadedImageIOBase.cpp
+++ b/src/layers/legacy/medImageIO/itkMultiThreadedImageIOBase.cpp
@@ -18,6 +18,7 @@
 
 namespace itk
 {
+  itkEventMacroDefinition(SliceReadEvent, itk::AnyEvent);
 
   MultiThreadedImageIOBase::MultiThreadedImageIOBase() :
     m_NumberOfThreads(0)

--- a/src/layers/legacy/medImageIO/itkMultiThreadedImageIOBase.h
+++ b/src/layers/legacy/medImageIO/itkMultiThreadedImageIOBase.h
@@ -78,5 +78,5 @@ namespace itk
     
   };
   
-  itkEventMacro (SliceReadEvent, AnyEvent)
+  itkEventMacroDeclaration(SliceReadEvent, itk::AnyEvent);
 } // end of namespace

--- a/superbuild/projects_modules/ITK.cmake
+++ b/superbuild/projects_modules/ITK.cmake
@@ -39,7 +39,7 @@ if (NOT USE_SYSTEM_${ep})
 ## #############################################################################
 
 set(git_url ${GITHUB_PREFIX}InsightSoftwareConsortium/ITK.git)
-set(git_tag v5.2.1)
+set(git_tag v5.3rc04)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project

--- a/superbuild/projects_modules/ITK.cmake
+++ b/superbuild/projects_modules/ITK.cmake
@@ -39,7 +39,7 @@ if (NOT USE_SYSTEM_${ep})
 ## #############################################################################
 
 set(git_url ${GITHUB_PREFIX}InsightSoftwareConsortium/ITK.git)
-set(git_tag v5.1.1)
+set(git_tag v5.2.1)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project

--- a/superbuild/projects_modules/LogDemons.cmake
+++ b/superbuild/projects_modules/LogDemons.cmake
@@ -40,7 +40,7 @@ if (NOT USE_SYSTEM_${ep})
 ## #############################################################################
 
 set(git_url ${GITHUB_PREFIX}Inria-Asclepios/LCC-LogDemons.git)
-set(git_tag ITK5.1.1)
+set(git_tag ITK5.3rc04)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project

--- a/superbuild/projects_modules/RPI.cmake
+++ b/superbuild/projects_modules/RPI.cmake
@@ -41,7 +41,8 @@ if (NOT USE_SYSTEM_${ep})
 ## #############################################################################
 
 set(git_url ${GITHUB_PREFIX}Inria-Asclepios/RPI.git)
-set(git_tag ITK5.1.1)
+set(git_tag ITK5.3rc04)
+
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project
 ## #############################################################################

--- a/superbuild/projects_modules/TTK.cmake
+++ b/superbuild/projects_modules/TTK.cmake
@@ -41,7 +41,7 @@ if (NOT USE_SYSTEM_${ep})
 ## #############################################################################
 
 set(git_url ${GITHUB_PREFIX}medInria/TTK.git)
-set(git_tag ITK5.2.1)
+set(git_tag ITK5.3rc04)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project

--- a/superbuild/projects_modules/TTK.cmake
+++ b/superbuild/projects_modules/TTK.cmake
@@ -41,7 +41,7 @@ if (NOT USE_SYSTEM_${ep})
 ## #############################################################################
 
 set(git_url ${GITHUB_PREFIX}medInria/TTK.git)
-set(git_tag ITK5.1.1)
+set(git_tag ITK5.2.1)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project


### PR DESCRIPTION
Switch ITK from ITK5.1.1 to ITK5.3rc04.

Based on https://github.com/medInria/medInria-public/pull/1078 for ITK 5.2.1.

Commits:
 * https://github.com/medInria/medInria-public/commit/e2550e995f417653f4fde19fc3b0192bebcf20c5
 * https://github.com/medInria/medInria-public/pull/1132/commits/acde3c71a7bc5d438328ddd22f7112e9c9b53fa6

NEEDS:
 *  Adapt RPI https://github.com/Inria-Asclepios/RPI/pull/24
 *  Adapt TTK https://github.com/medInria/TTK/pull/5
 *  Adapt LCCLogDemons https://github.com/Inria-Asclepios/LCC-LogDemons/pull/8

:m: