### PR TITLE
[vtkImageInfo] an other way to reset the complex structure and please GCC

### DIFF
--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
@@ -58,7 +58,7 @@ void vtkImage2DDisplay::SetInputData(vtkImageData *pi_poVtkImage)
     }
     else
     {
-        m_sVtkImageInfo = medVtkImageInfo();
+        memset(reinterpret_cast<void*>(&m_sVtkImageInfo), 0, sizeof(m_sVtkImageInfo));
     }
 }
 

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.cpp
@@ -52,7 +52,7 @@ void vtkImage3DDisplay::SetInputData(vtkImageData *pi_poVtkImage)
     }
     else
     {
-        m_sVtkImageInfo = medVtkImageInfo();
+        memset(reinterpret_cast<void*>(&m_sVtkImageInfo), 0, sizeof(m_sVtkImageInfo));
     }
 }
 


### PR DESCRIPTION
An other way to be GCC compliant with m_sVtkImageInfo, seen with @Florent2305.

(previously changed on https://github.com/medInria/medInria-public/pull/1151)

:m: