### PR TITLE
[manualRegistration] solve top views size problem

### DIFF
--- a/src/plugins/legacy/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src/plugins/legacy/manualRegistration/manualRegistrationToolBox.cpp
@@ -464,7 +464,7 @@ void manualRegistrationToolBox::constructContainers(medTabbedViewContainers* tab
 
         d->leftContainer = tabContainers->insertNewTab(0,"ManualRegistration");
         tabContainers->setCurrentIndex(0);
-        d->leftContainer->addData(d->currentView->layerData(0));//
+        d->leftContainer->addData(d->currentView->layerData(0));
         qobject_cast<medAbstractImageView*>(d->leftContainer->view())->windowLevelParameter(0)->setValues(windowing0);
 
         d->bottomContainer = d->leftContainer->splitHorizontally();
@@ -472,11 +472,12 @@ void manualRegistrationToolBox::constructContainers(medTabbedViewContainers* tab
         qobject_cast<medAbstractImageView*>(d->bottomContainer->view())->windowLevelParameter(0)->setValues(windowing0);
         d->bottomContainer->addData(d->currentView->layerData(1));
         qobject_cast<medAbstractImageView*>(d->bottomContainer->view())->windowLevelParameter(1)->setValues(windowing1);
-        tabContainers->containersInTab(0);
 
         d->rightContainer = d->leftContainer->splitVertically();
         d->rightContainer->addData(d->currentView->layerData(1));
         qobject_cast<medAbstractImageView*>(d->rightContainer->view())->windowLevelParameter(0)->setValues(windowing1);
+
+        tabContainers->adjustContainersSize();
 
         d->leftContainer->setUserSplittable(false);
         d->rightContainer->setUserSplittable(false);


### PR DESCRIPTION
From PR https://github.com/Inria-Asclepios/medInria-public/pull/781 on MUSICardio side.

When using the `constructContainers` method to construct manually the containers, it needs to adjust the containers size.

:m: