### PR TITLE
[Reslice] background color for selected view

### DIFF
--- a/src/plugins/legacy/reformat/medResliceViewer.cpp
+++ b/src/plugins/legacy/reformat/medResliceViewer.cpp
@@ -162,6 +162,7 @@ medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medA
         riw[i]->SetRenderWindow(renderWindow);
         riw[i]->GetRenderer()->SetBackground(0,0,0); // black background
     }
+    riw[selectedView]->GetRenderer()->SetBackground(0.3,0,0);
 
     // Build views
     for (int i = 0; i < 4; i++)
@@ -507,18 +508,15 @@ bool medResliceViewer::eventFilter(QObject *object, QEvent *event)
     {
         for(int i=0; i<3; i++)
         {
+            riw[i]->GetRenderer()->SetBackground(0,0,0);
             if (views[i]==object)
             {
                 selectedView = i;
             }
         }
-        return false;
+        riw[selectedView]->GetRenderer()->SetBackground(0.3,0,0);
     }
-
-    if (event->type() == QEvent::FocusOut)
-    {
-        return false;
-    }
+    
     return false;
 }
 


### PR DESCRIPTION
As done in https://github.com/Inria-Asclepios/medInria-public/pull/823

This PR adds back a (background) color to display the current selected view.
This is needed for the user to choose the main orientation that is going to be used in the output data.

:m: