### PR TITLE
[mha] put back mha with mhd by default exporting data

### DIFF
--- a/src/plugins/legacy/itkDataImage/writers/itkMetaDataImageWriter.cpp
+++ b/src/plugins/legacy/itkDataImage/writers/itkMetaDataImageWriter.cpp
@@ -51,7 +51,7 @@ QStringList itkMetaDataImageWriter::handled() const {
 
 QStringList itkMetaDataImageWriter::supportedFileExtensions() const
 {
-    return QStringList() << ".mhd";
+    return QStringList() << ".mha" << ".mhd";
 }
 
 bool itkMetaDataImageWriter::registered() {


### PR DESCRIPTION
On master branch, "mha" was missing from supported file extensions to export data. Only mhd. This PR adds back mha, as on medInria3.4.x branch.

:m:
