### PR TITLE
[medClutEditor] remove todo comments not needed anymore

### DIFF
--- a/src/layers/medCore/legacy/gui/lookUpTables/medClutEditor.h
+++ b/src/layers/medCore/legacy/gui/lookUpTables/medClutEditor.h
@@ -27,7 +27,6 @@ class medAbstractImageView;
 
 class medClutEditorVertexPrivate;
 
-// TODO use QGraphicsObjectItem noobs.
 class MEDCORE_EXPORT medClutEditorVertex : public QGraphicsObject
 {
     Q_OBJECT


### PR DESCRIPTION
The changes done in https://github.com/medInria/medInria-public/pull/1178 were already applied on medInria4/dev, however, this `todo` comment is useless now.

:m: