### PR TITLE
[SplashScreen] display the splashscreen on right screen and in release only

### DIFF
--- a/src/app/medInria/medApplication.cpp
+++ b/src/app/medInria/medApplication.cpp
@@ -52,7 +52,13 @@ medApplication::medApplication(int & argc, char**argv) :
     QApplication(argc, argv),
     d(new medApplicationPrivate)
 {
+
+    // Do not show the splash screen in debug builds because it hogs the
+    // foreground, hiding all other windows. This makes debugging the startup
+    // operations difficult.
+#ifdef NDEBUG
     initializeSplashScreen();
+#endif
 
     d->listenClick = false;
 
@@ -68,7 +74,6 @@ medApplication::medApplication(int & argc, char**argv) :
     this->setOrganizationDomain("fr");
     this->setWindowIcon(QIcon(":/medInria.ico"));
 
-    //medLogger::initialize();
     medNewLogger::initialize(&medNewLogger::mainInstance());
 
     qInfo() << "####################################";
@@ -125,8 +130,10 @@ void medApplication::setMainWindow(medMainWindow *mw)
     this->setProperty("MainWindow",var);
     d->systemOpenInstructions.clear();
 
+#ifdef NDEBUG
     // Wait until the app is displayed to close itself
     d->splashScreen->finish(d->mainWindow);
+#endif
 }
 
 /*!

--- a/src/app/medInria/medApplication.cpp
+++ b/src/app/medInria/medApplication.cpp
@@ -52,7 +52,6 @@ medApplication::medApplication(int & argc, char**argv) :
     QApplication(argc, argv),
     d(new medApplicationPrivate)
 {
-
     // Do not show the splash screen in debug builds because it hogs the
     // foreground, hiding all other windows. This makes debugging the startup
     // operations difficult.
@@ -205,12 +204,35 @@ void medApplication::initialize()
 }
 
 /**
+ * @brief Get back the previous screen used to display the application
+ * 
+ * @return QScreen 
+ */
+QScreen* medApplication::getPreviousScreen()
+{
+    medSettingsManager *manager = medSettingsManager::instance();
+    int currentScreen = 0;
+    QVariant currentScreenQV = manager->value("medMainWindow", "currentScreen");
+    if (!currentScreenQV.isNull())
+    {
+        currentScreen = currentScreenQV.toInt();
+
+        // If the previous used screen has been removed, initialization
+        if (currentScreen >= QApplication::desktop()->screenCount())
+        {
+            currentScreen = 0;
+        }
+    }
+    return screens().at(currentScreen);
+}
+
+/**
  * @brief Set the Qt splash screen to the application logo.
  * 
  */
 void medApplication::initializeSplashScreen()
 {
-    d->splashScreen = new QSplashScreen(QPixmap(":/pixmaps/medInria-splash.png"),
+    d->splashScreen = new QSplashScreen(getPreviousScreen(), QPixmap(":/pixmaps/medInria-splash.png"),
         Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint);
     d->splashScreen->setAttribute(Qt::WA_DeleteOnClose, true);
     d->splashScreen->show();

--- a/src/app/medInria/medApplication.h
+++ b/src/app/medInria/medApplication.h
@@ -33,6 +33,7 @@ public:
     void setMainWindow(medMainWindow *mw);
     void initializeSplashScreen();
     void initializeThemes();
+    QScreen* getPreviousScreen();
 
 signals:
     void showMessage(const QString& message);

--- a/src/app/medInria/medMainWindow.cpp
+++ b/src/app/medInria/medMainWindow.cpp
@@ -415,15 +415,14 @@ void medMainWindow::restoreSettings()
 
 void medMainWindow::saveSettings()
 {
+    medSettingsManager *manager = medSettingsManager::instance();
     if(!this->isFullScreen())
     {
-        medSettingsManager * mnger = medSettingsManager::instance();
-        mnger->setValue("medMainWindow", "state", this->saveState());
-        mnger->setValue("medMainWindow", "geometry", this->saveGeometry());
-
-        // Keep the current screen for multiple-screens display
-        mnger->setValue("medMainWindow", "currentScreen", QApplication::desktop()->screenNumber(this));
+        manager->setValue("medMainWindow", "state", this->saveState());
+        manager->setValue("medMainWindow", "geometry", this->saveGeometry());
     }
+    // Keep the current screen for multiple-screens display
+    manager->setValue("medMainWindow", "currentScreen", QApplication::desktop()->screenNumber(this));
 }
 
 void medMainWindow::switchToDefaultWorkSpace()


### PR DESCRIPTION
Put back the old splashscreen behavior: 
* do not show on debug mode
* display at the previous screen used by the application
* also a small debug: save the current screen even if the app is in fullscreen

:m: