### PR TITLE
[Reslice] proper release of RAM (#774)

### DIFF
--- a/src/plugins/legacy/reformat/medResliceViewer.cpp
+++ b/src/plugins/legacy/reformat/medResliceViewer.cpp
@@ -17,12 +17,12 @@
 
 #include <medAbstractDataFactory.h>
 #include <medAbstractLayeredView.h>
+#include <medDoubleParameterL.h>
 #include <medSliderSpinboxPair.h>
 #include <medTransform.h>
 #include <medUtilities.h>
 #include <medUtilitiesITK.h>
 #include <medVtkViewBackend.h>
-#include <medDoubleParameterL.h>
 
 #include <vtkCamera.h>
 #include <vtkCellPicker.h>
@@ -36,13 +36,13 @@
 #include <vtkPlaneSource.h>
 #include <vtkProperty.h>
 #include <vtkRenderer.h>
+#include <vtkRenderWindowInteractor.h>
 #include <vtkResliceCursor.h>
 #include <vtkResliceCursorActor.h>
 #include <vtkResliceCursorPolyDataAlgorithm.h>
 #include <vtkResliceCursorThickLineRepresentation.h>
 #include <vtkResliceCursorWidget.h>
 #include <vtkTransform.h>
-#include <vtkRenderWindowInteractor.h>
 
 class medResliceCursorCallback : public vtkCommand
 {
@@ -122,7 +122,10 @@ public:
         reformatViewer->getImagePlaneWidget(0)->GetInteractor()->GetRenderWindow()->Render();
     }
 
-    medResliceCursorCallback() {}
+    ~medResliceCursorCallback()
+    {
+        reformatViewer = nullptr;
+    }
 
     medResliceViewer *reformatViewer;
 };
@@ -140,7 +143,10 @@ medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medA
     selectedView = 2;
 
     int *imageDims = view3d->GetMedVtkImageInfo()->dimensions;
-    outputSpacingOrSize  = view3d->GetMedVtkImageInfo()->spacing;
+
+    // Copy view information before it's destroyed, allowing to use outputSpacingOrSize later.
+    double *spacing = view3d->GetMedVtkImageInfo()->spacing;
+    memcpy(outputSpacingOrSize.data(), spacing, 3*sizeof(double));
 
     viewBody = new QWidget(parent);
 
@@ -167,7 +173,7 @@ medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medA
     }
 
     // Position of the new views in tab
-    QGridLayout *gridLayout = new QGridLayout(parent);
+    QGridLayout *gridLayout = new QGridLayout();
     gridLayout->addWidget(views[2], 0, 0);
     gridLayout->addWidget(views[3], 0, 1);
     gridLayout->addWidget(views[1], 1, 0);
@@ -286,6 +292,7 @@ medResliceViewer::~medResliceViewer()
         planeWidget[i] = nullptr;
     }
     vtkViewData = nullptr;
+    inputData = nullptr;
 }
 
 QString medResliceViewer::identifier() const
@@ -384,7 +391,7 @@ void medResliceViewer::saveImage()
     // Apply resampling in mm
     if (reformaTlbx->findChild<QComboBox*>("bySpacingOrSize")->currentText() == "Spacing")
     {
-        reslicerTop->SetOutputSpacing(outputSpacingOrSize);
+        reslicerTop->SetOutputSpacing(outputSpacingOrSize.data());
     }
     reslicerTop->Update();
 

--- a/src/plugins/legacy/reformat/medResliceViewer.h
+++ b/src/plugins/legacy/reformat/medResliceViewer.h
@@ -12,18 +12,18 @@ PURPOSE.
 
 =========================================================================*/
 
+#include "resliceToolBox.h"
+
+#include <medAbstractView.h>
+#include <vtkImageView3D.h>
+
 #include <dtkCoreSupport/dtkSmartPointer.h>
 
 #include <itkImage.h>
 
-#include <medAbstractView.h>
-
 #include <QVTKOpenGLWidget.h>
 
-#include <resliceToolBox.h>
-
 #include <vtkImagePlaneWidget.h>
-#include <vtkImageView3D.h>
 #include <vtkResliceImageViewer.h>
 #include <vtkSmartPointer.h>
 
@@ -85,7 +85,7 @@ protected:
     QWidget *viewBody;
     QVTKOpenGLWidget *views[4];
     dtkSmartPointer<medAbstractData> inputData;
-    double *outputSpacingOrSize;
+    std::array<double, 3> outputSpacingOrSize;
     unsigned char selectedView;
     vtkImageView3D *view3d;
     vtkSmartPointer<vtkImageData> vtkViewData;

--- a/src/plugins/legacy/reformat/resliceToolBox.h
+++ b/src/plugins/legacy/reformat/resliceToolBox.h
@@ -23,10 +23,10 @@ class resliceToolBoxPrivate;
  * "startReformatButton" : QPushButton\n
  * "stopReformatButton" : QPushButton\n
  * "saveImageButton" : QPushButton\n
- * "bySpacingOrDimension" : medComboBox\n
- * "SpacingX" : QDoubleSpinBox\n
- * "SpacingY" : QDoubleSpinBox\n
- * "SpacingZ" : QDoubleSpinBox\n
+ * "bySpacingOrDimension" : QComboBox\n
+ * "SpacingOrSizeX" : medDoubleParameterL\n
+ * "SpacingOrSizeY" : medDoubleParameterL\n
+ * "SpacingOrSizeZ" : medDoubleParameterL\n
  * "helpBegin" : QLabel
  */
 class REFORMATPLUGIN_EXPORT resliceToolBox : public medAbstractSelectableToolBox


### PR DESCRIPTION
From PR https://github.com/Inria-Asclepios/medInria-public/pull/774 initially on MUSICardio.

> This toolbox allows to solve memory problems in Reslice toolbox: mem leaks and memory used where it was not needed.
> 
> The toolbox does not close anymore the first container to create a new one with medResliceViewer. Instead, it removes the view, change the "default widget" to medResliceViewer, then at stop it initializes the default widget and add back the original data in the container, creating a new view itself.
> Also now, changing from this toolbox to an other does not create a new container/view/etc, especially if the toolbox was not activated. Before that, even opening this toolbox with a data and switching to an other toolbox was using a lot a memory for nothing.

:m: