### PR TITLE
[Notifications] fix multiple size problems

### DIFF
--- a/src/app/medInria/main.cpp
+++ b/src/app/medInria/main.cpp
@@ -264,7 +264,7 @@ int main(int argc, char *argv[])
 
         auto notifBanner = static_cast<medNotificationPaneWidget*>(medNotifSysPresenter(notifSys).buildNotificationWindow());
         notifBanner->setParent(mainwindow);
-        QObject::connect(mainwindow->notifButton(), &QToolButton::clicked, notifBanner, &medNotificationPaneWidget::swithVisibility);
+        QObject::connect(mainwindow->notifButton(), &QToolButton::clicked, notifBanner, &medNotificationPaneWidget::switchVisibility);
 
         mainwindow->setAttribute(Qt::WA_DeleteOnClose, true);
 

--- a/src/app/medInria/medMainWindow.cpp
+++ b/src/app/medInria/medMainWindow.cpp
@@ -452,7 +452,7 @@ void medMainWindow::switchToDefaultWorkSpace()
 
 void medMainWindow::toggleNotificationPanel()
 {
-    d->notifWindow->swithVisibility();
+    d->notifWindow->switchVisibility();
 }
 
 /**
@@ -617,12 +617,6 @@ void medMainWindow::onShowDataSources()
     dialog->setLayout(layout);
     dialog->exec();
 }
-
-
-//void medMainWindow::onShowNotifPanel()
-//{
-//    d->notifWindow->swithVisibility();
-//}
 
 void medMainWindow::onShowAbout()
 {
@@ -1270,9 +1264,14 @@ bool medMainWindow::event(QEvent * e)
     return QMainWindow::event(e) ;
 }
 
+/**
+ * @brief Run after application resize through resize buttons.
+ * 
+ * @param event 
+ */
 void medMainWindow::resizeEvent(QResizeEvent *event)
 {
-    d->notifWindow->windowGeometryUpdate(this->size());
+    d->notifWindow->windowGeometryUpdate();
 }
 
 void medMainWindow::adjustContainersSize()

--- a/src/app/medInria/medMainWindow.h
+++ b/src/app/medInria/medMainWindow.h
@@ -125,14 +125,12 @@ private slots:
 
     void open_waitForImportedSignal(medDataIndex,QUuid);
 
-
     void openFromSystem();
     void openDicomFromSystem();
     void setSourceVisibility(bool checked);
     
     void onShowBrowser();
     void onShowDataSources();
-    //void onShowNotifPanel();
     void onShowHelp();
 
     /**

--- a/src/layers/medCore/source/medDataHub.cpp
+++ b/src/layers/medCore/source/medDataHub.cpp
@@ -287,7 +287,7 @@ medAbstractData * medDataHub::getData(medDataIndex const & index)
     }
     else
     {
-        bool bOnline, bWritable, bLocal, bCache;   
+        bool bOnline, bWritable, bLocal, bCache;
         QString sourceId = index.sourceId();
         if (sourceId == "fs") 
         {
@@ -306,7 +306,8 @@ medAbstractData * medDataHub::getData(medDataIndex const & index)
         }
         else
         {
-            medNotif::createNotif(notifLevel::error, "Data can't be retrieved", QString("Unable to retrieve data from source ") + sourceId + QString(" for data index ") + index.asString());
+            medNotif::createNotif(notifLevel::error, "Data can't be retrieved",
+                QString("Unable to retrieve data from source ") + sourceId + QString(" for data index ") + index.asString());
         }
     }
 
@@ -720,9 +721,8 @@ bool medDataHub::writeResults(QString pi_sourceId, medAbstractData * pi_pData, Q
     }
     // ////////////////////////////////////////////////////////////////////////////////////////
 
-
     // ////////////////////////////////////////////////////////////////////////////////////////
-    // Check la coherence de la proposition par rapport a l'URI
+    // Check consistency of the proposal with URI
     auto limite = std::min(originPath.size(), sugestedPath.size());
     for (int i = 0; i < limite; ++i)
     {
@@ -1275,12 +1275,10 @@ medAbstractData * medDataHub::loadDataFromPathAsIndex(medDataIndex index, QUuid 
         return pDataRes;
     }
     QString path = indexToFileSysPath(index.asString());
-    std::shared_ptr<medNotif> notif = medNotif::createNotif(notifLevel::info , QString("Load File ") + path, " from local file system", -1, -1);
+    std::shared_ptr<medNotif> notif = medNotif::createNotif(notifLevel::info , QString("Load File ") + QFileInfo(path).fileName(), " from local file system", -1, -1);
     medAbstractData * pDataRes = medDataImporter::convertSingleDataOnfly(path);
     if (pDataRes)
     {
-        // QString index = fileSysPathToIndex(path);
-
         pDataRes->setDataIndex(index);
 
         m_IndexToData[index] = pDataRes;
@@ -1296,7 +1294,6 @@ medAbstractData * medDataHub::loadDataFromPathAsIndex(medDataIndex index, QUuid 
     else
     {
         notif->update(notifLevel::warning, -2, QString("Failure"));
-        // medNotif::createNotif(notifLevel::warning, QString("Converting file ") + path, " failed");
     }
     return pDataRes;
 }

--- a/src/layers/medCoreGui/notification/widgets/medNotifWidget.cpp
+++ b/src/layers/medCoreGui/notification/widgets/medNotifWidget.cpp
@@ -60,6 +60,7 @@ medNotifWidget::medNotifWidget(medUsrNotif &notif, medNotificationPaneWidget * p
     widgetLayout->addLayout(m_titleLayout);
     
     m_msgLabel = new QLabel(notif->getMessage());
+    m_msgLabel->setWordWrap(true);
     widgetLayout->addWidget(m_msgLabel);
 
     m_progressWidget = new QProgressBar();

--- a/src/layers/medCoreGui/notification/widgets/medNotifWindow.h
+++ b/src/layers/medCoreGui/notification/widgets/medNotifWindow.h
@@ -29,19 +29,17 @@ public:
     medNotificationPaneWidget(medNotifSys * pi_pNotification, QMainWindow *pi_parent = nullptr);
     ~medNotificationPaneWidget() = default;
 
-    void setParent(QMainWindow *pi_parent); 
+    void setParent(QMainWindow *pi_parent);
+    void paintEvent(QPaintEvent *event);
 
 public slots:
     void notifWidgetAskDeletion(medUsrNotif notif);
     void removeNotification(medUsrNotif notif);
-
     void addNotification(medUsrNotif notif);
-
     void showPane(bool show);
-    void windowGeometryUpdate(QSize const & size);
+    void windowGeometryUpdate();
     void showAndHigligth(medUsrNotif notif);
-    void swithVisibility();
-
+    void switchVisibility();
     void clicked(QPoint);
 
 signals:
@@ -59,4 +57,5 @@ private:
     QPropertyAnimation                * m_alphaAnimation;
     QMainWindow                       * m_parent;
     QSize                               m_winSize;
+    bool                                isDisplayed;
 };


### PR DESCRIPTION
This PR:
 * fixes height problem, now it ends at the application bottom
 * refreshes size at application resize (buttons or manually)
 * fixes width problem with long text (word wrap)
 * fixes width problem with widget title: display name of the loaded file, and not the path

:m: