### PR TITLE
[PolygonROI] ROI/repulsor crashs and interactor problems (#807)

### DIFF
--- a/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
@@ -395,6 +395,10 @@ void polygonRoiToolBox::clickClosePolygon(bool state)
         {
             viewEventHash[activeDataIndex]->onSelectContainer();
         }
+        else if (!viewEventHash.empty())
+        {
+            viewEventHash.values().first()->getCurrentView()->selectedRequest(true);
+        }
     }
     saveBinaryMaskButton->setEnabled(state);
     saveContourButton->setEnabled(state);
@@ -465,7 +469,6 @@ void polygonRoiToolBox::clear()
 
     pMedToolBox->clear();
     pMedToolBox->setEnabled(false);
-
 }
 
 QList<medAbstractData *> polygonRoiToolBox::getITKImageDataInSelectedView(medAbstractView *view)

--- a/src/plugins/legacy/polygonRoi/viewevent/baseViewEvent.cpp
+++ b/src/plugins/legacy/polygonRoi/viewevent/baseViewEvent.cpp
@@ -47,10 +47,13 @@ baseViewEvent::baseViewEvent(medAbstractImageView *iView, polygonRoiToolBox *too
 
     // interactors
     interactorStyleRepulsor = vtkInriaInteractorStylePolygonRepulsor::New();
+    originalInteractor = view2d->GetInteractor();
 }
 
 baseViewEvent::~baseViewEvent()
 {
+    activateRepulsor(false);
+
     delete crossPosition;
     removeViewInteractor();
     manageTickVisibility(false);
@@ -59,13 +62,7 @@ baseViewEvent::~baseViewEvent()
         delete label;
     }
     labelList.clear();
-    cursorState = CURSORSTATE::CS_DEFAULT;
-    isRepulsorActivated = false;
-    if (interactorStyleRepulsor)
-    {
-        interactorStyleRepulsor->Delete();
-        interactorStyleRepulsor = nullptr;
-    }
+
     currentLabel = nullptr;
     currentView = nullptr;
 }
@@ -701,14 +698,14 @@ void baseViewEvent::activateRepulsor(bool state)
             }
         }
     }
-    else
+    else if (cursorState == CURSORSTATE::CS_REPULSOR)
     {
         cursorState = CURSORSTATE::CS_DEFAULT;
         vtkInteractorStyleImageView2D *interactorStyle2D = vtkInteractorStyleImageView2D::New();
         globalVtkLeftButtonBehaviour = view2d->GetLeftButtonInteractionStyle();
         interactorStyle2D->SetLeftButtonInteraction(vtkInteractorStyleImageView2D::InteractionTypeNull);
         view2d->SetInteractorStyle(interactorStyle2D);
-        view2d->SetupInteractor(view2d->GetInteractor()); // to reinstall vtkImageView2D pipeline
+        view2d->SetupInteractor(originalInteractor);
         interactorStyle2D->Delete();
     }
 }

--- a/src/plugins/legacy/polygonRoi/viewevent/baseViewEvent.h
+++ b/src/plugins/legacy/polygonRoi/viewevent/baseViewEvent.h
@@ -120,6 +120,7 @@ private:
     QList<medDisplayPosContours> copyNodesList;
     double savedMousePosition[2];
     dtkSmartPointer<medAbstractData> contourOutput;
+    vtkRenderWindowInteractor* originalInteractor;
 
     void leftButtonBehaviour(medAbstractView *view);
     bool rightButtonBehaviour(medAbstractView *view, QMouseEvent *mouseEvent);

--- a/src/plugins/legacy/polygonRoi/viewinteractors/polygonRoi.cpp
+++ b/src/plugins/legacy/polygonRoi/viewinteractors/polygonRoi.cpp
@@ -302,7 +302,7 @@ void polygonRoi::manageVisibility()
     }
     else
     {
-        if (d->view->GetSlice() == getIdSlice())
+        if (isInCurrentSlice())
         {
             On();
         }
@@ -520,7 +520,7 @@ bool polygonRoi::pasteContour(QVector<QVector2D> &nodes)
 
 bool polygonRoi::isInCurrentSlice()
 {
-    return (d->view->GetSlice() == getIdSlice());
+    return (static_cast<unsigned int>(d->view->GetSlice()) == getIdSlice());
 }
 
 void polygonRoi::setCurrentSlice()


### PR DESCRIPTION
From PR of MUSICardio https://github.com/Inria-Asclepios/medInria-public/pull/807

> There are some problems with Polygon ROI toolbox.
> 
> ### Solved in this PR
>  * If you want to draw a ROI with SHIFT-click, the first click was not drawing anything. This is important because some users think the toolbox is not working.
>  * A warning message has been solved.
>  * Draw a ROI, activate then deactivate repulsor: user looses the possibility to change the view contrast.
>  * Draw a ROI, activate repulsor, change toolbox (run `clear()` method) then click on the view -> crash.
> 
> ### Problems that are still there
>  * Activate the toolbox, draw 1 landmark, activate Repulsor, click on the view -> crash
>  * The last point fixed above does not crash anymore, however we loose the possibility to change the view contrast. The user needs to choose an other mouse interaction setting and go back to the original one to reset the interactor. It's annoying and it would be nice to solve that, but at least it's not crashing.

:m: