### PR TITLE
[VTK] avoid med crash with wrong version of vtk files

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
@@ -224,7 +224,10 @@ medAbstractData *medDatabaseReader::readFile( const QStringList& filenames )
         connect ( dataReader, SIGNAL ( progressed ( int ) ), this, SIGNAL ( progressed ( int ) ) );
         if ( dataReader->canRead ( filenames ) )
         {
-            dataReader->read ( filenames );
+            if (dataReader->read(filenames) == false)
+            {
+                break;
+            }
             dataReader->enableDeferredDeletion ( false );
             medData = dynamic_cast<medAbstractData*>(dataReader->data());
 


### PR DESCRIPTION
Same as https://github.com/medInria/medInria-public/pull/1135 on master branch.

If there is a reading problem importing data, medInria should not crash.

:m: