### PR TITLE
[vtkImageOrientedPointWidget] switch to modern vtk 9.3.1 use for windows

### DIFF
--- a/src/layers/legacy/medVtkInria/vtkWidgetsAddOn/vtkImageOrientedPointWidget.cxx
+++ b/src/layers/legacy/medVtkInria/vtkWidgetsAddOn/vtkImageOrientedPointWidget.cxx
@@ -1459,22 +1459,3 @@ void vtkImageOrientedPointWidget::SizeHandles()
   // TODO...
   return;
 }
-
-//----------------------------------------------------------------------------
-#ifndef VTK_LEGACY_REMOVE
-# ifdef VTK_WORKAROUND_WINDOWS_MANGLE
-#  undef SetProp
-void vtkImageOrientedPointWidget::SetPropA(vtkProp* prop)
-{
-  VTK_LEGACY_REPLACED_BODY(vtkImageOrientedPointWidget::SetProp, "VTK 5.0",
-                           vtkImageOrientedPointWidget::SetViewProp);
-  this->SetViewProp(prop);
-}
-void vtkImageOrientedPointWidget::SetPropW(vtkProp* prop)
-{
-  VTK_LEGACY_REPLACED_BODY(vtkImageOrientedPointWidget::SetProp, "VTK 5.0",
-                           vtkImageOrientedPointWidget::SetViewProp);
-  this->SetViewProp(prop);
-}
-# endif
-#endif

--- a/src/layers/legacy/medVtkInria/vtkWidgetsAddOn/vtkImageOrientedPointWidget.h
+++ b/src/layers/legacy/medVtkInria/vtkWidgetsAddOn/vtkImageOrientedPointWidget.h
@@ -178,20 +178,6 @@ public:
   // Is the path closed or open?
   int IsClosed();
 
-#ifdef VTK_WORKAROUND_WINDOWS_MANGLE
-# define SetPropA SetProp
-# define SetPropW SetProp
-#endif
-
-#ifdef VTK_WORKAROUND_WINDOWS_MANGLE
-# undef SetPropA
-# undef SetPropW
-  //BTX
-  VTK_LEGACY(void SetPropA(vtkProp*));
-  VTK_LEGACY(void SetPropW(vtkProp*));
-  //ETX
-#endif
-
 protected:
   vtkImageOrientedPointWidget();
   ~vtkImageOrientedPointWidget();


### PR DESCRIPTION
Following https://github.com/medInria/medInria-public/pull/1246

Debug windows compilation, due to VTK 9.3.1. Use of modern "SetViewProp" method.

:m: