### PR TITLE
[Paint] Remove annotation data when destroying paint toolbox

### DIFF
--- a/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
+++ b/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
@@ -507,6 +507,7 @@ AlgorithmPaintToolBox::AlgorithmPaintToolBox(QWidget *parent ) :
 AlgorithmPaintToolBox::~AlgorithmPaintToolBox()
 {
     setOfPaintBrushRois.clear();
+    m_imageData->removeAttachedData(m_maskAnnotationData);
 }
 
 medAbstractData* AlgorithmPaintToolBox::processOutput()

--- a/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
+++ b/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
@@ -507,7 +507,11 @@ AlgorithmPaintToolBox::AlgorithmPaintToolBox(QWidget *parent ) :
 AlgorithmPaintToolBox::~AlgorithmPaintToolBox()
 {
     setOfPaintBrushRois.clear();
-    m_imageData->removeAttachedData(m_maskAnnotationData);
+
+    if (m_imageData && m_maskAnnotationData)
+    {
+        m_imageData->removeAttachedData(m_maskAnnotationData);
+    }
 }
 
 medAbstractData* AlgorithmPaintToolBox::processOutput()


### PR DESCRIPTION
From PR https://github.com/Inria-Asclepios/medInria-public/pull/771 and https://github.com/Inria-Asclepios/medInria-public/pull/776

Correctly remove attached data at the end of Paint toolbox.

:m: