### PR TITLE
[DataImporter] rm redundant delete --dev

### DIFF
--- a/src/layers/medCore/source/medDataImporter.cpp
+++ b/src/layers/medCore/source/medDataImporter.cpp
@@ -290,12 +290,6 @@ medAbstractData * medDataImporter::readFiles(QList<medAbstractDataReader *> &rea
             }
             ++i;
         }
-
-        for (int i; i < readers.size(); ++i)
-        {
-            delete(readers[i]);
-            readers[i] = nullptr;
-        }
     }
 
     return medDataRes;


### PR DESCRIPTION
Same as https://github.com/medInria/medInria-public/pull/1285

> Following https://github.com/medInria/medInria-public/pull/1282
> 
> This PR removes a delete loop, which is done in reset method for saved usedReader readers.
> This loop which was not functional before, needs to be removed because it can create crashes.

:m: