### PR TITLE
Notification widget bug and minor compilation issue

### DIFF
--- a/src/layers/medCoreGui/notification/widgets/medNotifWindow.cpp
+++ b/src/layers/medCoreGui/notification/widgets/medNotifWindow.cpp
@@ -114,6 +114,7 @@ void medNotificationPaneWidget::addNotification(medUsrNotif notif)
     QGraphicsOpacityEffect * show_effect = new QGraphicsOpacityEffect(newNotifiWidgetPopup);
     show_effect->setOpacity(1);
     m_alphaAnimation = new QPropertyAnimation(show_effect, "opacity");
+    connect(m_alphaAnimation, &QPropertyAnimation::finished, newNotifiWidgetPopup, &QObject::deleteLater);
     newNotifiWidgetPopup->setGraphicsEffect(show_effect);
     m_alphaAnimation->setStartValue(1);
     m_alphaAnimation->setEndValue(0);

--- a/src/plugins/legacy/medShanoir/internal/Levels.h
+++ b/src/plugins/legacy/medShanoir/internal/Levels.h
@@ -113,7 +113,7 @@ struct StudyDetails
 template <typename T> 
 static inline auto findLevelElement(const QList<T> &levels, int id)
 {
-    QList<typename T>::const_iterator it;
+    typename QList<T>::const_iterator it;
     it = std::find_if(levels.begin(), levels.end(), [id](const T& level) 
     {
         return level.id == id;


### PR DESCRIPTION
When the notification popup fades out it is not destroyed. This prevents the user from using the mouse on the area where the popup is still present (but invisible).
(I also fixed a minor compilation issue I encountered while testing testing bug)