### PR TITLE
[5.0.1] specify dev branch change with python integration

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -17,9 +17,10 @@ medInria 5.0:
 - Registration workspace: automatic cast of data in LCC and Diffeomorphic toolboxes.
 - Enhance memory management of the application to avoid memory leaks.
 - Add DicomRT writer.
-- BUGFIX 5.0.1:
+- RELEASE 5.0.1:
     * Compilation on Ubuntu 24.
     * Switch to ITK v5.4.5.
+    * Python integration.
 
 medInria 4.0:
 - INFORMATION: this version of medInria is NOT packaged with Anima plugins. We apologize for the inconvenience, we're working on adding them in a near release.


### PR DESCRIPTION
On dev branch there was the addition of https://github.com/medInria/medInria-public/pull/1268 also.

It's better to include it to the synchronization of dev -> master for the 5.0.1 release.

It will be cleaner to have dev and master identical for now.

:m: 