### PR TITLE
Use DICOM UIDs to identify patients and studies

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseNonPersistentImporter.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseNonPersistentImporter.cpp
@@ -89,7 +89,13 @@ medDataIndex medDatabaseNonPersistentImporter::populateDatabaseAndGenerateThumbn
     QString birthdate = medMetaDataKeys::BirthDate.getFirstValue(data);
 
     // check if patient is already in the persistent database
-    medDataIndex databaseIndex = medDataManager::instance().controller()->indexForPatient(patientName);
+    medDataIndex databaseIndex = medDataManager::instance().controller()->indexForPatientID(patientId);
+
+    if (!databaseIndex.isValidForPatient())
+    {
+        databaseIndex = medDataManager::instance().controller()->indexForPatient(patientName);
+    }
+
     medDatabaseNonPersistentItem *patientItem = nullptr;
 
     if ( databaseIndex.isValid() )
@@ -101,8 +107,8 @@ medDataIndex medDatabaseNonPersistentImporter::populateDatabaseAndGenerateThumbn
     {
         // check if patient is already in the non persistent database
         for ( int i=0; i<items.count(); i++ )
-            //if ( items[i]->name() ==patientName )
-            if ( medMetaDataKeys::PatientName.getFirstValue(items[i]->data()) == patientName )
+            if ((!patientId.isEmpty() && medMetaDataKeys::PatientID.getFirstValue(items[i]->data()) == patientId)
+                || medMetaDataKeys::PatientName.getFirstValue(items[i]->data()) == patientName)
             {
                 patientDbId = items[i]->index().patientId();
                 patientItem = items[i];

--- a/src/layers/legacy/medCoreLegacy/database/medDatabasePersistentController.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabasePersistentController.cpp
@@ -326,6 +326,35 @@ medDataIndex medDatabasePersistentController::indexForPatient(
     return medDataIndex();
 }
 
+medDataIndex medDatabasePersistentController::indexForPatientID(const QString& patientId)
+{
+    medDataIndex dataIndex;
+
+    if (!patientId.isEmpty())
+    {
+        QSqlDatabase dbConnection = getThreadSpecificConnection();
+        QSqlQuery query(dbConnection);
+
+        query.prepare("SELECT id FROM patient WHERE patientId = :patientId");
+        query.bindValue(":patientId", patientId);
+
+        QMutexLocker mutexLocker(&getDatabaseMutex());
+
+        if (!execQuery(query, __FILE__, __LINE__))
+        {
+            qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
+        }
+
+        if (query.first())
+        {
+            QVariant patientDbId = query.value(0);
+            dataIndex = medDataIndex::makePatientIndex(this->dataSourceId(), patientDbId.toInt());
+        }
+    }
+
+    return dataIndex;
+}
+
 medDataIndex medDatabasePersistentController::indexForStudy(int id)
 {
     QSqlDatabase dbConnection = getThreadSpecificConnection();

--- a/src/layers/legacy/medCoreLegacy/database/medDatabasePersistentController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabasePersistentController.h
@@ -43,6 +43,7 @@ public:
     medDataIndex indexForSeries(int id);
 
     medDataIndex indexForPatient(const QString &patientName);
+    medDataIndex indexForPatientID(const QString &patientId);
     medDataIndex indexForStudy(const QString &patientName,
                                const QString &studyName);
     medDataIndex indexForStudyUID(const QString &patientName,


### PR DESCRIPTION
When importing new data medInria uses the patient name, patient birthdate and study name to identify existing patients or studies. It should be using uids instead. This causes issues with data for which these fields are empty. This PR modifies the algorithm so that the patient and study uids are used in addition to the previous tags so as to handle all cases and be retrocompatible.