### PR TITLE
[medVtkImageInfo] proper reset of a complex structure

### DIFF
--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
@@ -58,7 +58,7 @@ void vtkImage2DDisplay::SetInputData(vtkImageData *pi_poVtkImage)
     }
     else
     {
-        memset(&m_sVtkImageInfo, 0, sizeof(m_sVtkImageInfo));
+        m_sVtkImageInfo = medVtkImageInfo();
     }
 }
 

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.cpp
@@ -52,7 +52,7 @@ void vtkImage3DDisplay::SetInputData(vtkImageData *pi_poVtkImage)
     }
     else
     {
-        memset(&m_sVtkImageInfo, 0, sizeof(m_sVtkImageInfo));
+        m_sVtkImageInfo = medVtkImageInfo();
     }
 }
 


### PR DESCRIPTION
At compilation of medInria i had some warning as:

``` 
medInria-public/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp:67:60: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct medVtkImageInfo’; use assignment or value-initialization instead [-Wclass-memaccess]
   67 |         memset(&m_sVtkImageInfo, 0, sizeof(m_sVtkImageInfo));
```

m_sVtkImageInfo is a complex structure with constructor and destructor, and should not be reset with memset.

:m: