### PR TITLE
Clean declaration and usage of the dataSetAttributes structure:

### DIFF
--- a/src/layers/medCore/source/medDataHub.cpp
+++ b/src/layers/medCore/source/medDataHub.cpp
@@ -632,9 +632,9 @@ void medDataHub::removeSource(QString const & pi_sourceId)
     emit sourceRemoved(pi_sourceId);
 }
 
-medDataHub::datasetAttributes medDataHub::getMetaData(medDataIndex const & index)
+medSourceHandler::datasetAttributes medDataHub::getMetaData(medDataIndex const & index)
 {
-    datasetAttributes metaRes;
+    medSourceHandler::datasetAttributes metaRes;
 
     auto *pModel = getModel(index.sourceId());
     if (pModel)
@@ -643,7 +643,7 @@ medDataHub::datasetAttributes medDataHub::getMetaData(medDataIndex const & index
         auto x = pModel->getMendatoriesMetaData(modelIndex);
         for (auto & valueKey : x.values.keys())
         {
-            metaRes.values[valueKey] = x.values[valueKey].toString();
+            metaRes.values[valueKey] = x.values[valueKey];
         }
         for (auto & tagKey : x.tags.keys())
         {
@@ -651,6 +651,33 @@ medDataHub::datasetAttributes medDataHub::getMetaData(medDataIndex const & index
         }
     }
 
+    return metaRes;
+}
+
+medSourceHandler::datasetAttributes medDataHub::getOptionalMetaData(medDataIndex const & index)
+{
+    medSourceHandler::datasetAttributes metaRes;
+
+    auto *pModel = getModel(index.sourceId());
+    if (pModel)
+    {
+        auto modelIndex = pModel->toIndex(index);
+        medSourceHandler::datasetAttributes attributes;
+        bool ok = pModel->getAdditionnalMetaData(modelIndex, attributes);
+        if (ok)
+        {
+            if (attributes.values.isEmpty())
+            {
+                m_sourcesHandler->optionalAttributes(index.sourceId(),index.level()-1, index.dataId(), metaRes);
+                pModel->setAdditionnalMetaData(modelIndex, metaRes);
+            }
+            else
+            {
+                metaRes = attributes;
+            }
+        }
+
+    }   
     return metaRes;
 }
 

--- a/src/layers/medCore/source/medDataHub.h
+++ b/src/layers/medCore/source/medDataHub.h
@@ -26,6 +26,7 @@
 #include <medAsyncRequest.h>
 #include <medDefaultWritingPolicy.h>
 #include <medVirtualRepresentation.h>
+#include <medSourceHandler.h>
 
 #include <dtkCoreSupport/dtkSmartPointer.h>
 
@@ -38,7 +39,6 @@ class MEDCORE_EXPORT medDataHub : public QObject
     Q_OBJECT
 
 public:
-    class datasetAttributes;
 
 
     static medDataHub* instance(QObject *parent = nullptr);
@@ -47,7 +47,8 @@ public:
     QString getDataName(medDataIndex const & index);
 
     medAbstractData * getData(medDataIndex const & index);
-    datasetAttributes getMetaData(medDataIndex const & index);
+    medSourceHandler::datasetAttributes getMetaData(medDataIndex const & index);
+    medSourceHandler::datasetAttributes getOptionalMetaData(medDataIndex const & index);
 
 
     bool saveData(medAbstractData *pi_pData, QString const &pi_baseName, QStringList &pio_uri);
@@ -136,14 +137,6 @@ private:
     QMap<medDataIndex, dtkSmartPointer<medAbstractData> > m_IndexToData;
     static medDataHub * s_instance;
 
-public:
-    struct datasetAttributes
-    {
-        QMap<QString, QString> values; // <keyName, value>
-        QMap<QString, QString> tags;   // <keyName, tag value>
-    };
-
-    using  listAttributes = QList<datasetAttributes>;
 };
 
 QString fileSysPathToIndex(const QString &path );

--- a/src/layers/medCore/source/operating/medSourceHandler.cpp
+++ b/src/layers/medCore/source/operating/medSourceHandler.cpp
@@ -91,7 +91,7 @@ bool medSourceHandler::sourceGlobalInfo(QString const & pi_sourceInstanceId, boo
     return bRes;
 }
 
-bool medSourceHandler::attributesForBuildTree(QString const & pi_sourceInstanceId, unsigned int pi_uiLevel, QString const & key, levelAttributes & po_entries)
+bool medSourceHandler::attributesForBuildTree(QString const & pi_sourceInstanceId, unsigned int pi_uiLevel, QString const & key, listAttributes & po_entries)
 {
     bool bRes = true;
 
@@ -106,16 +106,25 @@ bool medSourceHandler::attributesForBuildTree(QString const & pi_sourceInstanceI
             datasetAttributes entryTmp;
             for (auto &minimalEntry : listOfMinimalEntries)
             {
-                entryTmp[keys[0]] = minimalEntry.key;
-                entryTmp[keys[1]] = minimalEntry.name;
+                entryTmp.values[keys[0]] = minimalEntry.key;
+                entryTmp.values[keys[1]] = minimalEntry.name;
 
-                entryTmp[keys[2]] = minimalEntry.description;
+                entryTmp.values[keys[2]] = minimalEntry.description;
                 po_entries.push_back(entryTmp);
             }
         }
         else
         {
-            po_entries = pSource->getMandatoryAttributes(pi_uiLevel, key);
+            auto listOfMandatoriesAttr = pSource->getMandatoryAttributes(pi_uiLevel, key);
+            datasetAttributes entryTmp;
+            for (auto &mandatoryAttribute : listOfMandatoriesAttr)
+            {
+                for (auto key: mandatoryAttribute.keys())
+                {
+                    entryTmp.values[key] = mandatoryAttribute[key];
+                }
+                po_entries.push_back(entryTmp);
+            }
         }
     }
     else
@@ -125,14 +134,23 @@ bool medSourceHandler::attributesForBuildTree(QString const & pi_sourceInstanceI
     return bRes;
 }
 
-bool medSourceHandler::mandatoriesAttributes(QString const & pi_sourceInstanceId, unsigned int pi_uiLevel, QString const & parentKey, levelAttributes & po_entries)
+bool medSourceHandler::mandatoriesAttributes(QString const & pi_sourceInstanceId, unsigned int pi_uiLevel, QString const & parentKey, listAttributes & po_entries)
 {
     bool bRes = true;
 
     medAbstractSource* pSource = m_sourceIdToInstanceMap.value(pi_sourceInstanceId);
     if (pSource)
     {
-        po_entries = pSource->getMandatoryAttributes(pi_uiLevel, parentKey);
+        auto listOfMandatoriesAttr = pSource->getMandatoryAttributes(pi_uiLevel, parentKey);
+        datasetAttributes entryTmp;
+        for (auto &mandatoryAttribute : listOfMandatoriesAttr)
+        {
+            for (auto key: mandatoryAttribute.keys())
+            {
+                entryTmp.values[key] = mandatoryAttribute[key];
+                po_entries.push_back(entryTmp);
+            }
+        }
     }
     else
     {
@@ -300,22 +318,21 @@ bool medSourceHandler::connect(QString const & pi_sourceInstanceId, bool pi_bOnl
     return bRes;
 }
 
-bool medSourceHandler::optionalAttributes(QString const & pi_sourceInstanceId, unsigned int pi_uiLevel, QString const & key, datasetAttributes & po_attributes, datasetAttributes & po_tags)
+bool medSourceHandler::optionalAttributes(QString const & pi_sourceInstanceId, unsigned int pi_uiLevel, QString const & key, datasetAttributes & po_attributes)
 {
     bool bRes = false;
 
     medAbstractSource* pSource = m_sourceIdToInstanceMap.value(pi_sourceInstanceId);
     if (pSource)
-    {
+    {   
         medAbstractSource::datasetAttributes tmp;
         bRes = pSource->getAdditionalAttributes(pi_uiLevel, key, tmp);
         if (bRes)
         {
-            po_attributes = tmp.values;
-            po_tags = tmp.tags;
+            po_attributes.values = tmp.values;
+            po_attributes.tags = tmp.tags;
         }
     }
-
     return bRes;
 }
 

--- a/src/layers/medCore/source/operating/medSourceHandler.h
+++ b/src/layers/medCore/source/operating/medSourceHandler.h
@@ -33,9 +33,14 @@ class MEDCORE_EXPORT medSourceHandler : public QObject
     Q_OBJECT
 
 public:
-    using datasetAttributes = QMap<QString, QString>;
-    using levelAttributes = QList<datasetAttributes>;
+    struct datasetAttributes
+    {
+        QMap<QString, QString> values; // <keyName, value>
+        QMap<QString, QString> tags;   // <keyName, tag value>
+    };
+    using  listAttributes = QList<datasetAttributes>;
 
+ 
     static medSourceHandler* instance(QObject *parent = nullptr);
 	~medSourceHandler();
 
@@ -43,9 +48,9 @@ public:
     // Members functions to interrogate sources
     bool sourceGlobalInfo       (QString const & pi_sourceInstanceId, bool &po_bOnline, bool & po_bLocal, bool &po_bWritable, bool &po_bCache);
     bool mandatoryAttributesKeys(QString const & pi_sourceInstanceId, unsigned int pi_uiLevel, QStringList & po_attributes);
-    bool attributesForBuildTree (QString const & pi_sourceInstanceId, unsigned int pi_uiLevel, QString const & key, levelAttributes & po_entries);
-    bool mandatoriesAttributes  (QString const & pi_sourceInstanceId, unsigned int pi_uiLevel, QString const & parentKey, levelAttributes & po_entries);
-    bool optionalAttributes     (QString const & pi_sourceInstanceId, unsigned int pi_uiLevel, QString const & key, datasetAttributes & po_attributes, datasetAttributes & po_tags);
+    bool attributesForBuildTree (QString const & pi_sourceInstanceId, unsigned int pi_uiLevel, QString const & key, listAttributes & po_entries);
+    bool mandatoriesAttributes  (QString const & pi_sourceInstanceId, unsigned int pi_uiLevel, QString const & parentKey, listAttributes & po_entries);
+    bool optionalAttributes     (QString const & pi_sourceInstanceId, unsigned int pi_uiLevel, QString const & key, datasetAttributes & po_attributes);
     bool getDirectData          (QString const & pi_sourceInstanceId, unsigned int pi_uiLevel, QString const & key, QVariant & po_data);
     bool addDirectData          (QString const & pi_sourceInstanceId, unsigned int pi_uiLevel, QString const & parentKey, QVariant const & pi_data, medAbstractSource::levelMinimalEntries & pio_minimalEntries);
     bool createFolder           (QString const & pi_sourceInstanceId, unsigned int pi_uiLevel, QString const & parentKey, medAbstractSource::levelMinimalEntries & pio_minimalEntries, medAbstractSource::datasetAttributes const &pi_attributes);

--- a/src/layers/medCore/source/operating/medSourceModel.h
+++ b/src/layers/medCore/source/operating/medSourceModel.h
@@ -17,6 +17,7 @@
 #include <medDataIndex.h>
 
 #include <medSourceModelItem.h>
+#include <medSourceHandler.h>
 
 #include <medCoreExport.h>
 
@@ -46,7 +47,6 @@ class MEDCORE_EXPORT medSourceModel : public QAbstractItemModel
 
 public:
 
-    struct datasetAttributes;
 
     medSourceModel(medDataHub *parent, QString const & sourceIntanceId);
     virtual ~medSourceModel();
@@ -95,9 +95,7 @@ public:
     QString getSourceIntanceId();
     void setOnline(bool pi_bOnline);
 
-    datasetAttributes getMendatoriesMetaData(QModelIndex const & index);
-    QList<QMap<int, QString>> getAdditionnalMetaData(QModelIndex const & index);
-    bool setAdditionnalMetaData(QModelIndex const & index, QList<QMap<int, QString>> &additionnalMetaData);
+    medSourceHandler::datasetAttributes getMendatoriesMetaData(QModelIndex const & index);
 
     bool currentOnlineStatus();
 
@@ -114,10 +112,8 @@ public:
     QString     keyForPath(QStringList rootUri, QString folder);
     bool        getChildrenNames(QStringList uri, QStringList &names);
 
-    bool        setAdditionnalMetaData2(QModelIndex const & index, datasetAttributes const &attributes);
-    bool        setAdditionnalMetaData2(QModelIndex const & index, QString const & key, QVariant const & value, QString const & tag = QString() );
-    bool        additionnalMetaData2(QModelIndex const & index, datasetAttributes & attributes);
-    bool        additionnalMetaData2(QModelIndex const & index, QString const & key, QVariant & value, QString & tag);
+    bool        setAdditionnalMetaData(QModelIndex const & index, medSourceHandler::datasetAttributes const &attributes);
+    bool        getAdditionnalMetaData(QModelIndex const & index, medSourceHandler::datasetAttributes & attributes);
 
     bool addEntry(QString pi_key, QString pi_name, QString pi_description, unsigned int pi_uiLevel, QString pi_parentKey);
     bool substituteTmpKey(QStringList uri, QString pi_key);
@@ -144,11 +140,11 @@ private:
     void populateLevel(QModelIndex const &index);
 
 
-    bool itemStillExist(QList<QMap<QString, QString>> &entries, medSourceModelItem * pItem);
-    void computeRowRangesToRemove(medSourceModelItem * pItem, QList<QMap<QString, QString>> &entries, QVector<QPair<int, int>> &rangeToRemove);
+    bool itemStillExist(medSourceHandler::listAttributes &entries, medSourceModelItem * pItem);
+    void computeRowRangesToRemove(medSourceModelItem * pItem, medSourceHandler::listAttributes &entries, QVector<QPair<int, int>> &rangeToRemove);
     void removeRowRanges(QVector<QPair<int, int>> &rangeToRemove, const QModelIndex & index);
 
-    void computeRowRangesToAdd(medSourceModelItem * pItem, QList<QMap<QString, QString>> &entries, QMap<int, QList<QMap<QString, QString>>> &entriesToAdd);
+    void computeRowRangesToAdd(medSourceModelItem * pItem, medSourceHandler::listAttributes &entries, QMap<int, QList<QMap<QString, QString>>> &entriesToAdd);
     void addRowRanges(QMap<int, QList<QMap<QString, QString>>> &entriesToAdd, const QModelIndex & index);
 
     bool currentLevelFetchable(medSourceModelItem * pItemCurrent);
@@ -164,12 +160,4 @@ signals:
 private:
     medDataModelElementPrivate* d;
 
-public:
-    struct datasetAttributes
-    {
-        QMap<QString, QVariant> values; // <keyName, value>
-        QMap<QString, QString> tags;
-        bool dropMimeData(const QMimeData * data, Qt::DropAction action, int row, int column, const QModelIndex & parent);
-        // <keyName, tag value>    
-    };
 };

--- a/src/layers/medCore/source/operating/medSourceModelItem.cpp
+++ b/src/layers/medCore/source/operating/medSourceModelItem.cpp
@@ -174,7 +174,7 @@ void medSourceModelItem::setParent(medSourceModelItem * parent)
     model->registerItem(this);
 }
 
-void medSourceModelItem::setMetaData(QMap<QString, QVariant> const & attributes, QMap<QString, QString> const & tags)
+void medSourceModelItem::setMetaData(QMap<QString, QString> const & attributes, QMap<QString, QString> const & tags)
 {
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
     for (auto const & key : attributes.keys())
@@ -186,8 +186,13 @@ void medSourceModelItem::setMetaData(QMap<QString, QVariant> const & attributes,
         itemMetaTag[key] = tags[key];
     }
 #else
-        itemMeta.insert(attributes);
-        itemMetaTag.insert(tags);
+    QVariantMap map;
+    for (auto key: attributes.keys())
+    {
+        map[key] = QVariant(attributes[key]);
+    }
+    itemMeta.insert(map);
+    itemMetaTag.insert(tags);
 #endif
 }
 

--- a/src/layers/medCore/source/operating/medSourceModelItem.h
+++ b/src/layers/medCore/source/operating/medSourceModelItem.h
@@ -40,7 +40,7 @@ public:
     medSourceModelItem* hasChildItemWithIID(QString iid);
     void setParent(medSourceModelItem *parent);
     QVariant data  (int column,  int role = Qt::DisplayRole) const;
-    void setMetaData(QMap<QString, QVariant> const &attributes, QMap<QString, QString> const &tags);
+    void setMetaData(QMap<QString, QString> const &attributes, QMap<QString, QString> const &tags);
 
 
     inline void setData(QVariant value, int column = 0, int role = Qt::DisplayRole) { itemData[column][role] = value; }

--- a/src/layers/medWidgets/source/widgets/medDataInfoWidget.cpp
+++ b/src/layers/medWidgets/source/widgets/medDataInfoWidget.cpp
@@ -1,11 +1,13 @@
 #include "medDataInfoWidget.h"
 
+#include <QPushButton>
 #include <QTreeWidget>
 #include <QVBoxLayout>
 #include <QLabel>
 #include <QHeaderView>
+#include <QDebug>
 
-medDataInfoWidget::medDataInfoWidget(QMap<QString, QString> dataAttributes, QWidget *parent) : QDialog(parent)
+medDataInfoWidget::medDataInfoWidget(QMap<QString, QString> dataAttributes, QMultiMap<QString, QString> optionalAttributes, QWidget *parent) : QDialog(parent)
 {
     QVBoxLayout *dialogLayout = new QVBoxLayout;
     setLayout(dialogLayout);
@@ -20,6 +22,20 @@ medDataInfoWidget::medDataInfoWidget(QMap<QString, QString> dataAttributes, QWid
     QLabel* explanation = new QLabel(tr("You can copy/paste a selected item with regular shortcuts from your OS.\n"));
     dialogLayout->addWidget(explanation);
 
+    QPushButton *plusButton = new QPushButton(QIcon(":/pixmaps/plus.png"), "");
+    plusButton->setToolTip("Show Optional Meta Data");
+    plusButton->setMaximumSize(QSize(20,20));
+    plusButton->setCheckable(true);
+    plusButton->setFlat(true);
+    plusButton->setDisabled(optionalAttributes.isEmpty());
+
+
+    QHBoxLayout *hLayout = new QHBoxLayout;
+    hLayout->addWidget(explanation);
+    hLayout->addWidget(plusButton, 0, Qt::AlignRight);
+
+    dialogLayout->addLayout(hLayout);
+
     auto tree = new QTreeWidget();
     tree->setFrameStyle(QFrame::NoFrame);
     tree->setAttribute(Qt::WA_MacShowFocusRect, false);
@@ -32,16 +48,59 @@ medDataInfoWidget::medDataInfoWidget(QMap<QString, QString> dataAttributes, QWid
     tree->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     tree->setColumnCount(2);
 
+    auto optionalTree = new QTreeWidget();
+    optionalTree->setFrameStyle(QFrame::NoFrame);
+    optionalTree->setAttribute(Qt::WA_MacShowFocusRect, false);
+    optionalTree->setUniformRowHeights(true);
+    optionalTree->setAlternatingRowColors(true);
+    optionalTree->setAnimated(true);
+    optionalTree->setSelectionBehavior(QAbstractItemView::SelectRows);
+    optionalTree->setSelectionMode(QAbstractItemView::SingleSelection);
+    optionalTree->header()->setStretchLastSection(true);
+    optionalTree->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    
+    bool isTag = false;
+    for (auto key : optionalAttributes.uniqueKeys())
+    {
+        QList<QString> valuesAndTags = optionalAttributes.values(key);
+        if (valuesAndTags.size()>1)
+        {
+            isTag = true;
+            break;
+        }
+    }
+    if (isTag)
+    {
+        optionalTree->setColumnCount(3);
+    }    
+    else{
+        optionalTree->setColumnCount(2);
+    }
+    optionalTree->setHidden(true);
+
+    connect(plusButton, &QPushButton::toggled, [=](bool checked) {
+        if (checked)
+        {
+            plusButton->setIcon(QIcon(":/pixmaps/minus.png"));
+            optionalTree->setHidden(false);
+        }
+        else
+        {
+            plusButton->setIcon(QIcon(":/pixmaps/plus.png"));
+            optionalTree->setHidden(true);
+        }
+    });
+
     // Create tree columns
     QStringList treeColumns;
     treeColumns << tr("Key") << tr("Value");
     tree->setHeaderLabels(treeColumns);
     tree->setColumnWidth(0, 200);
     tree->setColumnWidth(1, 400);
-    dialogLayout->addWidget(tree);
-    this->resize(700, 700);
 
-    // Populate the tree
+    dialogLayout->addWidget(tree);
+
+    // Populate the mandatory metadata tree
     for (QString key : dataAttributes.keys())
     {
         // Only keep non empty metadata values
@@ -53,9 +112,40 @@ medDataInfoWidget::medDataInfoWidget(QMap<QString, QString> dataAttributes, QWid
             tree->addTopLevelItem(item);
         }
     }
-
     tree->setSortingEnabled(true);
     tree->sortByColumn(0, Qt::AscendingOrder);
+
+    QStringList optionalColumns;
+    optionalColumns << tr("Key") << tr("Value");
+    optionalTree->setColumnWidth(0, 200);
+    optionalTree->setColumnWidth(1, 300);
+    if (isTag)
+    {
+        optionalColumns << tr("Tags");
+        optionalTree->setColumnWidth(2, 300);
+     } 
+    optionalTree->setHeaderLabels(optionalColumns);
+
+    dialogLayout->addWidget(optionalTree);
+    this->resize(800, 700);
+
+    for (QString key: optionalAttributes.uniqueKeys())
+    {
+        QList<QString> values = optionalAttributes.values(key);
+        if (!values.isEmpty())
+        {
+            QTreeWidgetItem * item = new QTreeWidgetItem(optionalTree);
+            item->setText(0, key);
+            for (int i = 0; i<values.size(); ++i)
+            {
+                item->setText(i+1, values[i]);
+            }
+            optionalTree->addTopLevelItem(item);
+        }
+    }
+    optionalTree->setSortingEnabled(true);
+    optionalTree->sortByColumn(0, Qt::AscendingOrder);
+
 }
 
 medDataInfoWidget::~medDataInfoWidget()

--- a/src/layers/medWidgets/source/widgets/medDataInfoWidget.h
+++ b/src/layers/medWidgets/source/widgets/medDataInfoWidget.h
@@ -15,10 +15,10 @@
 
 #include <medWidgetsExport.h>
 
-
 #include <QWidget>
 #include <QDialog>
 #include <QMap>
+#include <QMultiMap>
 #include <QString>
 
 class medSourceModelPresenter;
@@ -27,6 +27,6 @@ class medDataInfoWidget : public QDialog
 {
     Q_OBJECT
 public:
-    medDataInfoWidget(QMap<QString, QString> dataAttributes, QWidget *parent = nullptr);
+    medDataInfoWidget(QMap<QString, QString> dataAttributes, QMultiMap<QString, QString> optionalAttributes, QWidget *parent = nullptr);
     virtual ~medDataInfoWidget();
 };

--- a/src/layers/medWidgets/source/widgets/medSourcesWidget.cpp
+++ b/src/layers/medWidgets/source/widgets/medSourcesWidget.cpp
@@ -144,7 +144,7 @@ void medSourcesWidget::addSource(medDataHub *dataHub, QString sourceInstanceId)
     //connect(readerAction,  &QAction::triggered, [=]() {  emit infoActionSignal(this->itemFromMenu(pMenu)); });
     //connect(unloadAction,  &QAction::triggered, [=]() {  emit infoActionSignal(this->itemFromMenu(pMenu)); });
     connect(infoAction,    &QAction::triggered, [=]() {
-        medSourceModel::datasetAttributes mandatoriesAttributes;
+        medSourceHandler::datasetAttributes mandatoriesAttributes;
 
         QModelIndex index = this->indexFromMenu(pMenu);
         if (index.isValid())
@@ -153,9 +153,30 @@ void medSourcesWidget::addSource(medDataHub *dataHub, QString sourceInstanceId)
             QMap<QString, QString> dataAttributes;
             for (auto & key : mandatoriesAttributes.values.keys())
             {
-                dataAttributes[key] = mandatoriesAttributes.values[key].toString();
+                dataAttributes[key] = mandatoriesAttributes.values[key];
             }
-            auto popupDataInfo = new medDataInfoWidget(dataAttributes);
+            
+            medDataIndex medIndex = static_cast<const medSourceModel*>(index.model())->dataIndexFromModelIndex(index);
+            medSourceHandler::datasetAttributes optionalAttr = dataHub->getOptionalMetaData(medIndex);
+            QMultiMap<QString, QString> optionalMultiMap;
+
+            for (auto key: optionalAttr.values.keys())
+            {
+                if (optionalAttr.tags.contains(key))
+                {
+                    auto tag = optionalAttr.tags.take(key);
+                    optionalMultiMap.insert(key, tag);
+                }
+                optionalMultiMap.insert(key, optionalAttr.values[key]);
+            }
+
+            for (auto key: optionalAttr.tags.keys())
+            {
+                optionalMultiMap.insert(key, optionalAttr.tags[key]);
+                optionalMultiMap.insert(key, " ");
+            }
+
+            auto popupDataInfo = new medDataInfoWidget(dataAttributes, optionalMultiMap);
             popupDataInfo->show();
         }
 


### PR DESCRIPTION
This struct was declared differently in several files. Only the declaration in medSourceHandler for use in core and the declaration in medAbstractSource are kept.

Removed old implementations of get/set optionalAttributes and developed a new one. These methods are used to
- retrieve optional metadata from the source and store it in the model
- Display optional attributes in graphical elements