### PR TITLE
[Compilation] morphomath_operation ITK modules

### DIFF
--- a/src/plugins/process/morphomath_operation/CMakeLists.txt
+++ b/src/plugins/process/morphomath_operation/CMakeLists.txt
@@ -63,7 +63,7 @@ target_include_directories(${TARGET_NAME}
 ## #############################################################################
 
 target_link_libraries(${TARGET_NAME}
-  ITKCommon
+  ITKMathematicalMorphology
   Qt5::Core
   dtkCore
   dtkLog


### PR DESCRIPTION
In order to compile dev branch on macOS and Windows (with VS 2022), we need to add the right ITK module in morphomath_operation plugin.