### PR TITLE
[medCropToolBox] fix error return value

### DIFF
--- a/src/plugins/legacy/reformat/medCropToolBox.cpp
+++ b/src/plugins/legacy/reformat/medCropToolBox.cpp
@@ -496,7 +496,7 @@ int medCropToolBoxPrivate::extractCroppedImage(medAbstractData* input, int* minI
         }
         if (maxIndices[i] < 0 || minIndices[i] >= static_cast<int>(imageSize[i]))
         {
-            return 0;
+            return medAbstractProcessLegacy::FAILURE;
         }
         desiredStart[i] = std::max(minIndices[i], 0);
         desiredSize[i] = std::min(maxIndices[i] + 1, static_cast<int>(imageSize[i])) - desiredStart[i];


### PR DESCRIPTION
Minor issue found while reviewing a PR. An internal function using error codes returned `0` (i.e. success) instead of a failure code.
(the error case is never encountered but this is still a technical bug)