### PR TITLE
[SplashScreen] speeds up launch removing txt on splashscreen

### DIFF
--- a/src/app/medInria/main.cpp
+++ b/src/app/medInria/main.cpp
@@ -126,8 +126,6 @@ int main(int argc,char* argv[])
     bool show_splash = false;
     #endif
 
-    medSettingsManager* mnger = medSettingsManager::instance();
-
     QStringList posargs;
     for (int i=1;i<application.arguments().size();++i)
     {
@@ -178,12 +176,7 @@ int main(int argc,char* argv[])
 
     if (show_splash)
     {
-        QObject::connect(medPluginManager::instance(),SIGNAL(loaded(QString)),
-                         &application,SLOT(redirectMessageToSplash(QString)) );
-        QObject::connect(&application,SIGNAL(showMessage(const QString&)),
-                         &splash,SLOT(showMessage(const QString&)) );
         splash.show();
-        splash.showMessage("Loading plugins...");
     }
 
     medDataManager::instance()->setDatabaseLocation();
@@ -253,8 +246,7 @@ int main(int argc,char* argv[])
        QGLFormat::setDefaultFormat(format);
     }
 
-    if (show_splash)
-        splash.finish(mainwindow);
+    splash.close();
 
 #if(USE_PYTHON)
     if(!pythonErrorMessage.isEmpty())

--- a/src/app/medInria/medSplashScreen.cpp
+++ b/src/app/medInria/medSplashScreen.cpp
@@ -22,11 +22,9 @@ class medSplashScreenPrivate
 {
 public:
     QPixmap  pixmap;
-    QString  message;
     int   alignment;
     QColor  color;
 };
-
 
 ////////////////////////////////////////////////////////////////////////////
 medSplashScreen::medSplashScreen(const QPixmap& thePixmap)
@@ -70,60 +68,11 @@ medSplashScreen::~medSplashScreen()
 }
 
 ////////////////////////////////////////////////////////////////////////////
-void medSplashScreen::clearMessage()
-{
-    d->message.clear();
-    repaint();
-}
-
-////////////////////////////////////////////////////////////////////////////
-void medSplashScreen::showMessage(const QString& message)
-{
-    const dtkPlugin* plugin = medPluginManager::instance()->plugin(message);
-    if (plugin)
-    {
-        d->message = QString("Loading: ") + plugin->name();
-    }
-    else
-    {
-        d->message = QString("Loading: ") + message;
-    }
-
-    repaint();
-}
-
-void medSplashScreen::repaint()
-{
-    QWidget::repaint();
-    QApplication::flush();
-    qApp->processEvents(QEventLoop::AllEvents);
-}
-
-void medSplashScreen::finish(QWidget *mainWin)
-
-{
-    if (mainWin)
-    {
-#if defined(Q_OS_LINUX)
-        Q_UNUSED(QTest::qWaitForWindowExposed(mainWin));
-#endif
-    }
-    close();
-}
-
-////////////////////////////////////////////////////////////////////////////
 void medSplashScreen::paintEvent(QPaintEvent* pe)
 {
     Q_UNUSED(pe);
 
-    QRect aTextRect(rect());
-    aTextRect.setRect(aTextRect.x() + 120,
-                      aTextRect.y() + 5,
-                      aTextRect.width() - 10,
-                      aTextRect.height() - 10);
-
     QPainter aPainter(this);
     aPainter.drawPixmap(rect(), d->pixmap);
     aPainter.setPen(d->color);
-    aPainter.drawText(aTextRect, d->alignment, d->message);
 }

--- a/src/app/medInria/medSplashScreen.h
+++ b/src/app/medInria/medSplashScreen.h
@@ -18,7 +18,7 @@
 class medSplashScreenPrivate;
 
 /**
- * @brief create SplaScreen widget with translucent background.
+ * @brief create Splashcreen widget with translucent background.
  *
  * not based on QSplashScreen which does not support this feature.
  Almost all features from the QSplashscreen are replicated, including messages refreshed before a QApplication event loop is running.
@@ -38,41 +38,7 @@ public:
     medSplashScreen(const QPixmap& pixmap);
     ~medSplashScreen();
 
-    /**
-     * @brief hides the splashscreen when w is shown.
-     *
-     * @param w
-     */
-    void finish(QWidget *w);
-
-    /**
-     * @brief Repaints the widget without the need of an event loop;
-     *
-     */
-    void repaint();
-
-public slots:
-    /**
-     * @brief Clears the message.
-     *
-     */
-    void clearMessage();
-
-    /**
-     * @brief Shows a message with the desired alignment and color.
-     *
-     * @param theMessage
-     * @param theAlignment
-     * @param theColor
-     */
-    void showMessage(const QString& theMessage);
-
 private:
-    /**
-     * @brief
-     *
-     * @param pe
-     */
     void paintEvent(QPaintEvent* pe);
 
     medSplashScreenPrivate * d;


### PR DESCRIPTION
This PR speeds up the launch of the software removing the display of each plugin name on it. 

On my machine (ubuntu) i had a 2 sec long splash screen, and with this i've got a instant launch. On some other machines, the splash screen is way longer so it can help too.

:m: