### PR TITLE
[Release3.4] add info about Anima plugins in release notes

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,5 +1,5 @@
 medInria 3.4:
-- INFORMATION: this version of medInria is NOT packaged with Anima plugins. We apologize for the inconvenience, we're working on adding them in a future release.
+- INFORMATION: this version of medInria is NOT packaged with Anima plugins. We apologize for the inconvenience, we're working on adding them in a near release.
 - Fix an incorrect zoom for some data displayed in a view. The zoom is now calculated with x and y dims, and not z
 - N4 Bias Correction process can stop now if the user wants to quit the application, it will stop at some algorithm checkpoints
 - Reslice toolbox: changing the dimension of spacing parameters does not zoom one of the views

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,4 +1,5 @@
 medInria 3.4:
+- INFORMATION: this version of medInria is NOT packaged with Anima plugins. We apologize for the inconvenience, we're working on adding them in a future release.
 - Fix an incorrect zoom for some data displayed in a view. The zoom is now calculated with x and y dims, and not z
 - N4 Bias Correction process can stop now if the user wants to quit the application, it will stop at some algorithm checkpoints
 - Reslice toolbox: changing the dimension of spacing parameters does not zoom one of the views


### PR DESCRIPTION
Due to changes in anima plugins management, and waiting for futur changes in medInria 4 changing the way plugins are handled, Anima plugins are temporarily removed from medInria.

This PR adds a mention about it in the release notes.

:m: