### PR TITLE
fix ep_Initialisation macro and adapt for non-cmake projects

### DIFF
--- a/superbuild/external_projects_tools/EP_Initialisation.cmake
+++ b/superbuild/external_projects_tools/EP_Initialisation.cmake
@@ -11,11 +11,30 @@
 #
 ################################################################################
 
-macro(ep_Initialisation ep
-  USE_SYSTEM use_system_def 
-  BUILD_SHARED_LIBS build_shared_libs_def
-  REQUIRED_FOR_PLUGINS required_for_plugins
-  )
+macro(ep_Initialisation ep)
+
+cmake_parse_arguments(ep_Initialisation
+    "NO_CMAKE_PACKAGE"
+    "USE_SYSTEM;BUILD_SHARED_LIBS;REQUIRED_FOR_PLUGINS;PACKAGE_NAME"
+    ""
+    ${ARGN}
+    )
+
+if (NOT ep_Initialisation_USE_SYSTEM)
+    set(ep_Initialisation_USE_SYSTEM OFF)
+endif()
+
+if (NOT ep_Initialisation_BUILD_SHARED_LIBS)
+    set(ep_Initialisation_BUILD_SHARED_LIBS ON)
+endif()
+
+if (NOT ep_Initialisation_REQUIRED_FOR_PLUGINS)
+    set(ep_Initialisation_REQUIRED_FOR_PLUGINS OFF)
+endif()
+
+if (NOT ep_Initialisation_PACKAGE_NAME)
+    set(ep_Initialisation_PACKAGE_NAME ${ep})
+endif()
   
 ## #############################################################################
 ## Add variable : do we want use the system version ?
@@ -23,48 +42,27 @@ macro(ep_Initialisation ep
 
 option(USE_SYSTEM_${ep} 
   "Use system installed version of ${ep}" 
-  ${use_system_def}
+  ${ep_Initialisation_USE_SYSTEM}
   )
 
 if (USE_SYSTEM_${ep})
-  find_package(${ep} REQUIRED)
 
-if (WIN32)
-  if (DEFINED ${ep}_DIR)
-    file(TO_CMAKE_PATH ${${ep}_DIR} ${ep}_DIR)
-  endif()
-  
-  if (DEFINED EP_PREFIX)
-    file(TO_CMAKE_PATH ${EP_PREFIX} EP_PREFIX)
-  endif()
-  
-  if (DEFINED ${ep}_BINARY_DIR)
-    file(TO_CMAKE_PATH ${${ep}_BINARY_DIR} ${ep}_BINARY_DIR)
-  endif()
-  
-  if (DEFINED EP_PATH_SOURCE)
-    file(TO_CMAKE_PATH ${EP_PATH_SOURCE} EP_PATH_SOURCE)
-  endif()
-  
-  if (DEFINED EP_PATH_BUILD)
-    file(TO_CMAKE_PATH ${EP_PATH_BUILD} EP_PATH_BUILD)
-  endif()
-endif()
+    if(NOT ep_Initialisation_NO_CMAKE_PACKAGE)
+        find_package(${ep_Initialisation_PACKAGE_NAME} REQUIRED)
 
 ## #############################################################################
 ## Complete superProjectConfig.cmake
 ## #############################################################################
 
-  if(${required_for_plugins})  
-  #  provide path of project needeed for Asclepios and visages plugins 
-  file(APPEND ${${PROJECT_NAME}_CONFIG_FILE}
-    "find_package(${ep} REQUIRED
-      PATHS \"${${ep}_DIR}\"
-      NO_CMAKE_BUILDS_PATH
-      )\n"
-    )
-  endif()
-
+        if(ep_Initialisation_REQUIRED_FOR_PLUGINS)
+            #  provide path of project needeed for Asclepios and visages plugins
+            file(APPEND ${${PROJECT_NAME}_CONFIG_FILE}
+                "find_package(${ep_Initialisation_PACKAGE_NAME} REQUIRED
+                    PATHS \"${${ep_Initialisation_PACKAGE_NAME}_DIR}\"
+                    )\n"
+                )
+        endif()
+    endif()
 
 else()
 ## ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -73,30 +71,30 @@ else()
 ## ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ## ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   
-  if (${required_for_plugins})
-    if (DEFINED ${ep}_BINARY_DIR)
-      file(APPEND ${${PROJECT_NAME}_CONFIG_FILE}
-      "find_package(${ep} REQUIRED
-        PATHS \"${${ep}_BINARY_DIR}\" 
-        PATH_SUFFIXES install build
-        NO_CMAKE_BUILDS_PATH
-        )\n"
-      )
-    else()
-	  if(DEFINED EP_PATH_BUILD)
-	      set(build_dir ${EP_PATH_BUILD})
-	  else()
-	      set(build_dir "${EP_PATH_SOURCE}/${ep}-build" )
-	  endif()
-	  
-      file(APPEND ${${PROJECT_NAME}_CONFIG_FILE}
-        "find_package(${ep} REQUIRED
-          PATHS \"${build_dir}\" 
-          PATH_SUFFIXES install build
-          NO_CMAKE_BUILDS_PATH
-          )\n"
-        )
-    endif()
+  if(NOT ep_Initialisation_NO_CMAKE_PACKAGE)
+      if (ep_Initialisation_REQUIRED_FOR_PLUGINS)
+          if (DEFINED ${ep}_BINARY_DIR)
+              file(APPEND ${${PROJECT_NAME}_CONFIG_FILE}
+                  "find_package(${ep_Initialisation_PACKAGE_NAME} REQUIRED
+                      PATHS \"${${ep_Initialisation_PACKAGE_NAME}_BINARY_DIR}\"
+                      PATH_SUFFIXES install build
+                      )\n"
+                  )
+          else()
+              if(DEFINED EP_PATH_BUILD)
+                  set(build_dir ${EP_PATH_BUILD})
+              else()
+                  set(build_dir "${EP_PATH_SOURCE}/${ep}-build" )
+              endif()
+
+              file(APPEND ${${PROJECT_NAME}_CONFIG_FILE}
+                  "find_package(${ep} REQUIRED
+                      PATHS \"${build_dir}\"
+                      PATH_SUFFIXES install build
+                      )\n"
+                  )
+          endif()
+      endif()
   endif()
 
 
@@ -106,7 +104,7 @@ else()
   
   option(BUILD_SHARED_LIBS_${ep} 
     "Build shared libs for ${ep}" 
-    ${build_shared_libs_def}
+    ${ep_Initialisation_BUILD_SHARED_LIBS}
     )
   mark_as_advanced(BUILD_SHARED_LIBS_${ep})
   


### PR DESCRIPTION
The current implementation of the `ep_Initialisation` has two issues:
- It does not correctly implement arguments. The argument names (such as `USE_SYSTEM`) should not be part of the signature.
- The macro expects external projects to be cmake packages that are searchable through `find_package`.
- The macro expects the package name to be the same as the external project name.

This PR correctly implements the arguments and adds `PACKAGE_NAME` to specify alternative package names and `NO_CMAKE_PACKAGE` to allow non cmake external projects to be added. (Note that `USE_SYSTEM`, `BUILD_SHARED_LIBS` and `REQUIRED_FOR_PLUGINS` should in practice be options, not single-value arguments, but I preferred keeping the macro compatible with the current code)

_(also the `NO_CMAKE_BUILDS_PATH` option to `find_package` is removed because it is no longer used by cmake)_