### PR TITLE
[polygonRoi] hide activation label (#773)

### DIFF
--- a/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
@@ -59,6 +59,7 @@ polygonRoiToolBox::polygonRoiToolBox(QWidget *parent ) :
     activateTBButton->setCheckable(true);
     activateTBButton->setObjectName("closedPolygonButton");
     connect(activateTBButton,SIGNAL(toggled(bool)),this,SLOT(clickClosePolygon(bool)));
+    connect(activateTBButton, &QAbstractButton::toggled, [=] (bool state) { explanation->setVisible(!state); });
 
     interpolate = new QCheckBox(tr("Interpolate between contours"));
     interpolate->setToolTip("Interpolate between master ROIs");


### PR DESCRIPTION
From PR https://github.com/Inria-Asclepios/medInria-public/pull/773

> The label stayed after activating the toolbox.