### PR TITLE
[medVtkImageInfo] proper reset of a complex structure -- master

### DIFF
--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
@@ -58,7 +58,7 @@ void vtkImage2DDisplay::SetInputData(vtkImageData *pi_poVtkImage)
     }
     else
     {
-        memset(&m_sVtkImageInfo, 0, sizeof(m_sVtkImageInfo));
+        m_sVtkImageInfo = medVtkImageInfo();
     }
 }
 

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.cpp
@@ -52,7 +52,7 @@ void vtkImage3DDisplay::SetInputData(vtkImageData *pi_poVtkImage)
     }
     else
     {
-        memset(&m_sVtkImageInfo, 0, sizeof(m_sVtkImageInfo));
+        m_sVtkImageInfo = medVtkImageInfo();
     }
 }
 


### PR DESCRIPTION
Same as https://github.com/medInria/medInria-public/pull/1151 on master branch.

m_sVtkImageInfo is a complex structure with constructor and destructor, and should not be reset with memset.

:m: