### PR TITLE
[Registration] cast data in LCC and Diffeo, enhance txt in Manual

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -24,8 +24,8 @@ medInria 4.0:
 - Fix some plugins wrongly loaded on Windows.
 - BUGFIX 4.0.1:
     * Fix the path to the online documentation.
-    * Allow to use data with different size or spasing in LCCLogDemons and DiffeomorphicDemons.
-    * Manual Registration: enhance landmarks numbers for better user understanding.
+    * Allow to use data with different size or spacing in LCCLogDemons and DiffeomorphicDemons.
+    * Manual Registration: enhance landmark numbers for better user understanding.
     * Fix Histogram Analysis width problem displaying multi-results.
 
 medInria 3.3:

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -22,7 +22,11 @@ medInria 4.0:
 - Switch to Ubuntu 22.
 - PolygonROI: update icons, fix a glitch when users change ROI label, hide label panel in pipelines.
 - Fix some plugins wrongly loaded on Windows.
-- BUGFIX 4.0.1: fix the path to the online documentation.
+- BUGFIX 4.0.1:
+    * Fix the path to the online documentation.
+    * Allow to use data with different size or spasing in LCCLogDemons and DiffeomorphicDemons.
+    * Manual Registration: enhance landmarks numbers for better user understanding.
+    * Fix Histogram Analysis width problem displaying multi-results.
 
 medInria 3.3:
 - Fix mirrored DICOM images problem

--- a/src/plugins/legacy/LCCLogDemons/LCCLogDemons.cpp
+++ b/src/plugins/legacy/LCCLogDemons/LCCLogDemons.cpp
@@ -19,7 +19,6 @@
 // /////////////////////////////////////////////////////////////////
 
 #include <itkImageRegistrationMethod.h>
-
 #include <itkImage.h>
 #include <itkResampleImageFilter.h>
 #include <itkCastImageFilter.h>
@@ -167,17 +166,24 @@ QString LCCLogDemons::description() const
 template <typename PixelType>
 int LCCLogDemonsPrivate::update()
 {
-    int testResult = proc->testInputs();
-    if (testResult != medAbstractProcessLegacy::SUCCESS)
-    {
-        return testResult;
-    }
+    RegImageType *inputFixed  = (RegImageType*) proc->fixedImage().GetPointer();
+    RegImageType *inputMoving = (RegImageType*) proc->movingImages()[0].GetPointer();
 
+    // Cast spacing, origin, direction and size from the moving data to the fixed one
+    typedef itk::ResampleImageFilter<RegImageType, RegImageType> ResampleFilterType;
+    typename ResampleFilterType::Pointer resampleFilter = ResampleFilterType::New();
+    resampleFilter->SetOutputSpacing(inputFixed->GetSpacing());
+    resampleFilter->SetOutputOrigin(inputFixed->GetOrigin());
+    resampleFilter->SetOutputDirection(inputFixed->GetDirection());
+    resampleFilter->SetSize(inputFixed->GetLargestPossibleRegion().GetSize());
+    resampleFilter->SetInput(inputMoving);
+    resampleFilter->Update();
+    inputMoving = resampleFilter->GetOutput();
+
+    // Register the fixed and moving data
     registrationMethod = new rpi::LCClogDemons<RegImageType,RegImageType,double> ();
-
-    registrationMethod->SetFixedImage((const RegImageType*) proc->fixedImage().GetPointer());
-    registrationMethod->SetMovingImage((const RegImageType*) proc->movingImages()[0].GetPointer());
-
+    registrationMethod->SetFixedImage(inputFixed);
+    registrationMethod->SetMovingImage(inputMoving);
     registrationMethod->SetUpdateRule(updateRule);
     registrationMethod->SetVerbosity(verbose);
 
@@ -219,12 +225,8 @@ int LCCLogDemonsPrivate::update()
     typedef itk::ResampleImageFilter< RegImageType,RegImageType, double> ResampleFilterType;
     typename ResampleFilterType::Pointer resampler = ResampleFilterType::New();
     resampler->SetTransform(registrationMethod->GetDisplacementFieldTransformation());
-    resampler->SetInput((const RegImageType*)proc->movingImages()[0].GetPointer());
-    resampler->SetSize( proc->fixedImage()->GetLargestPossibleRegion().GetSize() );
-    resampler->SetOutputOrigin( proc->fixedImage()->GetOrigin() );
-    resampler->SetOutputSpacing( proc->fixedImage()->GetSpacing() );
-    resampler->SetOutputDirection( proc->fixedImage()->GetDirection() );
-    resampler->SetDefaultPixelValue( 0 );
+    resampler->SetInput(inputMoving);
+    resampler->SetDefaultPixelValue(0);
     
     // Set the image interpolator
     switch(interpolatorType)
@@ -266,31 +268,11 @@ int LCCLogDemonsPrivate::update()
         qDebug() << "ExceptionObject caught (resampler): " << err.GetDescription();
         return medAbstractProcessLegacy::FAILURE;
     }
-    
-    itk::ImageBase<3>::Pointer result = resampler->GetOutput();
-    result->DisconnectPipeline();
-    
+
     if (proc->output())
     {
-        proc->output()->setData (result);
+        proc->output()->setData(resampler->GetOutput());
     }
-    return medAbstractProcessLegacy::SUCCESS;
-}
-
-medAbstractProcessLegacy::DataError LCCLogDemons::testInputs()
-{
-    if (d->proc->fixedImage()->GetLargestPossibleRegion().GetSize()
-            != d->proc->movingImages()[0]->GetLargestPossibleRegion().GetSize())
-    {
-        return medAbstractProcessLegacy::MISMATCHED_DATA_SIZE;
-    }
-
-    if (d->proc->fixedImage()->GetSpacing()
-            != d->proc->movingImages()[0]->GetSpacing())
-    {
-        return medAbstractProcessLegacy::MISMATCHED_DATA_SPACING;
-    }
-
     return medAbstractProcessLegacy::SUCCESS;
 }
 

--- a/src/plugins/legacy/LCCLogDemons/LCCLogDemons.cpp
+++ b/src/plugins/legacy/LCCLogDemons/LCCLogDemons.cpp
@@ -166,8 +166,8 @@ QString LCCLogDemons::description() const
 template <typename PixelType>
 int LCCLogDemonsPrivate::update()
 {
-    RegImageType *inputFixed  = (RegImageType*) proc->fixedImage().GetPointer();
-    RegImageType *inputMoving = (RegImageType*) proc->movingImages()[0].GetPointer();
+    RegImageType *inputFixed  = static_cast<RegImageType*>(proc->fixedImage().GetPointer());
+    RegImageType *inputMoving = static_cast<RegImageType*>(proc->movingImages()[0].GetPointer());
 
     // Cast spacing, origin, direction and size from the moving data to the fixed one
     typedef itk::ResampleImageFilter<RegImageType, RegImageType> ResampleFilterType;

--- a/src/plugins/legacy/LCCLogDemons/LCCLogDemons.h
+++ b/src/plugins/legacy/LCCLogDemons/LCCLogDemons.h
@@ -69,11 +69,6 @@ public:
     */
     virtual QString getTitleAndParameters();
 
-    /**
-     * @brief testInputs() tests origin, dimension and spacing of the input
-     * @return medAbstractProcess::DataError according to the test result
-    */
-    medAbstractProcessLegacy::DataError testInputs();
 protected :
     /**
      * @brief

--- a/src/plugins/legacy/LCCLogDemons/LCCLogDemonsToolBox.cpp
+++ b/src/plugins/legacy/LCCLogDemons/LCCLogDemonsToolBox.cpp
@@ -53,14 +53,7 @@ public:
 LCCLogDemonsToolBox::LCCLogDemonsToolBox(QWidget *parent) : medAbstractSelectableToolBox(parent), d(new LCCLogDemonsToolBoxPrivate)
 {
     QWidget *widget = new QWidget(this);
-
     QVBoxLayout * layout = new QVBoxLayout();
-
-    QLabel *explanation = new QLabel("Drop 2 datasets with same size and spacing.\n");
-    explanation->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
-    explanation->setWordWrap(true);
-    explanation->setStyleSheet("font: italic");
-    layout->addWidget(explanation);
 
     // Standard parameters
     d->iterationsLine = new QLineEdit();

--- a/src/plugins/legacy/diffeomorphicDemons/diffeomorphicDemons.cpp
+++ b/src/plugins/legacy/diffeomorphicDemons/diffeomorphicDemons.cpp
@@ -96,8 +96,8 @@ int diffeomorphicDemonsPrivate::update()
     typedef itk::Image< float, 3 > RegImageType;
     typedef double TransformScalarType;
 
-    FixedImageType  *inputFixed  = (FixedImageType*)  proc->fixedImage().GetPointer();
-    MovingImageType *inputMoving = (MovingImageType*) proc->movingImages()[0].GetPointer();
+    FixedImageType  *inputFixed  = static_cast<FixedImageType*>(proc->fixedImage().GetPointer());
+    MovingImageType *inputMoving = static_cast<MovingImageType*>(proc->movingImages()[0].GetPointer());
 
     // Cast spacing, origin, direction and size from the moving data to the fixed one
     typedef itk::ResampleImageFilter<MovingImageType, MovingImageType> ResampleFilterType;

--- a/src/plugins/legacy/diffeomorphicDemons/diffeomorphicDemons.h
+++ b/src/plugins/legacy/diffeomorphicDemons/diffeomorphicDemons.h
@@ -138,12 +138,6 @@ public:
     */
     virtual QString getTitleAndParameters();
 
-    /**
-         * @brief testInputs() tests origin, dimension and spacing of the input
-         * @return medAbstractProcess::DataError according to the test result
-         */
-    medAbstractProcessLegacy::DataError testInputs();
-
 protected :
     /**
      * @brief Writes the transformation, in this case the displacement field,

--- a/src/plugins/legacy/diffeomorphicDemons/diffeomorphicDemonsToolBox.cpp
+++ b/src/plugins/legacy/diffeomorphicDemons/diffeomorphicDemonsToolBox.cpp
@@ -42,14 +42,7 @@ diffeomorphicDemonsToolBox::diffeomorphicDemonsToolBox(QWidget *parent)
     : medAbstractSelectableToolBox(parent), d(new diffeomorphicDemonsToolBoxPrivate)
 {
     QWidget *widget = new QWidget(this);
-
     QVBoxLayout *layout = new QVBoxLayout();
-
-    QLabel *explanation = new QLabel("Drop 2 datasets with same size and spacing.\n");
-    explanation->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
-    explanation->setWordWrap(true);
-    explanation->setStyleSheet("font: italic");
-    layout->addWidget(explanation);
 
     d->iterationsBox = new QLineEdit();
     d->iterationsBox->setText("15x10x5");

--- a/src/plugins/legacy/manualRegistration/manualRegistration.cpp
+++ b/src/plugins/legacy/manualRegistration/manualRegistration.cpp
@@ -165,7 +165,7 @@ template <typename PixelType, typename TransformType> int manualRegistrationPriv
     resampler->SetOutputOrigin( proc->fixedImage()->GetOrigin() );
     resampler->SetOutputSpacing( proc->fixedImage()->GetSpacing() );
     resampler->SetOutputDirection( proc->fixedImage()->GetDirection() );
-    resampler->SetDefaultPixelValue( 0 );
+    resampler->SetDefaultPixelValue(0);
 
     try
     {

--- a/src/plugins/legacy/manualRegistration/manualRegistration.cpp
+++ b/src/plugins/legacy/manualRegistration/manualRegistration.cpp
@@ -160,8 +160,8 @@ template <typename PixelType, typename TransformType> int manualRegistrationPriv
     typedef itk::ResampleImageFilter< MovingImageType,MovingImageType,TransformScalarType >    ResampleFilterType;
     typename ResampleFilterType::Pointer resampler = ResampleFilterType::New();
     resampler->SetTransform(transform);
-    resampler->SetInput((const MovingImageType*)proc->movingImages()[0].GetPointer());
-    resampler->SetSize( proc->fixedImage()->GetLargestPossibleRegion().GetSize() );
+    resampler->SetInput(static_cast<const MovingImageType*>(proc->movingImages()[0].GetPointer()));
+    resampler->SetSize(proc->fixedImage()->GetLargestPossibleRegion().GetSize());
     resampler->SetOutputOrigin( proc->fixedImage()->GetOrigin() );
     resampler->SetOutputSpacing( proc->fixedImage()->GetSpacing() );
     resampler->SetOutputDirection( proc->fixedImage()->GetDirection() );

--- a/src/plugins/legacy/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src/plugins/legacy/manualRegistration/manualRegistrationToolBox.cpp
@@ -70,9 +70,10 @@ manualRegistrationToolBox::manualRegistrationToolBox(QWidget *parent)
     d->b_startManualRegistration->setObjectName("startManualRegistrationButton");
 
     d->explanation = new QLabel("To add a landmark: \n\tShift + left mouse button\nTo remove a pair of landmarks: \n\tBackspace + left mouse button", widget);
+    d->explanation->setStyleSheet("font: italic");
 
-    d->numberOfLdInLeftContainer = new QLabel("Number of landmarks in left container: 0", widget);
-    d->numberOfLdInRightContainer = new QLabel("Number of landmarks in right container: 0", widget);
+    d->numberOfLdInLeftContainer = new QLabel("Number of landmarks in left container: <b>0</b>", widget);
+    d->numberOfLdInRightContainer = new QLabel("Number of landmarks in right container: <b>0</b>", widget);
 
     // Choice between transformations
     QHBoxLayout* transformationLayout = new QHBoxLayout;
@@ -564,8 +565,8 @@ void manualRegistrationToolBox::displayButtons(bool show)
 
 void manualRegistrationToolBox::updateGUI(int left, int right)
 {
-    d->numberOfLdInLeftContainer->setText( "Number of landmarks in left container: " + QString::number(left));
-    d->numberOfLdInRightContainer->setText("Number of landmarks in right container: " + QString::number(right));
+    d->numberOfLdInLeftContainer->setText(QString("Number of landmarks in left container: <b>%1</b>").arg(left));
+    d->numberOfLdInRightContainer->setText(QString("Number of landmarks in right container: <b>%1</b>").arg(right));
 
     if (left == right)
     {


### PR DESCRIPTION
From PR https://github.com/Inria-Asclepios/medInria-public/pull/861 on MUSICardio.

This PR enhances the Registration workspace:

 * LCC Log Demons and Diffeomorphic cast data before registering, instead of blocking if the inputs were not the same size, spacing, etc.
 * Manual Registration: users were not seeing so much the landmark number, this PR enhance the design of the text.

:m: