### PR TITLE
debug medInria core

### DIFF
--- a/src/app/medInria/main.cpp
+++ b/src/app/medInria/main.cpp
@@ -293,7 +293,6 @@ int main(int argc, char *argv[])
 
         auto notifBanner = static_cast<medNotificationPaneWidget*>(medNotifSysPresenter(notifSys).buildNotificationWindow());
         notifBanner->setParent(mainwindow);
-        QObject::connect(mainwindow, &medMainWindow::resized, notifBanner, &medNotificationPaneWidget::windowGeometryUpdate);
         QObject::connect(mainwindow->notifButton(), &QToolButton::clicked, notifBanner, &medNotificationPaneWidget::swithVisibility);
 
         mainwindow->setAttribute(Qt::WA_DeleteOnClose, true);

--- a/src/app/medInria/medMainWindow.cpp
+++ b/src/app/medInria/medMainWindow.cpp
@@ -158,7 +158,6 @@ medMainWindow::medMainWindow ( QWidget *parent ) : QMainWindow ( parent ), d ( n
     auto * notifSys = medApplicationContext::instance()->getNotifSys();
     d->notifWindow = static_cast<medNotificationPaneWidget*>(medNotifSysPresenter(notifSys).buildNotificationWindow());
     d->notifWindow->setParent(this);
-    QObject::connect(this, &medMainWindow::resized, d->notifWindow, &medNotificationPaneWidget::windowGeometryUpdate);
     QObject::connect(d->notifWindow, &medNotificationPaneWidget::expanded, medApplicationContext::instance()->getApp(), &medApplication::listenClick);
     QObject::connect(medApplicationContext::instance()->getApp(), &medApplication::mouseGlobalClick, d->notifWindow, &medNotificationPaneWidget::clicked);
 
@@ -1257,6 +1256,11 @@ bool medMainWindow::event(QEvent * e)
         break;
     } ;
     return QMainWindow::event(e) ;
+}
+
+void medMainWindow::resizeEvent(QResizeEvent *event)
+{
+    d->notifWindow->windowGeometryUpdate(this->size());
 }
 
 void medMainWindow::adjustContainersSize()

--- a/src/app/medInria/medMainWindow.h
+++ b/src/app/medInria/medMainWindow.h
@@ -203,6 +203,7 @@ protected:
     void closeEvent(QCloseEvent *event);
     void mousePressEvent(QMouseEvent * event);
     bool event(QEvent * e);
+    void resizeEvent(QResizeEvent *event);
     void dragEnterEvent(QDragEnterEvent *event);
     void dragLeaveEvent(QDragLeaveEvent *event);
     void dragMoveEvent(QDragMoveEvent *event);

--- a/src/layers/medCore/parameter/medStringParameter.cpp
+++ b/src/layers/medCore/parameter/medStringParameter.cpp
@@ -13,6 +13,8 @@
 
 #include <medStringParameter.h>
 
+#include <QLineEdit>
+
 class medStringParameterPrivate
 {
 public:
@@ -51,7 +53,13 @@ bool medStringParameter::copyValueTo(medAbstractParameter & dest)
 
 bool medStringParameter::setValue( QString const& value)
 {
+    QLineEdit *line = qobject_cast<QLineEdit*>(QObject::sender());
+
     bool bRes = true;
+    
+    int cursorPos;
+    if(line)
+        cursorPos = line->cursorPosition();
 
     if(value != d->value)
     {
@@ -64,6 +72,9 @@ bool medStringParameter::setValue( QString const& value)
           emit valueChanged(d->value);
        }
     }
+
+    if(line)
+        line->setCursorPosition(cursorPos);
 
     return bRes;
 }

--- a/src/layers/medCoreGui/notification/widgets/medNotifWindow.cpp
+++ b/src/layers/medCoreGui/notification/widgets/medNotifWindow.cpp
@@ -154,9 +154,9 @@ void medNotificationPaneWidget::showPane(bool show)
     emit expanded(show);
 }
 
-void medNotificationPaneWidget::windowGeometryUpdate(QRect const & geo)
+void medNotificationPaneWidget::windowGeometryUpdate(QSize const & size)
 {
-    m_winSize = geo.size();
+    m_winSize = size;
     if (width())
     {
         int statusBarHeight = 0;

--- a/src/layers/medCoreGui/notification/widgets/medNotifWindow.h
+++ b/src/layers/medCoreGui/notification/widgets/medNotifWindow.h
@@ -38,7 +38,7 @@ public slots:
     void addNotification(medUsrNotif notif);
 
     void showPane(bool show);
-    void windowGeometryUpdate(QRect const & geo);
+    void windowGeometryUpdate(QSize const & size);
     void showAndHigligth(medUsrNotif notif);
     void swithVisibility();
 

--- a/src/layers/medCoreGui/parameter/medStringParameterPresenter.cpp
+++ b/src/layers/medCoreGui/parameter/medStringParameterPresenter.cpp
@@ -185,7 +185,7 @@ QWidget * medStringParameterPresenter::buildLineEditFileImport()
     auto *pParam = d->parameter;
     connect(searchButton, &QPushButton::clicked, [=]()
     {
-        QString sourceFile = QFileDialog::getOpenFileName(nullptr, tr("Select JSON file with filtering DICOM keys"), QDir::homePath(), tr("JSON file (*.json)"));
+        QString sourceFile = QFileDialog::getOpenFileName(nullptr, pParam->caption(), QDir::homePath(), tr("JSON file (*.json)"));
         if(!sourceFile.isEmpty()){
             displayPath->setText(QDir::toNativeSeparators(sourceFile));
             pParam->setValue(displayPath->text());

--- a/src/layers/medCoreGui/source/medSourceModelPresenter.cpp
+++ b/src/layers/medCoreGui/source/medSourceModelPresenter.cpp
@@ -63,6 +63,8 @@ QTreeView * medSourceModelPresenter::buildTree(QSortFilterProxyModel *proxy)
 //    treeViewRes->setStyleSheet("QTreeView::item:selection{background-color:transparent}");
     treeViewRes->setItemDelegateForColumn(0, new medSourcesItemDelegate(treeViewRes));
 
+    connect(model, &QObject::destroyed, treeViewRes, &QObject::deleteLater);
+
     return treeViewRes;
 }
 

--- a/src/layers/medCoreGui/source/settings/widgets/medSourceSettingsWidget.cpp
+++ b/src/layers/medCoreGui/source/settings/widgets/medSourceSettingsWidget.cpp
@@ -277,15 +277,18 @@ bool medSourceSettingsWidget::eventFilter(QObject * watched, QEvent * event)
 
 void medSourceSettingsWidget::currentItemChanged(QListWidgetItem * current, QListWidgetItem * previous)
 {
-    auto *pListWidget = current->listWidget();
-    if (pListWidget->itemWidget(current) == this)
+    if(current)
     {
-        m_sourceSelected = true;
-        repaint();
-    }
-    else if (pListWidget->itemWidget(previous) == this)
-    {
-        m_sourceSelected = false;
-        repaint();
+        auto *pListWidget = current->listWidget();
+        if (pListWidget->itemWidget(current) == this)
+        {
+            m_sourceSelected = true;
+            repaint();
+        }
+        else if (pListWidget->itemWidget(previous) == this)
+        {
+            m_sourceSelected = false;
+            repaint();
+        }
     }
 }

--- a/src/layers/medCoreGui/source/settings/widgets/medSourcesSettings.cpp
+++ b/src/layers/medCoreGui/source/settings/widgets/medSourcesSettings.cpp
@@ -178,6 +178,11 @@ void medSourcesSettings::createSource()
     {
         qDebug()<<"A problem occurred creating a new source.";
     }
+
+    if(m_sourceToItem.size() == 1)
+    {
+        emit createdSource();
+    }
 }
 
 /**

--- a/src/layers/medCoreGui/source/settings/widgets/medSourcesSettings.cpp
+++ b/src/layers/medCoreGui/source/settings/widgets/medSourcesSettings.cpp
@@ -181,7 +181,7 @@ void medSourcesSettings::createSource()
 
     if(m_sourceToItem.size() == 1)
     {
-        emit createdSource();
+        emit firstCreatedSource();
     }
 }
 

--- a/src/layers/medCoreGui/source/settings/widgets/medSourcesSettings.h
+++ b/src/layers/medCoreGui/source/settings/widgets/medSourcesSettings.h
@@ -71,7 +71,7 @@ protected:
     QWidget * createConfPathWidget();
 
 signals:
-    void createdSource();
+    void firstCreatedSource();
     
 private:
     //Data

--- a/src/layers/medCoreGui/source/settings/widgets/medSourcesSettings.h
+++ b/src/layers/medCoreGui/source/settings/widgets/medSourcesSettings.h
@@ -69,6 +69,9 @@ public:
 protected:
     void updateSelectedSourceDescription(int pi_index);
     QWidget * createConfPathWidget();
+
+signals:
+    void createdSource();
     
 private:
     //Data

--- a/src/layers/medCoreGui/source/settings/widgets/medSourcesSettingsHandlerWidget.cpp
+++ b/src/layers/medCoreGui/source/settings/widgets/medSourcesSettingsHandlerWidget.cpp
@@ -68,6 +68,11 @@ medSourcesSettingsHandlerWidget::medSourcesSettingsHandlerWidget(medSourcesSetti
     connect(m_setDefaultButton, &QPushButton::clicked, pi_parent, &medSourcesSettings::setAsDefault); // Change default source
     connect(m_removeButton,     &QPushButton::clicked, pi_parent, &medSourcesSettings::removeSource); // Ask to remove source
     connect(m_connectButton, &QPushButton::clicked, pi_parent, &medSourcesSettings::updateSourceConnection); 
+
+    connect(pi_parent, &medSourcesSettings::createdSource, [&]
+    {
+        m_connectButton->setDisabled(false);
+    });
 }
 
 /**

--- a/src/layers/medCoreGui/source/settings/widgets/medSourcesSettingsHandlerWidget.cpp
+++ b/src/layers/medCoreGui/source/settings/widgets/medSourcesSettingsHandlerWidget.cpp
@@ -69,7 +69,7 @@ medSourcesSettingsHandlerWidget::medSourcesSettingsHandlerWidget(medSourcesSetti
     connect(m_removeButton,     &QPushButton::clicked, pi_parent, &medSourcesSettings::removeSource); // Ask to remove source
     connect(m_connectButton, &QPushButton::clicked, pi_parent, &medSourcesSettings::updateSourceConnection); 
 
-    connect(pi_parent, &medSourcesSettings::createdSource, [&]
+    connect(pi_parent, &medSourcesSettings::firstCreatedSource, [&]
     {
         m_connectButton->setDisabled(false);
     });

--- a/src/layers/medCoreGui/source/widgets/medSourcesItemDelegate.cpp
+++ b/src/layers/medCoreGui/source/widgets/medSourcesItemDelegate.cpp
@@ -32,10 +32,13 @@ void medSourcesItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem
         else if (value == DATASTATE_ROLE_DATALOADED)
         {
             auto list = m_treeView->selectionModel()->selectedIndexes();
-            if (list[0] == index)
-                m_treeView->setStyleSheet("QTreeView { selection-color: #0EBFEF;}");
-            else
-                m_treeView->setStyleSheet("QTreeView { selection-color: #FF8833;}");
+            if(!list.empty())
+            {
+                if (list[0] == index)
+                    m_treeView->setStyleSheet("QTreeView { selection-color: #0EBFEF;}");
+                else
+                    m_treeView->setStyleSheet("QTreeView { selection-color: #FF8833;}");
+            }
             opt.font.setBold(true);
             painter->drawPixmap(QRect(opt.rect.x()-40, opt.rect.y(), opt.decorationSize.width(), opt.rect.height()), QPixmap(":icons/icons8-download-16.png"));//QPixmap(":icons/yellow_spot.svg"));
         }


### PR DESCRIPTION
- medSourcesItemDelegate : fixed segmentation fault error caused by protocol change with medPACS plugin 
- medSourcesSettings et medSourcesSettingsHandlerWidget : added a signal for the creation of a first instance of any plugin to activate the 'connect' button display
- medSourceSettingsWidget : fixed segmentation fault caused by deleting all plugin instances
- medSourceModelPresenter and medDataHubPresenter : fixed problem displaying a newly created instance in the Browser: list of instances + display of instance data
- medStringParameterPresenter : change the dialog window name of buildLineEditFileImport to make this representation a case for reuse
- medStringParameter : change the medStringParameter cursor position to remain at the position of the last modification
- medMainWindow, medNotifWindow and main : add a main window resizeEvent to update size of the notif window + signature modification