### PR TITLE
[Thumbnail] no need to warn if no thumbn since the thumbnail setting added

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
@@ -699,10 +699,7 @@ QString medAbstractDatabaseImporter::generateThumbnail ( medAbstractData* medDat
         qWarning("medAbstractDatabaseImporter: Cannot create directory: %s", qPrintable(pathToStoreThumbnail));
     }
 
-    if ( ! thumbnail.save ( fullThumbnailPath, "PNG" ))
-    {
-        qWarning("medAbstractDatabaseImporter: Saving thumbnail to %s failed.", qPrintable(fullThumbnailPath));
-    }
+    thumbnail.save(fullThumbnailPath, "PNG");
 
     medData->addMetaData ( medMetaDataKeys::ThumbnailPath.key(), thumbnailPath );
 

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
@@ -184,10 +184,6 @@ medAbstractData* medDatabaseReader::run()
 
     QString fullThumbnailPath(medStorage::dataLocation() + thumbnailPath);
     QFileInfo fullThumbnailPathInfo(fullThumbnailPath);
-    if (!fullThumbnailPathInfo.exists())
-    {
-        qWarning("No thumbnail found at path: %s", qPrintable(fullThumbnailPath));
-    }
     medMetaDataKeys::SeriesThumbnail.add (medData, fullThumbnailPath);
 
     medMetaDataKeys::PatientID.set ( medData, patientId );


### PR DESCRIPTION
Since a thumbnail setting has been added to allow or not the creation of the thumbnail at data import, there is no need to display a warning about the existence of thumbnail during the saving of a temporary data.

:m: