### PR TITLE
Remove BUILD_ALWAYS from external projects

### DIFF
--- a/superbuild/projects_modules/DCMTK.cmake
+++ b/superbuild/projects_modules/DCMTK.cmake
@@ -115,7 +115,6 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 1
   )
 
 ## #############################################################################

--- a/superbuild/projects_modules/ITK.cmake
+++ b/superbuild/projects_modules/ITK.cmake
@@ -99,7 +99,6 @@ ExternalProject_Add(${ep}
   CMAKE_CACHE_ARGS ${cmake_cache_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 1
   )
 
 ## #############################################################################

--- a/superbuild/projects_modules/LogDemons.cmake
+++ b/superbuild/projects_modules/LogDemons.cmake
@@ -94,7 +94,6 @@ ExternalProject_Add(${ep}
   CMAKE_CACHE_ARGS ${cmake_cache_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 1
   )
   
 ## #############################################################################

--- a/superbuild/projects_modules/QtDCM.cmake
+++ b/superbuild/projects_modules/QtDCM.cmake
@@ -104,7 +104,6 @@ ExternalProject_Add(${ep}
   CMAKE_CACHE_ARGS ${cmake_cache_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 1
   )  
 
 ## #############################################################################

--- a/superbuild/projects_modules/RPI.cmake
+++ b/superbuild/projects_modules/RPI.cmake
@@ -94,7 +94,6 @@ ExternalProject_Add(${ep}
   CMAKE_CACHE_ARGS ${cmake_cache_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 0
   ) 
   
 ## #############################################################################

--- a/superbuild/projects_modules/TTK.cmake
+++ b/superbuild/projects_modules/TTK.cmake
@@ -95,7 +95,6 @@ ExternalProject_Add(${ep}
   CMAKE_CACHE_ARGS ${cmake_cache_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 1
   )
  
 ## #############################################################################

--- a/superbuild/projects_modules/VTK.cmake
+++ b/superbuild/projects_modules/VTK.cmake
@@ -166,7 +166,6 @@ ExternalProject_Add(${ep}
   CMAKE_CACHE_ARGS ${cmake_cache_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 1
   )
   
 ## #############################################################################

--- a/superbuild/projects_modules/dtk.cmake
+++ b/superbuild/projects_modules/dtk.cmake
@@ -105,7 +105,6 @@ ExternalProject_Add(${ep}
   CMAKE_CACHE_ARGS ${cmake_cache_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 1
   )
 
 ## #############################################################################

--- a/superbuild/projects_modules/dtkImaging.cmake
+++ b/superbuild/projects_modules/dtkImaging.cmake
@@ -94,7 +94,6 @@ ExternalProject_Add(${ep}
   CMAKE_CACHE_ARGS ${cmake_cache_args}
   DEPENDS ${${ep}_dependencies}
   INSTALL_COMMAND ""
-  BUILD_ALWAYS 1
   )
 
 ## #############################################################################


### PR DESCRIPTION
The `BUILD_ALWAYS` option is not needed unless the sources are manually modified in the project (so only for medInria). Removing it avoids unnecessary recompilations when making changes to the superbuild.