### PR TITLE
[DataImporter] rm redundant delete code which can crash

### DIFF
--- a/src/layers/medCore/source/medDataImporter.cpp
+++ b/src/layers/medCore/source/medDataImporter.cpp
@@ -290,12 +290,6 @@ medAbstractData * medDataImporter::readFiles(QList<medAbstractDataReader *> &rea
             }
             ++i;
         }
-
-        for (int i; i < readers.size(); ++i)
-        {
-            delete(readers[i]);
-            readers[i] = nullptr;
-        }
     }
 
     return medDataRes;


### PR DESCRIPTION
Following https://github.com/medInria/medInria-public/pull/1282

This PR removes a delete loop, which is done _also_ in reset method for saved usedReader readers.
This loop which was not functional before, needs to be removed because it can create crashes.

:m: