### PR TITLE
[DCM] same test as on med3.3 branch, quicker

### DIFF
--- a/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
+++ b/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
@@ -687,7 +687,7 @@ double DCMTKImageIO::GetPositionOnStackingAxisForImage (int index)
 double DCMTKImageIO::GetPositionFromPrincipalAxisIndex(int index, int principalAxisIndex)
 {
     std::string s_position = this->GetMetaDataValueString("(0020,0032)", index);
-    if ( s_position == "" )
+    if (s_position.empty())
     {
         itkWarningMacro ( << "Tag (0020,0032) (ImageOrigin) was not found, assuming 0.0/0.0/0.0" << std::endl);
         return 0.0;


### PR DESCRIPTION
The "empty" test is quicker than "==". This PR updates the medInria3.4 branch as done on medInria3.3.

Ref:
https://github.com/medInria/medInria-public/pull/1192
https://github.com/medInria/medInria-public/pull/1202

:m: