### PR TITLE
[VTK] avoid med crash with wrong version of vtk files

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
@@ -256,7 +256,10 @@ medAbstractData *medDatabaseReader::readFile( const QStringList& filenames )
             }
             else
             {
-                dataReader->read(filenames);
+                if (dataReader->read(filenames) == false)
+                {
+                    break;
+                }
             }
             dataReader->enableDeferredDeletion ( false );
             medData = dynamic_cast<medAbstractData*>(dataReader->data());


### PR DESCRIPTION
Opening a VTK from VTK 9 for instance in medInria 3.4 crashs the application. 
This PR avoids the crash.

:m: