### PR TITLE
Add development settings

### DIFF
--- a/src/app/medInria/medApplication.cpp
+++ b/src/app/medInria/medApplication.cpp
@@ -18,6 +18,7 @@
 #include <medAbstractDataFactory.h>
 #include <medCore.h>
 #include <medDatabaseSettingsWidget.h>
+#include <medDevelopmentSettingsWidget.h>
 #include <medDataManager.h>
 #include <medDiffusionWorkspace.h>
 #include <medFilteringWorkspace.h>
@@ -139,6 +140,7 @@ void medApplication::initialize()
     medSettingsWidgetFactory* settingsWidgetFactory = medSettingsWidgetFactory::instance();
     settingsWidgetFactory->registerSettingsWidget<medStartupSettingsWidget>();
     settingsWidgetFactory->registerSettingsWidget<medDatabaseSettingsWidget>();
+    settingsWidgetFactory->registerSettingsWidget<medDevelopmentSettingsWidget>();
 
     //Register annotations
     medAbstractDataFactory * datafactory = medAbstractDataFactory::instance();

--- a/src/layers/legacy/medCoreLegacy/gui/settingsWidgets/medDevelopmentSettingsWidget.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/settingsWidgets/medDevelopmentSettingsWidget.cpp
@@ -1,0 +1,66 @@
+/*==============================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2024. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+==============================================================================*/
+
+#include "medDevelopmentSettingsWidget.h"
+
+#include <medSettingsManager.h>
+
+#include <QCheckBox>
+#include <QLabel>
+#include <QFormLayout>
+#include <QVBoxLayout>
+
+class medDevelopmentSettingsWidgetPrivate
+{
+public:
+    QCheckBox* developerModeCheckBox;
+};
+
+medDevelopmentSettingsWidget::medDevelopmentSettingsWidget(QWidget *parent) :
+    medSettingsWidget(parent), d(new medDevelopmentSettingsWidgetPrivate())
+{
+    setTabName("Development");
+
+    QFormLayout* formLayout = new QFormLayout();
+    formLayout->setSizeConstraint(QLayout::SetFixedSize);
+    formLayout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
+    
+    QVBoxLayout *mainLayout = new QVBoxLayout();
+    mainLayout->addLayout(formLayout);
+
+    d->developerModeCheckBox = new QCheckBox("Enable developer mode");
+    formLayout->addRow(d->developerModeCheckBox);
+
+    QLabel* label = new QLabel("<em>Enabling developer mode will make various "
+                               "development-specific options visible throughout "
+                               "the application.</em>");
+    formLayout->addRow(label);
+
+    setLayout(mainLayout);
+}
+
+bool medDevelopmentSettingsWidget::write()
+{
+    medSettingsManager::instance().setValue("development", "developer_mode", d->developerModeCheckBox->isChecked());
+    return true;
+}
+
+void medDevelopmentSettingsWidget::read()
+{
+    d->developerModeCheckBox->setChecked(medSettingsManager::instance().value("development", "developer_mode").toBool());
+}
+
+bool medDevelopmentSettingsWidget::validate()
+{
+    return true;
+}

--- a/src/layers/legacy/medCoreLegacy/gui/settingsWidgets/medDevelopmentSettingsWidget.h
+++ b/src/layers/legacy/medCoreLegacy/gui/settingsWidgets/medDevelopmentSettingsWidget.h
@@ -1,0 +1,37 @@
+#pragma once
+
+/*==============================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2024. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+==============================================================================*/
+
+#include <medCoreLegacyExport.h>
+#include <medSettingsWidget.h>
+
+class medDevelopmentSettingsWidgetPrivate;
+
+class MEDCORELEGACY_EXPORT medDevelopmentSettingsWidget : public medSettingsWidget
+{
+    Q_OBJECT
+    MED_SETTINGS_INTERFACE("Development", "Development Settings")
+
+public:
+    medDevelopmentSettingsWidget(QWidget* parent = nullptr);
+
+    virtual bool write();
+
+public slots:
+    virtual void read();
+    virtual bool validate();
+
+private:
+    medDevelopmentSettingsWidgetPrivate *d;
+};


### PR DESCRIPTION
This PR adds a settings tab intended for developers.  Activating the option can make various functions and info visible in the application that would be useful for developers but confusing for normal users.