### PR TITLE
[Paint] solve problems switching between tools (#770)

### DIFF
--- a/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.h
+++ b/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.h
@@ -124,10 +124,10 @@ public:
 public slots:
     void updateView();
 
-    void activateStroke();
+    void activateStroke(bool checked);
     void activateCustomedCursor();
     void deactivateCustomedCursor();
-    void activateMagicWand();
+    void activateMagicWand(bool checked);
     void updateMagicWandComputationSpeed();
 
     void copyMetaData(medAbstractData *output,


### PR DESCRIPTION
From PR https://github.com/Inria-Asclepios/medInria-public/pull/770

> This PR solves problems using tools in Paint:
> 
>  * Paint/Erase and Magic Wand buttons do not set properly their widgets.
>  * Clear button was hiding buttons even if data were in the view, run twice a part of the cleaning process, then and Add and Erase buttons when shown were not handled well.

:m: